### PR TITLE
adds optional link to the subkey of a view header

### DIFF
--- a/src/components/view-header/ViewHeader.tsx
+++ b/src/components/view-header/ViewHeader.tsx
@@ -16,11 +16,14 @@ import {
 import { HelpContext } from "../help-enabler/HelpHeader";
 import { useTranslation } from "react-i18next";
 import { PageBreadCrumbs } from "../bread-crumb/PageBreadCrumbs";
+import { ExternalLink } from "../external-link/ExternalLink";
 
 export type ViewHeaderProps = {
   titleKey: string;
   badge?: string;
   subKey: string;
+  subKeyLinkText?: string;
+  subKeyLinkAddress?: string;
   selectItems?: ReactElement[];
   isEnabled?: boolean;
   onSelect?: (value: string) => void;
@@ -31,6 +34,8 @@ export const ViewHeader = ({
   titleKey,
   badge,
   subKey,
+  subKeyLinkText,
+  subKeyLinkAddress,
   selectItems,
   isEnabled = true,
   onSelect,
@@ -98,7 +103,17 @@ export const ViewHeader = ({
         </Level>
         {enabled && (
           <TextContent>
-            <Text>{t(subKey)}</Text>
+            <Text>
+              {t(subKey)}
+              {subKeyLinkText && (
+                <ExternalLink
+                  href={subKeyLinkAddress}
+                  title={t(subKeyLinkText)}
+                  isInline
+                  className="pf-u-ml-md"
+                />
+              )}
+            </Text>
           </TextContent>
         )}
       </PageSection>

--- a/src/components/view-header/ViewHeader.tsx
+++ b/src/components/view-header/ViewHeader.tsx
@@ -12,6 +12,7 @@ import {
   ToolbarItem,
   Badge,
   Select,
+  ButtonProps,
 } from "@patternfly/react-core";
 import { HelpContext } from "../help-enabler/HelpHeader";
 import { useTranslation } from "react-i18next";
@@ -22,8 +23,7 @@ export type ViewHeaderProps = {
   titleKey: string;
   badge?: string;
   subKey: string;
-  subKeyLinkText?: string;
-  subKeyLinkAddress?: string;
+  subKeyLinkProps?: ButtonProps;
   selectItems?: ReactElement[];
   isEnabled?: boolean;
   onSelect?: (value: string) => void;
@@ -34,8 +34,7 @@ export const ViewHeader = ({
   titleKey,
   badge,
   subKey,
-  subKeyLinkText,
-  subKeyLinkAddress,
+  subKeyLinkProps,
   selectItems,
   isEnabled = true,
   onSelect,
@@ -105,10 +104,9 @@ export const ViewHeader = ({
           <TextContent>
             <Text>
               {t(subKey)}
-              {subKeyLinkText && (
+              {subKeyLinkProps && (
                 <ExternalLink
-                  href={subKeyLinkAddress}
-                  title={t(subKeyLinkText)}
+                  {...subKeyLinkProps}
                   isInline
                   className="pf-u-ml-md"
                 />

--- a/src/stories/ViewHeader.stories.tsx
+++ b/src/stories/ViewHeader.stories.tsx
@@ -22,6 +22,8 @@ Extended.args = {
   titleKey: "This is the title",
   badge: "badge",
   subKey: "This is the description.",
+  subKeyLinkText: "More information",
+  subKeyLinkAddress: "http://google.com",
   selectItems: [
     <SelectOption key="first" value="first-item">
       First item

--- a/src/stories/ViewHeader.stories.tsx
+++ b/src/stories/ViewHeader.stories.tsx
@@ -22,8 +22,10 @@ Extended.args = {
   titleKey: "This is the title",
   badge: "badge",
   subKey: "This is the description.",
-  subKeyLinkText: "More information",
-  subKeyLinkAddress: "http://google.com",
+  subKeyLinkProps: {
+    title: "More information",
+    href: "http://google.com",
+  },
   selectItems: [
     <SelectOption key="first" value="first-item">
       First item


### PR DESCRIPTION
This adds props to the ViewHeader to pass in link text and a url, which will be appended to the subKey text.

Added to allow for a link in the help text of a header, as shown here: https://marvelapp.com/prototype/ecjc94b/screen/72071043