### PR TITLE
Fixed build by making secondaryActions optional

### DIFF
--- a/src/components/list-empty-state/ListEmptyState.tsx
+++ b/src/components/list-empty-state/ListEmptyState.tsx
@@ -21,7 +21,7 @@ export type ListEmptyStateProps = {
   instructions: string;
   primaryActionText: string;
   onPrimaryAction: MouseEventHandler<HTMLButtonElement>;
-  secondaryActions: Action[];
+  secondaryActions?: Action[];
 };
 
 export const ListEmptyState = ({
@@ -42,17 +42,19 @@ export const ListEmptyState = ({
         <Button variant="primary" onClick={onPrimaryAction}>
           {primaryActionText}
         </Button>
-        <EmptyStateSecondaryActions>
-          {secondaryActions.map((action) => (
-            <Button
-              key={action.text}
-              variant={action.type || ButtonVariant.primary}
-              onClick={action.onClick}
-            >
-              {action.text}
-            </Button>
-          ))}
-        </EmptyStateSecondaryActions>
+        {secondaryActions && (
+          <EmptyStateSecondaryActions>
+            {secondaryActions.map((action) => (
+              <Button
+                key={action.text}
+                variant={action.type || ButtonVariant.primary}
+                onClick={action.onClick}
+              >
+                {action.text}
+              </Button>
+            ))}
+          </EmptyStateSecondaryActions>
+        )}
       </EmptyState>
     </>
   );


### PR DESCRIPTION
Secondary actions in ListEmptyState.tsx is an optional prop.  This fix updates the code to make it optional, so that secondary actions are available when they are needed on specific pages.

Here's an example:

https://marvelapp.com/prototype/f0e8fih/screen/72043135
