### PR TITLE
Update route-config.ts

### DIFF
--- a/src/route-config.ts
+++ b/src/route-config.ts
@@ -158,7 +158,7 @@ export const routes: RoutesFn = (t: TFunction) => [
     access: "anyone",
   },
   {
-    path: "",
+    path: "*",
     component: PageNotFoundSection,
     breadcrumb: "",
     access: "anyone",


### PR DESCRIPTION
Fixed error "`path` must be provided in every route object" in console

## Motivation
Im trying to run this locally and got an error from withBreadCrumb: `path` must be provided in every route object and its breaking to load non existing route

## Brief Description
So the error is saying no path should be empty. so to handle that I have added * to show user not found page if the route does not exist.

## Additional Notes
Before:
![Screenshot from 2020-11-12 11-43-22](https://user-images.githubusercontent.com/45024975/98902837-74728780-24dc-11eb-9767-1d331054dfbf.png)
After:
![Screenshot from 2020-11-12 11-43-54](https://user-images.githubusercontent.com/45024975/98902858-7a686880-24dc-11eb-9908-ec4068968501.png)

