### PR TITLE
Fix disabled label for user fed card view

### DIFF
--- a/src/components/keycloak-card/KeycloakCard.tsx
+++ b/src/components/keycloak-card/KeycloakCard.tsx
@@ -55,7 +55,10 @@ export const KeycloakCard = ({
       <CardFooter>
         {footerText && footerText}
         {labelText && (
-          <Label color={labelColor || "gray"} className="keycloak__keycloak-card__footer-label">
+          <Label
+            color={labelColor || "gray"}
+            className="keycloak__keycloak-card__footer-label"
+          >
             {labelText}
           </Label>
         )}

--- a/src/components/keycloak-card/KeycloakCard.tsx
+++ b/src/components/keycloak-card/KeycloakCard.tsx
@@ -10,7 +10,6 @@ import {
   KebabToggle,
   Label,
 } from "@patternfly/react-core";
-// import { useTranslation } from "react-i18next";
 import "./keycloak-card.css";
 
 export type KeycloakCardProps = {
@@ -18,6 +17,7 @@ export type KeycloakCardProps = {
   title: string;
   dropdownItems?: ReactElement[];
   labelText?: string;
+  labelColor?: any;
   footerText?: string;
   configEnabled?: boolean;
   providerId?: string;
@@ -27,6 +27,7 @@ export const KeycloakCard = ({
   dropdownItems,
   title,
   labelText,
+  labelColor,
   footerText,
 }: KeycloakCardProps) => {
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
@@ -54,7 +55,7 @@ export const KeycloakCard = ({
       <CardFooter>
         {footerText && footerText}
         {labelText && (
-          <Label color="blue" className="keycloak__keycloak-card__footer-label">
+          <Label color={labelColor || "gray"} className="keycloak__keycloak-card__footer-label">
             {labelText}
           </Label>
         )}

--- a/src/user-federation/UserFederationSection.tsx
+++ b/src/user-federation/UserFederationSection.tsx
@@ -113,6 +113,11 @@ export const UserFederationSection = () => {
                 ? `${t("common:enabled")}`
                 : `${t("common:disabled")}`
             }
+            labelColor={
+              (userFederation.config as Config)!.enabled[0] !== "false"
+              ? "blue"
+              : "gray"
+            }
           />
         </GalleryItem>
       );
@@ -127,7 +132,7 @@ export const UserFederationSection = () => {
         subKeyLinkProps={learnMoreLinkProps}
         {...(userFederations && userFederations.length > 0
           ? {
-              lowerDropdownItems: { ufAddProviderDropdownItems },
+              lowerDropdownItems: ufAddProviderDropdownItems,
               lowerDropdownMenuTitle: "user-federation:addNewProvider",
             }
           : {})}

--- a/src/user-federation/UserFederationSection.tsx
+++ b/src/user-federation/UserFederationSection.tsx
@@ -115,8 +115,8 @@ export const UserFederationSection = () => {
             }
             labelColor={
               (userFederation.config as Config)!.enabled[0] !== "false"
-              ? "blue"
-              : "gray"
+                ? "blue"
+                : "gray"
             }
           />
         </GalleryItem>


### PR DESCRIPTION
## Motivation
https://github.com/keycloak/keycloak-admin-ui/issues/213

## Brief Description
Fixes three issues:
- Return from REST call to get enabled/disabled was not handled correctly as an array
- Disabled label was displaying as blue instead of gray as per spec
- Add new provider dropdown was not populating with items once separate card component was created 

## Verification Steps
In the legacy Keycloak Admin Console UI:
1. Select Configure > User Federation and select kerberos or ldap from the Add provider dropdown.
2. Enter the information for a new provider... just use placeholder text in the required fields, it's not verified.
3. Repeat steps 1-2 to create a second card, but this time, make sure to set the Enabled toggle to OFF.

In the new Keycloak Admin Console:
1. Verify that one of the cards is labeled correctly as Enabled and the other as Disabled.
2. Verify that the color for the disabled label is gray and the enabled label is blue.
3. Select the Add new provider dropdown and verify that the LDAP and Kerberos items appear. Note that these are not functional as of yet, they are placeholders commands only.

## Checklist:
- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated
- [x] Formatting has been performed via prettier/eslint
- [x] Type checking has been performed via 'yarn check-types'

## Additional Notes
Screen cap showing all 3 fixes:
![three-userfed-fixes](https://user-images.githubusercontent.com/39063664/98991846-6b90ae80-24fa-11eb-9817-c96813da94dc.png)
