### PR TITLE
don't update realm selector on navigation

### DIFF
--- a/src/PageNav.tsx
+++ b/src/PageNav.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { memo, useState } from "react";
 import { useHistory } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import {
@@ -14,13 +14,28 @@ import { useAdminClient } from "./context/auth/AdminClient";
 import { useAccess } from "./context/access/Access";
 import { routes } from "./route-config";
 
-export const PageNav: React.FunctionComponent = () => {
-  const { t } = useTranslation("common");
-  const { hasAccess, hasSomeAccess } = useAccess();
+const RealmSelectorNav = () => {
   const adminClient = useAdminClient();
   const realmLoader = async () => {
     return await adminClient.realms.find();
   };
+  return (
+    <NavList>
+      <DataLoader loader={realmLoader}>
+        {(realmList) => (
+          <NavItem className="keycloak__page_nav__nav_item__realm-selector">
+            <RealmSelector realmList={realmList.data || []} />
+          </NavItem>
+        )}
+      </DataLoader>
+    </NavList>
+  );
+};
+const RealmSelect = memo(RealmSelectorNav);
+
+export const PageNav: React.FunctionComponent = () => {
+  const { t } = useTranslation("common");
+  const { hasAccess, hasSomeAccess } = useAccess();
 
   const history = useHistory();
 
@@ -76,15 +91,7 @@ export const PageNav: React.FunctionComponent = () => {
     <PageSidebar
       nav={
         <Nav onSelect={onSelect}>
-          <NavList>
-            <DataLoader loader={realmLoader}>
-              {(realmList) => (
-                <NavItem className="keycloak__page_nav__nav_item__realm-selector">
-                  <RealmSelector realmList={realmList.data || []} />
-                </NavItem>
-              )}
-            </DataLoader>
-          </NavList>
+          <RealmSelect />
           {showManage && (
             <NavGroup title={t("manage")}>
               <LeftNav title="clients" path="/clients" />


### PR DESCRIPTION
fixes: #123


## Motivation
<!-- Add references to relevant tickets, issues, design specs and/or a short description of what motivated you to do it. -->

## Brief Description
<!-- Add a short answer for: 
What was done in this PR? (e.g Fix to prevent users from accessing feature X.)
Why it was done? (e.g Feature X was deprecated.)
-->
uses React.memo to "cache" the realm selector

## Verification Steps
<!--
Add the steps required to verify this change. Keep in mind that these steps should be written so groups unfamiliar with the 
new functionality can follow them, such as QE or documentation.

1. Go to `XX >> YY >> SS`.
2. Create a new item `N` with info `X`.
3. Right-click the item and select Delete.
4. Verify that the item is no longer present in the left navigation menu.
-->
changing the "section" no longer refreshes the realm selector

## Checklist:

- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [x] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated
- [x] Formatting has been performed via prettier/eslint
- [x] Type checking has been performed via 'yarn check-types'

## Additional Notes
<!-- 
Add images and/or screen caps to illustrate what was changed if this pull request adds to or modifies existing user-visible appearance/output. 
-->