### PR TITLE
Add role mapping into the flow and filter the clients that don't have roles

### DIFF
--- a/src/client-scopes/add/RoleMappingForm.tsx
+++ b/src/client-scopes/add/RoleMappingForm.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect, useState } from "react";
-import { useHistory } from "react-router-dom";
+import { useHistory, useParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { Controller, useForm } from "react-hook-form";
 import {
@@ -29,11 +29,7 @@ import { ViewHeader } from "../../components/view-header/ViewHeader";
 import { HelpItem } from "../../components/help-enabler/HelpItem";
 import { ProtocolMapperRepresentation } from "../models/client-scope";
 
-export type RoleMappingFormProps = {
-  clientScopeId: string;
-};
-
-export const RoleMappingForm = ({ clientScopeId }: RoleMappingFormProps) => {
+export const RoleMappingForm = () => {
   const { realm } = useContext(RealmContext);
   const adminClient = useAdminClient();
   const history = useHistory();
@@ -41,6 +37,7 @@ export const RoleMappingForm = ({ clientScopeId }: RoleMappingFormProps) => {
 
   const { t } = useTranslation("client-scopes");
   const { register, handleSubmit, control, errors } = useForm();
+  const { clientScopeId } = useParams<{ clientScopeId: string }>();
 
   const [roleOpen, setRoleOpen] = useState(false);
 

--- a/src/route-config.ts
+++ b/src/route-config.ts
@@ -20,6 +20,7 @@ import { UserFederationSection } from "./user-federation/UserFederationSection";
 import { UsersSection } from "./user/UsersSection";
 import { MappingDetails } from "./client-scopes/details/MappingDetails";
 import { ClientDetails } from "./clients/ClientDetails";
+import { RoleMappingForm } from "./client-scopes/add/RoleMappingForm";
 
 export type RouteDef = {
   path: string;
@@ -71,6 +72,12 @@ export const routes: RoutesFn = (t: TFunction) => [
     path: "/client-scopes/:id",
     component: ClientScopeForm,
     breadcrumb: t("client-scopes:clientScopeDetails"),
+    access: "view-clients",
+  },
+  {
+    path: "/client-scopes/:scopeId/oidc-role-name-mapper",
+    component: RoleMappingForm,
+    breadcrumb: t("client-scopes:mappingDetails"),
     access: "view-clients",
   },
   {

--- a/src/stories/RoleMappingForm.stories.tsx
+++ b/src/stories/RoleMappingForm.stories.tsx
@@ -33,7 +33,7 @@ export const RoleMappingFormExample = () => (
       }
     >
       <Page>
-        <RoleMappingForm clientScopeId="dummy" />
+        <RoleMappingForm />
       </Page>
     </AdminClient.Provider>
   </ServerInfoContext.Provider>


### PR DESCRIPTION
added a filter on the clients to only show the ones that have roles. Used `clientId` instead of `name` to show the clients in the dropdown and added a route so that it will use this screen if you use the "role mapping" in the dialog.