### PR TITLE
Allow login to different realms using query param

### DIFF
--- a/public/keycloak.json
+++ b/public/keycloak.json
@@ -1,8 +1,0 @@
-{
-  "realm": "master",
-  "auth-server-url": "http://localhost:8180/auth/",
-  "ssl-required": "external",
-  "resource": "security-admin-console-v2",
-  "public-client": true,
-  "confidential-port": 0
-}

--- a/src/components/realm-selector/RealmSelector.tsx
+++ b/src/components/realm-selector/RealmSelector.tsx
@@ -69,7 +69,7 @@ export const RealmSelector = ({ realmList }: RealmSelectorProps) => {
 
   const dropdownItems = realmList.map((r) => (
     <DropdownItem
-      key={r.id}
+      key={`realm-dropdown-item-${r.realm}`}
       onClick={() => {
         setRealm(r.realm);
         setOpen(!open);

--- a/src/context/auth/keycloak.ts
+++ b/src/context/auth/keycloak.ts
@@ -1,5 +1,13 @@
 import Keycloak, { KeycloakInstance } from "keycloak-js";
-const keycloak: KeycloakInstance = Keycloak("/keycloak.json");
+
+const realm =
+  new URLSearchParams(window.location.search).get("realm") || "master";
+
+const keycloak: KeycloakInstance = Keycloak({
+  url: "http://localhost:8180/auth/",
+  realm: realm,
+  clientId: "security-admin-console-v2",
+});
 
 export default async function (): Promise<KeycloakInstance> {
   await keycloak.init({ onLoad: "check-sso", pkceMethod: "S256" }).catch(() => {


### PR DESCRIPTION
## Motivation
Need to be able to develop and test when user logs in using a realm other than master.

The mechanism for determining the realm and the auth URL will need to change as we figure out how this is going to be deployed.  So this is a temporary fix.

## Brief Description
You can now go to admin console with http://localhost:8080/?realm=test

## Verification Steps

1. Create a realm called "test"
2. Add a user to test realm
3. Give the user permissions using realm-management client roles
4. Optional step: Set up fine grained permissions
5. http://localhost:8080/?realm=test
6. Log in.

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated
- [X] Formatting has been performed via prettier/eslint
- [X] Type checking has been performed via 'yarn check-types'

