### PR TITLE
Fixes wrapping in user federation cards

### DIFF
--- a/src/components/keycloak-card/KeycloakCard.tsx
+++ b/src/components/keycloak-card/KeycloakCard.tsx
@@ -9,6 +9,8 @@ import {
   Dropdown,
   KebabToggle,
   Label,
+  Flex,
+  FlexItem,
 } from "@patternfly/react-core";
 import "./keycloak-card.css";
 
@@ -53,15 +55,16 @@ export const KeycloakCard = ({
       </CardHeader>
       <CardBody />
       <CardFooter>
-        {footerText && footerText}
-        {labelText && (
-          <Label
-            color={labelColor || "gray"}
-            className="keycloak__keycloak-card__footer-label"
-          >
-            {labelText}
-          </Label>
-        )}
+        <Flex>
+          <FlexItem className="keycloak--keycloak-card__footer">
+            {footerText && footerText}
+          </FlexItem>
+          <FlexItem>
+            {labelText && (
+              <Label color={labelColor || "gray"}>{labelText}</Label>
+            )}
+          </FlexItem>
+        </Flex>
       </CardFooter>
     </Card>
   );

--- a/src/components/keycloak-card/keycloak-card.css
+++ b/src/components/keycloak-card/keycloak-card.css
@@ -1,3 +1,3 @@
-  .keycloak__keycloak-card__footer-label {
-    margin-left: var(--pf-global--spacer--lg);
-  }
+.keycloak-admin--keycloak-card__footer-text {
+  --pf-l-flex--spacer: var(--pf-l-flex--spacer--lg);
+}

--- a/src/user-federation/UserFederationSection.tsx
+++ b/src/user-federation/UserFederationSection.tsx
@@ -100,7 +100,10 @@ export const UserFederationSection = () => {
         </DropdownItem>,
       ];
       return (
-        <GalleryItem key={index}>
+        <GalleryItem
+          key={index}
+          className="keycloak-admin--user-federation__gallery-item"
+        >
           <KeycloakCard
             id={userFederation.id!}
             dropdownItems={ufCardDropdownItems}

--- a/src/user-federation/user-federation.css
+++ b/src/user-federation/user-federation.css
@@ -1,3 +1,7 @@
 .keycloak__user-federation__dropdown {
-    margin-top: var(--pf-global--spacer--lg);
-  }
+  margin-top: var(--pf-global--spacer--lg);
+}
+
+.keycloak-admin--user-federation__gallery-item {
+  display: contents;
+}


### PR DESCRIPTION
## Motivation
Fixes #223 

## Brief Description
The user federation card footer was changed to a flex layout so that it would wrap properly
Also, the gallery items were adjusted so that the cards would maintain the same height as each other.

## Verification Steps
Go to a realm that has user federation items, or add them with the old console. 
View the user federation section in Firefox. To reproduce the bug, you must have had the View -> Zoom -> Zoom text only turned on. 
Hit cmd+ to increase text size and see that the wrapping and card size stay in alignment.

## Checklist:

- [x] Code has been tested locally by PR requester
- [NA] User-visible strings are using the react-i18next framework (useTranslation)
- [NA] Help has been implemented
- [x] axe report has been run and resulting a11y issues have been resolved
- [NA] Unit tests have been created/updated
- [x] Formatting has been performed via prettier/eslint
- [x] Type checking has been performed via 'yarn check-types'

## Additional Notes
Before:
![image](https://user-images.githubusercontent.com/19825616/99445146-3239b380-28eb-11eb-955d-23ce4e602995.png)

After:
![image](https://user-images.githubusercontent.com/19825616/99445153-382f9480-28eb-11eb-9178-9990579d3282.png)

