### PR TITLE
Change list view header action menu from select to dropdown

### DIFF
--- a/src/clients/ClientSettings.tsx
+++ b/src/clients/ClientSettings.tsx
@@ -117,13 +117,22 @@ export const ClientSettings = () => {
                 titleKey={name}
                 subKey="clients:clientsExplain"
                 dropdownItems={[
-                  <DropdownItem key="download" value="download">
+                  <DropdownItem
+                    key="download"
+                    onClick={() => toggleDownloadDialog()}
+                  >
                     {t("downloadAdapterConfig")}
                   </DropdownItem>,
-                  <DropdownItem key="export" value="export">
+                  <DropdownItem
+                    key="export"
+                    onClick={() => exportClient(form.getValues())}
+                  >
                     {t("common:export")}
                   </DropdownItem>,
-                  <DropdownItem key="delete" value="delete">
+                  <DropdownItem
+                    key="delete"
+                    onClick={() => toggleDeleteDialog()}
+                  >
                     {t("common:delete")}
                   </DropdownItem>,
                 ]}
@@ -134,15 +143,6 @@ export const ClientSettings = () => {
                   } else {
                     onChange(value);
                     save();
-                  }
-                }}
-                onSelect={(value) => {
-                  if (value === "export") {
-                    exportClient(form.getValues());
-                  } else if (value === "delete") {
-                    toggleDeleteDialog();
-                  } else if (value === "download") {
-                    toggleDownloadDialog();
                   }
                 }}
               />

--- a/src/clients/ClientSettings.tsx
+++ b/src/clients/ClientSettings.tsx
@@ -10,8 +10,8 @@ import {
   ActionGroup,
   Button,
   AlertVariant,
-  SelectOption,
   ButtonVariant,
+  DropdownItem,
 } from "@patternfly/react-core";
 import { useParams } from "react-router-dom";
 import { Controller, useForm } from "react-hook-form";
@@ -116,16 +116,16 @@ export const ClientSettings = () => {
               <ViewHeader
                 titleKey={name}
                 subKey="clients:clientsExplain"
-                selectItems={[
-                  <SelectOption key="download" value="download">
+                dropdownItems={[
+                  <DropdownItem key="download" value="download">
                     {t("downloadAdapterConfig")}
-                  </SelectOption>,
-                  <SelectOption key="export" value="export">
+                  </DropdownItem>,
+                  <DropdownItem key="export" value="export">
                     {t("common:export")}
-                  </SelectOption>,
-                  <SelectOption key="delete" value="delete">
+                  </DropdownItem>,
+                  <DropdownItem key="delete" value="delete">
                     {t("common:delete")}
-                  </SelectOption>,
+                  </DropdownItem>,
                 ]}
                 isEnabled={value}
                 onToggle={(value) => {

--- a/src/components/view-header/ViewHeader.tsx
+++ b/src/components/view-header/ViewHeader.tsx
@@ -87,7 +87,6 @@ export const ViewHeader = ({
                     />
                   </ToolbarItem>
                   <ToolbarItem>
-                    {/* This is the dropdown to replace the select.  It operates but does not initiate the actions. See it by going to Clients and click on a client. All 3 menu actions should work but don't. */}
                     <Dropdown
                       position={DropdownPosition.right}
                       toggle={

--- a/src/components/view-header/ViewHeader.tsx
+++ b/src/components/view-header/ViewHeader.tsx
@@ -13,18 +13,22 @@ import {
   Badge,
   Select,
   ButtonProps,
+  Dropdown,
+  DropdownToggle,
+  DropdownPosition,
 } from "@patternfly/react-core";
 import { HelpContext } from "../help-enabler/HelpHeader";
 import { useTranslation } from "react-i18next";
 import { PageBreadCrumbs } from "../bread-crumb/PageBreadCrumbs";
 import { ExternalLink } from "../external-link/ExternalLink";
+import { isRowExpanded } from "@patternfly/react-table";
 
 export type ViewHeaderProps = {
   titleKey: string;
   badge?: string;
   subKey: string;
   subKeyLinkProps?: ButtonProps;
-  selectItems?: ReactElement[];
+  dropdownItems?: ReactElement[];
   isEnabled?: boolean;
   onSelect?: (value: string) => void;
   onToggle?: (value: boolean) => void;
@@ -35,14 +39,19 @@ export const ViewHeader = ({
   badge,
   subKey,
   subKeyLinkProps,
-  selectItems,
+  dropdownItems,
   isEnabled = true,
   onSelect,
   onToggle,
 }: ViewHeaderProps) => {
   const { t } = useTranslation();
   const { enabled } = useContext(HelpContext);
-  const [open, setOpen] = useState(false);
+  const [isDropdownOpen, setDropdownOpen] = useState(false);
+
+  const onDropdownToggle = () => {
+    setDropdownOpen(!isDropdownOpen);
+  };
+
   return (
     <>
       <PageSection variant="light">
@@ -62,7 +71,7 @@ export const ViewHeader = ({
             </Level>
           </LevelItem>
           <LevelItem></LevelItem>
-          {selectItems && (
+          {dropdownItems && (
             <LevelItem>
               <Toolbar>
                 <ToolbarContent>
@@ -81,7 +90,25 @@ export const ViewHeader = ({
                     />
                   </ToolbarItem>
                   <ToolbarItem>
-                    <Select
+                    {/* This is the dropdown to replace the select.  It operates but does not initiate the actions. See it by going to Clients and click on a client. All 3 menu actions should work but don't. */}
+                    <Dropdown
+                      position={DropdownPosition.right}
+                      toggle={
+                        <DropdownToggle onToggle={onDropdownToggle}>
+                          {t("common:action")}
+                        </DropdownToggle>
+                      }
+                      isOpen={isDropdownOpen}
+                      dropdownItems={dropdownItems}
+                      onSelect={(value) => {
+                        if (onSelect) {
+                          onSelect((value as unknown) as string);
+                        }
+                        setDropdownOpen(false);
+                      }}
+                    />
+                    {/* This is the old select to be replaced by a dropdown */}
+                    {/* <Select
                       placeholderText={t("common:action")}
                       isOpen={open}
                       onToggle={() => setOpen(!open)}
@@ -93,7 +120,7 @@ export const ViewHeader = ({
                       }}
                     >
                       {selectItems}
-                    </Select>
+                    </Select> */}
                   </ToolbarItem>
                 </ToolbarContent>
               </Toolbar>

--- a/src/components/view-header/ViewHeader.tsx
+++ b/src/components/view-header/ViewHeader.tsx
@@ -11,7 +11,6 @@ import {
   ToolbarContent,
   ToolbarItem,
   Badge,
-  Select,
   ButtonProps,
   Dropdown,
   DropdownToggle,
@@ -30,7 +29,6 @@ export type ViewHeaderProps = {
   subKeyLinkProps?: ButtonProps;
   dropdownItems?: ReactElement[];
   isEnabled?: boolean;
-  onSelect?: (value: string) => void;
   onToggle?: (value: boolean) => void;
 };
 
@@ -41,7 +39,6 @@ export const ViewHeader = ({
   subKeyLinkProps,
   dropdownItems,
   isEnabled = true,
-  onSelect,
   onToggle,
 }: ViewHeaderProps) => {
   const { t } = useTranslation();
@@ -100,27 +97,7 @@ export const ViewHeader = ({
                       }
                       isOpen={isDropdownOpen}
                       dropdownItems={dropdownItems}
-                      onSelect={(value) => {
-                        if (onSelect) {
-                          onSelect((value as unknown) as string);
-                        }
-                        setDropdownOpen(false);
-                      }}
                     />
-                    {/* This is the old select to be replaced by a dropdown */}
-                    {/* <Select
-                      placeholderText={t("common:action")}
-                      isOpen={open}
-                      onToggle={() => setOpen(!open)}
-                      onSelect={(_, value) => {
-                        if (onSelect) {
-                          onSelect(value as string);
-                        }
-                        setOpen(false);
-                      }}
-                    >
-                      {selectItems}
-                    </Select> */}
                   </ToolbarItem>
                 </ToolbarContent>
               </Toolbar>

--- a/src/stories/ViewHeader.stories.tsx
+++ b/src/stories/ViewHeader.stories.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Meta, Story } from "@storybook/react";
-import { Page, SelectOption } from "@patternfly/react-core";
+import { DropdownItem, Page } from "@patternfly/react-core";
 import {
   ViewHeader,
   ViewHeaderProps,
@@ -26,13 +26,13 @@ Extended.args = {
     title: "More information",
     href: "http://google.com",
   },
-  selectItems: [
-    <SelectOption key="first" value="first-item">
+  dropdownItems: [
+    <DropdownItem key="first" value="first-item">
       First item
-    </SelectOption>,
-    <SelectOption key="second" value="second-item">
+    </DropdownItem>,
+    <DropdownItem key="second" value="second-item">
       Second item
-    </SelectOption>,
+    </DropdownItem>,
   ],
 };
 

--- a/src/stories/ViewHeader.stories.tsx
+++ b/src/stories/ViewHeader.stories.tsx
@@ -27,10 +27,10 @@ Extended.args = {
     href: "http://google.com",
   },
   dropdownItems: [
-    <DropdownItem key="first" value="first-item">
+    <DropdownItem key="first" value="first-item" onClick={() => {}}>
       First item
     </DropdownItem>,
-    <DropdownItem key="second" value="second-item">
+    <DropdownItem key="second" value="second-item" onClick={() => {}}>
       Second item
     </DropdownItem>,
   ],


### PR DESCRIPTION
Fixes #171 
The action menu should have been a dropdown rather than select, and a dropdown allows a right alignment, so this fixes the overflow off the right side as well as correcting the semantics of the element.

To verify, look at the ViewHeader story and also the Client settings page (actions menu in the header)
