### PR TITLE
fixed x and empty select on dialog

### DIFF
--- a/src/client-scopes/add/MapperDialog.tsx
+++ b/src/client-scopes/add/MapperDialog.tsx
@@ -65,6 +65,9 @@ export const AddMapperDialog = (props: AddMapperDialogProps) => {
     setRows([...allRows.filter((row) => !nameFilter.includes(row.item.name))]);
   }
 
+  const selectedRows = rows
+    .filter((row) => row.selected)
+    .map((row) => row.item);
   const isBuiltIn = !!props.filter;
 
   return (
@@ -79,14 +82,9 @@ export const AddMapperDialog = (props: AddMapperDialogProps) => {
               <Button
                 id="modal-confirm"
                 key="confirm"
-                isDisabled={rows.length === 0}
+                isDisabled={rows.length === 0 || selectedRows.length === 0}
                 onClick={() => {
-                  const selectedRows = rows
-                    .filter((row) => row.selected)
-                    .map((row) => row.item);
-                  if (selectedRows.length > 0) {
-                    props.onConfirm(selectedRows);
-                  }
+                  props.onConfirm(selectedRows);
                   props.toggleDialog();
                 }}
               >

--- a/src/client-scopes/add/MapperDialog.tsx
+++ b/src/client-scopes/add/MapperDialog.tsx
@@ -72,6 +72,7 @@ export const AddMapperDialog = (props: AddMapperDialogProps) => {
       variant={ModalVariant.medium}
       title={t("chooseAMapperType")}
       isOpen={props.open}
+      onClose={props.toggleDialog}
       actions={
         isBuiltIn
           ? [
@@ -80,9 +81,12 @@ export const AddMapperDialog = (props: AddMapperDialogProps) => {
                 key="confirm"
                 isDisabled={rows.length === 0}
                 onClick={() => {
-                  props.onConfirm(
-                    rows.filter((row) => row.selected).map((row) => row.item)
-                  );
+                  const selectedRows = rows
+                    .filter((row) => row.selected)
+                    .map((row) => row.item);
+                  if (selectedRows.length > 0) {
+                    props.onConfirm(selectedRows);
+                  }
                   props.toggleDialog();
                 }}
               >

--- a/src/client-scopes/add/__tests__/MapperDialog.test.tsx
+++ b/src/client-scopes/add/__tests__/MapperDialog.test.tsx
@@ -17,7 +17,7 @@ describe("<MapperDialog/>", () => {
           toggleDialog={() => setOpen(!open)}
         />
         <Button id="open" onClick={() => setOpen(true)}>
-          Show
+          {!open ? "Show" : "Hide"}
         </Button>
       </ServerInfoContext.Provider>
     );
@@ -33,7 +33,7 @@ describe("<MapperDialog/>", () => {
     expect(container).toMatchSnapshot();
 
     container.find("button#modal-confirm").simulate("click");
-    expect(onConfirm).toBeCalledWith([]);
+    expect(onConfirm).toBeCalledTimes(0);
   });
 
   it("should return array with selected build in protocol mapping", () => {
@@ -73,5 +73,18 @@ describe("<MapperDialog/>", () => {
     expect(onConfirm).toBeCalledWith(
       serverInfo.protocolMapperTypes[protocol][0]
     );
+  });
+
+  it("should close the dialog on 'X' click", () => {
+    const container = mount(
+      <Test protocol="openid-connect" onConfirm={() => {}} />
+    );
+
+    expect(container.find("button#open").text()).toBe("Show");
+    container.find("button#open").simulate("click");
+    expect(container.find("button#open").text()).toBe("Hide");
+    container.find('button[aria-label="Close"]').simulate("click");
+
+    expect(container.find("button#open").text()).toBe("Show");
   });
 });

--- a/src/client-scopes/add/__tests__/MapperDialog.test.tsx
+++ b/src/client-scopes/add/__tests__/MapperDialog.test.tsx
@@ -23,17 +23,16 @@ describe("<MapperDialog/>", () => {
     );
   };
 
-  it("should return empty array when selecting nothing", () => {
-    const onConfirm = jest.fn();
+  it("should have disabled add button when nothing is selected", () => {
     const container = mount(
-      <Test filter={[]} protocol="openid-connect" onConfirm={onConfirm} />
+      <Test filter={[]} protocol="openid-connect" onConfirm={() => {}} />
     );
 
     container.find("button#open").simulate("click");
     expect(container).toMatchSnapshot();
 
-    container.find("button#modal-confirm").simulate("click");
-    expect(onConfirm).toBeCalledTimes(0);
+    const button = container.find("button#modal-confirm");
+    expect(button.hasClass("pf-m-disabled")).toBe(true);
   });
 
   it("should return array with selected build in protocol mapping", () => {

--- a/src/client-scopes/add/__tests__/__snapshots__/MapperDialog.test.tsx.snap
+++ b/src/client-scopes/add/__tests__/__snapshots__/MapperDialog.test.tsx.snap
@@ -1,14 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<MapperDialog/> should return empty array when selecting nothing 1`] = `
+exports[`<MapperDialog/> should have disabled add button when nothing is selected 1`] = `
 <Test
   filter={Array []}
-  onConfirm={[MockFunction]}
+  onConfirm={[Function]}
   protocol="openid-connect"
 >
   <AddMapperDialog
     filter={Array []}
-    onConfirm={[MockFunction]}
+    onConfirm={[Function]}
     open={true}
     protocol="openid-connect"
     toggleDialog={[Function]}
@@ -18,7 +18,7 @@ exports[`<MapperDialog/> should return empty array when selecting nothing 1`] = 
         Array [
           <Button
             id="modal-confirm"
-            isDisabled={false}
+            isDisabled={true}
             onClick={[Function]}
           >
             Add
@@ -1026,11 +1026,12 @@ exports[`<MapperDialog/> should return empty array when selecting nothing 1`] = 
                     class="pf-c-modal-box__footer"
                   >
                     <button
-                      aria-disabled="false"
-                      class="pf-c-button pf-m-primary"
+                      aria-disabled="true"
+                      class="pf-c-button pf-m-primary pf-m-disabled"
                       data-ouia-component-id="OUIA-Generated-Button-primary-2"
                       data-ouia-component-type="PF4/Button"
                       data-ouia-safe="true"
+                      disabled=""
                       id="modal-confirm"
                       type="button"
                     >
@@ -1059,7 +1060,7 @@ exports[`<MapperDialog/> should return empty array when selecting nothing 1`] = 
             Array [
               <Button
                 id="modal-confirm"
-                isDisabled={false}
+                isDisabled={true}
                 onClick={[Function]}
               >
                 Add
@@ -17440,20 +17441,21 @@ exports[`<MapperDialog/> should return empty array when selecting nothing 1`] = 
                         >
                           <Button
                             id="modal-confirm"
-                            isDisabled={false}
+                            isDisabled={true}
                             key="confirm"
                             onClick={[Function]}
                           >
                             <button
-                              aria-disabled={false}
+                              aria-disabled={true}
                               aria-label={null}
-                              className="pf-c-button pf-m-primary"
+                              className="pf-c-button pf-m-primary pf-m-disabled"
                               data-ouia-component-id="OUIA-Generated-Button-primary-2"
                               data-ouia-component-type="PF4/Button"
                               data-ouia-safe={true}
-                              disabled={false}
+                              disabled={true}
                               id="modal-confirm"
                               onClick={[Function]}
+                              tabIndex={null}
                               type="button"
                             >
                               Add

--- a/src/client-scopes/add/__tests__/__snapshots__/MapperDialog.test.tsx.snap
+++ b/src/client-scopes/add/__tests__/__snapshots__/MapperDialog.test.tsx.snap
@@ -17508,7 +17508,7 @@ exports[`<MapperDialog/> should return empty array when selecting nothing 1`] = 
       onClick={[Function]}
       type="button"
     >
-      Show
+      Hide
     </button>
   </Button>
 </Test>
@@ -19157,7 +19157,7 @@ exports[`<MapperDialog/> should return selected protocol mapping type on click 1
       onClick={[Function]}
       type="button"
     >
-      Show
+      Hide
     </button>
   </Button>
 </Test>


### PR DESCRIPTION
## Motivation
<!-- Add references to relevant tickets, issues, design specs and/or a short description of what motivated you to do it. -->
fixes: #210

## Brief Description
<!-- Add a short answer for: 
What was done in this PR? (e.g Fix to prevent users from accessing feature X.)
Why it was done? (e.g Feature X was deprecated.)
-->

## Verification Steps
<!--
Add the steps required to verify this change. Keep in mind that these steps should be written so groups unfamiliar with the 
new functionality can follow them, such as QE or documentation.

1. Go to `XX >> YY >> SS`.
2. Create a new item `N` with info `X`.
3. Right-click the item and select Delete.
4. Verify that the item is no longer present in the left navigation menu.
-->
client scope -> client scope details -> mapping -> add build in mapper -> click "Add"
open this dialog again and press 'X'

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [x] Unit tests have been created/updated
- [x] Formatting has been performed via prettier/eslint
- [x] Type checking has been performed via 'yarn check-types'

## Additional Notes
<!-- 
Add images and/or screen caps to illustrate what was changed if this pull request adds to or modifies existing user-visible appearance/output. 
-->