### PR TITLE
User federation Kerberos settings wip

### DIFF
--- a/src/stories/UserFedKerberosSettings.stories.tsx
+++ b/src/stories/UserFedKerberosSettings.stories.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { Meta } from "@storybook/react";
+import { Page } from "@patternfly/react-core";
+import { UserFederationKerberosSettings } from "../user-federation/UserFederationKerberosSettings";
+
+export default {
+  title: "User Federation Kerberos Settings Tab",
+  component: UserFederationKerberosSettings,
+} as Meta;
+
+export const view = () => {
+  return (
+    <Page>
+      <UserFederationKerberosSettings />
+    </Page>
+  );
+};

--- a/src/user-federation/KerberosSettingsCache.tsx
+++ b/src/user-federation/KerberosSettingsCache.tsx
@@ -1,0 +1,51 @@
+import { Form, FormGroup, Select, SelectOption } from "@patternfly/react-core";
+import { useTranslation } from "react-i18next";
+import React from "react";
+import { HelpItem } from "../components/help-enabler/HelpItem";
+
+export const KerberosSettingsCache = () => {
+  const { t } = useTranslation("user-federation");
+  const helpText = useTranslation("user-federation-help").t;
+
+  return (
+    <>
+      {/* Cache settings */}
+      <Form isHorizontal>
+        <FormGroup
+          label={t("cachePolicy")}
+          labelIcon={
+            <HelpItem
+              helpText={helpText("cachePolicyHelp")}
+              forLabel={t("cachePolicy")}
+              forID="kc-cache-policy"
+            />
+          }
+          fieldId="kc-cache-policy"
+        >
+          <Select
+            toggleId="kc-cache-policy"
+            // isOpen={openType}
+            onToggle={() => {}}
+            // variant={SelectVariant.single}
+            // value={selected}
+            // selections={selected}
+            // onSelect={(_, value) => {
+            //   setSelected(value as string);
+            //   setOpenType(false);
+            // }}
+            aria-label="Select Input"
+          >
+            {/* {configFormats.map((configFormat) => ( */}
+            <SelectOption
+              key={"key"}
+              value={"value"}
+              // isSelected={selected === configFormat.id}
+            >
+              {"display name"}
+            </SelectOption>
+          </Select>
+        </FormGroup>
+      </Form>
+    </>
+  );
+};

--- a/src/user-federation/KerberosSettingsRequired.tsx
+++ b/src/user-federation/KerberosSettingsRequired.tsx
@@ -1,8 +1,6 @@
 import {
-  Button,
   Form,
   FormGroup,
-  InputGroup,
   Select,
   SelectOption,
   Switch,
@@ -11,7 +9,6 @@ import {
 import { useTranslation } from "react-i18next";
 import React from "react";
 import { HelpItem } from "../components/help-enabler/HelpItem";
-import { EyeIcon } from "@patternfly/react-icons";
 
 export const KerberosSettingsRequired = () => {
   const { t } = useTranslation("user-federation");

--- a/src/user-federation/KerberosSettingsRequired.tsx
+++ b/src/user-federation/KerberosSettingsRequired.tsx
@@ -1,0 +1,216 @@
+import {
+  Button,
+  Form,
+  FormGroup,
+  InputGroup,
+  Select,
+  SelectOption,
+  Switch,
+  TextInput,
+} from "@patternfly/react-core";
+import { useTranslation } from "react-i18next";
+import React from "react";
+import { HelpItem } from "../components/help-enabler/HelpItem";
+import { EyeIcon } from "@patternfly/react-icons";
+
+export const KerberosSettingsRequired = () => {
+  const { t } = useTranslation("user-federation");
+  const helpText = useTranslation("user-federation-help").t;
+
+  return (
+    <>
+      {/* Required settings */}
+      <Form isHorizontal>
+        <FormGroup
+          label={t("consoleDisplayName")}
+          labelIcon={
+            <HelpItem
+              helpText={helpText("consoleDisplayNameHelp")}
+              forLabel={t("consoleDisplayName")}
+              forID="kc-console-display-name"
+            />
+          }
+          fieldId="kc-console-display-name"
+          isRequired
+        >
+          <TextInput
+            isRequired
+            type="text"
+            id="kc-console-display-name"
+            name="kc-console-display-name"
+            // value={value1}
+            // onChange={this.handleTextInputChange1}
+          />
+        </FormGroup>
+
+        <FormGroup
+          label={t("kerberosRealm")}
+          labelIcon={
+            <HelpItem
+              helpText={helpText("kerberosRealmHelp")}
+              forLabel={t("kerberosRealm")}
+              forID="kc-kerberos-realm"
+            />
+          }
+          fieldId="kc-kerberos-realm"
+          isRequired
+        >
+          <TextInput
+            isRequired
+            type="text"
+            id="kc-kerberos-realm"
+            name="kc-kerberos-realm"
+            // value={value1}
+            // onChange={this.handleTextInputChange1}
+          />
+        </FormGroup>
+
+        <FormGroup
+          label={t("serverPrincipal")}
+          labelIcon={
+            <HelpItem
+              helpText={helpText("serverPrincipalHelp")}
+              forLabel={t("serverPrincipal")}
+              forID="kc-server-principal"
+            />
+          }
+          fieldId="kc-server-principal"
+          isRequired
+        >
+          <TextInput
+            isRequired
+            type="text"
+            id="kc-server-principal"
+            name="kc-server-principal"
+            // value={value1}
+            // onChange={this.handleTextInputChange1}
+          />
+        </FormGroup>
+
+        <FormGroup
+          label={t("keyTab")}
+          labelIcon={
+            <HelpItem
+              helpText={helpText("keyTabHelp")}
+              forLabel={t("keyTab")}
+              forID="kc-key-tab"
+            />
+          }
+          fieldId="kc-key-tab"
+          isRequired
+        >
+          <TextInput
+            isRequired
+            type="text"
+            id="kc-key-tab"
+            name="kc-key-tab"
+            // value={value1}
+            // onChange={this.handleTextInputChange1}
+          />
+        </FormGroup>
+
+        <FormGroup
+          label={t("debug")}
+          labelIcon={
+            <HelpItem
+              helpText={helpText("debugHelp")}
+              forLabel={t("debug")}
+              forID="kc-debug"
+            />
+          }
+          fieldId="kc-debug"
+          hasNoPaddingTop
+        >
+          <Switch
+            id={"kc-debug"}
+            isChecked={true}
+            isDisabled={false}
+            onChange={() => undefined as any}
+            label={t("common:on")}
+            labelOff={t("common:off")}
+          />
+        </FormGroup>
+
+        <FormGroup
+          label={t("allowPasswordAuthentication")}
+          labelIcon={
+            <HelpItem
+              helpText={helpText("allowPasswordAuthenticationHelp")}
+              forLabel={t("allowPasswordAuthentication")}
+              forID="kc-allow-password-authentication"
+            />
+          }
+          fieldId="kc-allow-password-authentication"
+          hasNoPaddingTop
+        >
+          <Switch
+            id={"kc-allow-password-authentication"}
+            isChecked={true}
+            isDisabled={false}
+            onChange={() => undefined as any}
+            label={t("common:on")}
+            labelOff={t("common:off")}
+          />
+        </FormGroup>
+
+        <FormGroup
+          label={t("editMode")}
+          labelIcon={
+            <HelpItem
+              helpText={helpText("editModeHelp")}
+              forLabel={t("editMode")}
+              forID="kc-edit-mode"
+            />
+          }
+          fieldId="kc-edit-mode"
+        >
+          <Select
+            toggleId="kc-edit-mode"
+            // isOpen={openType}
+            onToggle={() => {}}
+            // variant={SelectVariant.single}
+            // value={selected}
+            // selections={selected}
+            // onSelect={(_, value) => {
+            //   setSelected(value as string);
+            //   setOpenType(false);
+            // }}
+            aria-label="edit mode" // TODO
+          >
+            {/* {configFormats.map((configFormat) => ( */}
+            <SelectOption
+              key={"key"}
+              value={"value"}
+              // isSelected={selected === configFormat.id}
+            >
+              {"display name"}
+            </SelectOption>
+            {/* ))} */}
+          </Select>
+        </FormGroup>
+
+        <FormGroup
+          label={t("updateFirstLogin")}
+          labelIcon={
+            <HelpItem
+              helpText={helpText("updateFirstLoginHelp")}
+              forLabel={t("updateFirstLogin")}
+              forID="kc-update-first-login"
+            />
+          }
+          fieldId="kc-update-first-login"
+          hasNoPaddingTop
+        >
+          <Switch
+            id={"kc-update-first-login"}
+            isChecked={true}
+            isDisabled={false}
+            onChange={() => undefined as any}
+            label={t("common:on")}
+            labelOff={t("common:off")}
+          />
+        </FormGroup>
+      </Form>
+    </>
+  );
+};

--- a/src/user-federation/UserFederationKerberosSettings.tsx
+++ b/src/user-federation/UserFederationKerberosSettings.tsx
@@ -1,13 +1,6 @@
-import {
-  PageSection,
-  Text,
-  TextContent,
-  TextVariants,
-  Title,
-} from "@patternfly/react-core";
+import { PageSection, Title } from "@patternfly/react-core";
 import { useTranslation } from "react-i18next";
 import React from "react";
-import { ScrollForm } from "../components/scroll-form/ScrollForm";
 import { KerberosSettingsRequired } from "./KerberosSettingsRequired";
 import { KerberosSettingsCache } from "./KerberosSettingsCache";
 

--- a/src/user-federation/UserFederationKerberosSettings.tsx
+++ b/src/user-federation/UserFederationKerberosSettings.tsx
@@ -1,0 +1,35 @@
+import {
+  PageSection,
+  Text,
+  TextContent,
+  TextVariants,
+  Title,
+} from "@patternfly/react-core";
+import { useTranslation } from "react-i18next";
+import React from "react";
+import { ScrollForm } from "../components/scroll-form/ScrollForm";
+import { KerberosSettingsRequired } from "./KerberosSettingsRequired";
+import { KerberosSettingsCache } from "./KerberosSettingsCache";
+
+export const UserFederationKerberosSettings = () => {
+  const { t } = useTranslation("user-federation");
+
+  return (
+    <>
+      <PageSection variant="light">
+        {/* Required settings */}
+        <Title size={"xl"} headingLevel={"h2"} className="pf-u-mb-lg">
+          {t("requiredSettings")}
+        </Title>
+        <KerberosSettingsRequired />
+      </PageSection>
+      <PageSection variant="light" isFilled>
+        {/* Cache settings */}
+        <Title size={"xl"} headingLevel={"h2"} className="pf-u-mb-lg">
+          {t("cacheSettings")}
+        </Title>
+        <KerberosSettingsCache />
+      </PageSection>
+    </>
+  );
+};

--- a/src/user-federation/help.json
+++ b/src/user-federation/help.json
@@ -38,6 +38,14 @@
     "validatePasswordPolicyHelp": "Determines if Keycloak should validate the password with the realm password policy before updating it",
     "trustEmailHelp": "If enabled, email provided by this provider is not verified even if verification is enabled for the realm.",
 
-    "IDK-periodicChangedUsersSyncHelp": "Should newly created users be created within LDAP store? Priority affects which provider is chosen to sync the new user."
+    "IDK-periodicChangedUsersSyncHelp": "Should newly created users be created within LDAP store? Priority affects which provider is chosen to sync the new user.",
+
+    "requiredSettingsHelp": "Required Settings",
+    "kerberosRealmHelp": "Name of kerberos realm. For example, FOO.ORG",
+    "serverPrincipalHelp": "Full name of server principal for HTTP service including server and domain name. For example, HTTP/host.foo.org@FOO.ORG",
+    "keyTabHelp": "Location of Kerberos KeyTab file containing the credentials of server principal. For example, /etc/krb5.keytab",
+    "debugHelp": "Enable/disable debug logging to standard output for Krb5LoginModule",
+    "allowPasswordAuthenticationHelp": "Enable/disable possibility of username/password authentication against Kerberos database",
+    "updateFirstLoginHelp": "Update profile on first login"
   }
 }

--- a/src/user-federation/messages.json
+++ b/src/user-federation/messages.json
@@ -56,6 +56,14 @@
     "advancedSettings": "Advanced settings",
     "enableLdapv3Password": "Enable the LDAPv3 password modify extended operation",
     "validatePasswordPolicy": "Validate password policy",
-    "trustEmail": "Trust email"
+    "trustEmail": "Trust email",
+
+    "requiredSettings": "Required Settings",
+    "kerberosRealm": "Kerberos realm",
+    "serverPrincipal": "Server principal",
+    "keyTab": "Key tab",
+    "debug": "Debug",
+    "allowPasswordAuthentication": "Allow password authentication",
+    "updateFirstLogin": "Update first login"
   }
 }


### PR DESCRIPTION
## Motivation
APPDUX-540 https://issues.redhat.com/browse/APPDUX-540

## Brief Description
This lays out the sections in the User Federation Kerberos Settings. It is NOT tied to data nor are controls like switches and dropdowns operational.
This is intended to lay out the page and establish the structure for future work.

## Verification Steps
This can only be viewed in Storybook. Find it under "User Federation LDAP Settings Tab". It can be compared to this mockup: https://marvelapp.com/prototype/ecjc94b/screen/72098368

## Checklist:

- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [x] Help has been implemented
- [x] axe report has been run and resulting a11y issues have been resolved
- [NA] Unit tests have been created/updated
- [x] Formatting has been performed via prettier/eslint
- [x] Type checking has been performed via 'yarn check-types'

## Additional Notes
<!-- 
Add images and/or screen caps to illustrate what was changed if this pull request adds to or modifies existing user-visible appearance/output. 
-->
