### PR TITLE
be able to use admin client in nodejs mode

### DIFF
--- a/src/KeycloakAdminConsole.tsx
+++ b/src/KeycloakAdminConsole.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import KeycloakAdminClient from "keycloak-admin";
+
+import { AdminClient } from "./context/auth/AdminClient";
+import { WhoAmIContextProvider } from "./context/whoami/WhoAmI";
+import { RealmContextProvider } from "./context/realm-context/RealmContext";
+import { App } from "./App";
+
+export type KeycloakAdminConsoleProps = {
+  adminClient: KeycloakAdminClient;
+};
+
+export const KeycloakAdminConsole = ({
+  adminClient,
+}: KeycloakAdminConsoleProps) => {
+  return (
+    <AdminClient.Provider value={adminClient}>
+      <WhoAmIContextProvider>
+        <RealmContextProvider>
+          <App />
+        </RealmContextProvider>
+      </WhoAmIContextProvider>
+    </AdminClient.Provider>
+  );
+};

--- a/src/PageHeader.tsx
+++ b/src/PageHeader.tsx
@@ -25,23 +25,31 @@ export const Header = () => {
 
   const ManageAccountDropdownItem = () => {
     return (
-      <DropdownItem
-        key="manage account"
-        onClick={() => adminClient.keycloak.accountManagement()}
-      >
-        {t("manageAccount")}
-      </DropdownItem>
+      <>
+        {adminClient.keycloak && (
+          <DropdownItem
+            key="manage account"
+            onClick={() => adminClient.keycloak.accountManagement()}
+          >
+            {t("manageAccount")}
+          </DropdownItem>
+        )}
+      </>
     );
   };
 
   const SignOutDropdownItem = () => {
     return (
-      <DropdownItem
-        key="sign out"
-        onClick={() => adminClient.keycloak.logout({ redirectUri: "" })}
-      >
-        {t("signOut")}
-      </DropdownItem>
+      <>
+        {adminClient.keycloak && (
+          <DropdownItem
+            key="sign out"
+            onClick={() => adminClient.keycloak.logout({ redirectUri: "" })}
+          >
+            {t("signOut")}
+          </DropdownItem>
+        )}
+      </>
     );
   };
 

--- a/src/clients/ClientsSection.tsx
+++ b/src/clients/ClientsSection.tsx
@@ -77,7 +77,11 @@ export const ClientsSection = () => {
             <ClientList
               clients={clients}
               refresh={loader}
-              baseUrl={adminClient.keycloak.authServerUrl!}
+              baseUrl={
+                adminClient.keycloak
+                  ? adminClient.keycloak.authServerUrl!
+                  : adminClient.baseUrl + "/"
+              }
             />
           </PaginatingTableToolbar>
         )}

--- a/src/context/whoami/WhoAmI.tsx
+++ b/src/context/whoami/WhoAmI.tsx
@@ -56,8 +56,6 @@ export const WhoAmIContextProvider = ({ children }: WhoAmIProviderProps) => {
   const adminClient = useContext(AdminClient)!;
 
   const whoAmILoader = async () => {
-    if (adminClient.keycloak === undefined) return undefined;
-
     return await adminClient.whoAmI.find();
   };
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,22 +3,13 @@ import ReactDom from "react-dom";
 import i18n from "./i18n";
 
 import init from "./context/auth/keycloak";
-import { AdminClient } from "./context/auth/AdminClient";
-import { RealmContextProvider } from "./context/realm-context/RealmContext";
-import { WhoAmIContextProvider } from "./context/whoami/WhoAmI";
-import { App } from "./App";
+import { KeycloakAdminConsole } from "./KeycloakAdminConsole";
 
 console.info("supported languages", ...i18n.languages);
 
 init().then((adminClient) => {
   ReactDom.render(
-    <AdminClient.Provider value={adminClient}>
-      <WhoAmIContextProvider>
-        <RealmContextProvider>
-          <App />
-        </RealmContextProvider>
-      </WhoAmIContextProvider>
-    </AdminClient.Provider>,
+    <KeycloakAdminConsole adminClient={adminClient} />,
     document.getElementById("app")
   );
 });


### PR DESCRIPTION
## Motivation
<!-- Add references to relevant tickets, issues, design specs and/or a short description of what motivated you to do it. -->
We could create an electron based keycloak admin client that could be used to administrate multiple keycloak instances
when we use the nodejs "version" of the admin client

## Brief Description
<!-- Add a short answer for: 
What was done in this PR? (e.g Fix to prevent users from accessing feature X.)
Why it was done? (e.g Feature X was deprecated.)
-->
When the admin client is in "nodejs mode" keycloak adapator is not set so this change adds checks on that.

## Verification Steps
<!--
Add the steps required to verify this change. Keep in mind that these steps should be written so groups unfamiliar with the 
new functionality can follow them, such as QE or documentation.

1. Go to `XX >> YY >> SS`.
2. Create a new item `N` with info `X`.
3. Right-click the item and select Delete.
4. Verify that the item is no longer present in the left navigation menu.
-->

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated
- [x] Formatting has been performed via prettier/eslint
- [x] Type checking has been performed via 'yarn check-types'

## Additional Notes
<!-- 
Add images and/or screen caps to illustrate what was changed if this pull request adds to or modifies existing user-visible appearance/output. 
-->