### PR TITLE
removed "Home" from navigation

### DIFF
--- a/src/client-scopes/messages.json
+++ b/src/client-scopes/messages.json
@@ -1,7 +1,7 @@
 {
   "client-scopes": {
     "createClientScope": "Create client scope",
-    "clientScopeList": "List of client scopes",
+    "clientScopeList": "Client scopes",
     "clientScopeDetails": "Client scope details",
     "clientScopeExplain": "Client scopes allow you to define a common set of protocol mappers and roles, which are shared between multiple clients",
     "searchFor": "Search for client scope",

--- a/src/clients/__tests__/__snapshots__/ClientList.test.tsx.snap
+++ b/src/clients/__tests__/__snapshots__/ClientList.test.tsx.snap
@@ -6,7 +6,7 @@ Object {
   "baseElement": <body>
     <div>
       <table
-        aria-label="Client list"
+        aria-label="Clients"
         class="pf-c-table pf-m-grid-md pf-m-compact"
         data-ouia-component-id="OUIA-Generated-Table-1"
         data-ouia-component-type="PF4/Table"
@@ -749,7 +749,7 @@ Object {
   </body>,
   "container": <div>
     <table
-      aria-label="Client list"
+      aria-label="Clients"
       class="pf-c-table pf-m-grid-md pf-m-compact"
       data-ouia-component-id="OUIA-Generated-Table-1"
       data-ouia-component-type="PF4/Table"

--- a/src/clients/messages.json
+++ b/src/clients/messages.json
@@ -14,7 +14,7 @@
     "settings": "Settings",
     "credentials": "Credentials",
     "details": "Details",
-    "clientList": "Client list",
+    "clientList": "Clients",
     "clientSettings": "Client details",
     "selectEncryptionType": "Select Encryption type",
     "generalSettings": "General Settings",

--- a/src/components/bread-crumb/PageBreadCrumbs.tsx
+++ b/src/components/bread-crumb/PageBreadCrumbs.tsx
@@ -1,22 +1,26 @@
 import React from "react";
 import { Link } from "react-router-dom";
-import { Breadcrumb, BreadcrumbItem } from "@patternfly/react-core";
 import useBreadcrumbs from "use-react-router-breadcrumbs";
 import { useTranslation } from "react-i18next";
+import { Breadcrumb, BreadcrumbItem } from "@patternfly/react-core";
 
 import { routes } from "../../route-config";
 
 export const PageBreadCrumbs = () => {
   const { t } = useTranslation();
-  const crumbs = useBreadcrumbs(routes(t));
+  const crumbs = useBreadcrumbs(routes(t)).slice(1);
   return (
-    <Breadcrumb>
-      {crumbs.map(({ match, breadcrumb: crumb }, i) => (
-        <BreadcrumbItem key={i} isActive={crumbs.length - 1 === i}>
-          {crumbs.length - 1 !== i && <Link to={match.url}>{crumb}</Link>}
-          {crumbs.length - 1 === i && <>{crumb}</>}
-        </BreadcrumbItem>
-      ))}
-    </Breadcrumb>
+    <>
+      {crumbs.length > 1 && (
+        <Breadcrumb>
+          {crumbs.map(({ match, breadcrumb: crumb }, i) => (
+            <BreadcrumbItem key={i} isActive={crumbs.length - 1 === i}>
+              {crumbs.length - 1 !== i && <Link to={match.url}>{crumb}</Link>}
+              {crumbs.length - 1 === i && <>{crumb}</>}
+            </BreadcrumbItem>
+          ))}
+        </Breadcrumb>
+      )}
+    </>
   );
 };

--- a/src/components/bread-crumb/__tests__/PageBreadCrumbs.test.tsx
+++ b/src/components/bread-crumb/__tests__/PageBreadCrumbs.test.tsx
@@ -6,7 +6,7 @@ import { MemoryRouter } from "react-router-dom";
 describe("BreadCrumbs tests", () => {
   it("couple of crumbs", () => {
     const crumbs = mount(
-      <MemoryRouter initialEntries={["/add-client"]}>
+      <MemoryRouter initialEntries={["/clients/1234"]}>
         <PageBreadCrumbs />
       </MemoryRouter>
     );

--- a/src/components/bread-crumb/__tests__/__snapshots__/PageBreadCrumbs.test.tsx.snap
+++ b/src/components/bread-crumb/__tests__/__snapshots__/PageBreadCrumbs.test.tsx.snap
@@ -22,20 +22,20 @@ exports[`BreadCrumbs tests couple of crumbs 1`] = `
             className="pf-c-breadcrumb__item"
           >
             <Link
-              to="/"
+              to="/clients"
             >
               <LinkAnchor
-                href="/"
+                href="/clients"
                 navigate={[Function]}
               >
                 <a
-                  href="/"
+                  href="/clients"
                   onClick={[Function]}
                 >
                   <span
-                    key="/"
+                    key="/clients"
                   >
-                    Home
+                    Clients
                   </span>
                 </a>
               </LinkAnchor>
@@ -79,9 +79,9 @@ exports[`BreadCrumbs tests couple of crumbs 1`] = `
               </AngleRightIcon>
             </span>
             <span
-              key="/add-client"
+              key="/clients/1234"
             >
-              Create client
+              Client details
             </span>
           </li>
         </BreadcrumbItem>


### PR DESCRIPTION
only show breadcrumb when there are 2 levels 
renamed the list clients and client scopes

[see marvel design](https://marvelapp.com/prototype/4bi07ca/section/1014937)