### PR TITLE
let post css use all paths

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,6 @@
 const postImport = require('postcss-import');
 module.exports = {
   plugins: [
-    postImport({path: ['./node_modules/@patternfly/patternfly/']}),
+    postImport(),
   ]
 }


### PR DESCRIPTION
fixes the occasional:

```
snowpack

  Server starting…

▼ Console

[snowpack] ! updating dependencies...
[snowpack] ignoring unsupported file "src/stories/ConfirmationDialog.stories.tsx.bak"
[snowpack] ! installing dependencies…
[snowpack] Cannot find module '@patternfly/patternfly/patternfly.min.css";
@import "@patternfly/patternfly/patternfly-addons.css'
Require stack:
- c:\GitHub\keycloak-admin-ui\node_modules\snowpack\dist-node\index.js
- c:\GitHub\keycloak-admin-ui\node_modules\snowpack\dist-node\index.bin.js
[snowpack] Install failed. 
```