### PR TITLE
Use realm name in urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "react-hook-form": "^6.8.2",
     "react-i18next": "^11.7.0",
     "react-router-dom": "^5.2.0",
-    "use-react-router-breadcrumbs": "^1.0.4"
+    "use-react-router-breadcrumbs": "^1.0.5"
   },
   "devDependencies": {
     "@babel/core": "^7.10.5",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,11 @@
-import React, { ReactNode } from "react";
+import React, { ReactNode, useEffect } from "react";
 import { Page } from "@patternfly/react-core";
-import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
+import {
+  BrowserRouter as Router,
+  Route,
+  Switch,
+  useParams,
+} from "react-router-dom";
 
 import { Header } from "./PageHeader";
 import { PageNav } from "./PageNav";
@@ -13,6 +18,7 @@ import { AccessContextProvider, useAccess } from "./context/access/Access";
 import { routes, RouteDef } from "./route-config";
 import { PageBreadCrumbs } from "./components/bread-crumb/PageBreadCrumbs";
 import { ForbiddenSection } from "./ForbiddenSection";
+import { useRealm } from "./context/realm-context/RealmContext";
 
 // This must match the id given as scrollableSelector in scroll-form
 const mainPageContentId = "kc-main-content-page-container";
@@ -31,6 +37,13 @@ const AppContexts = ({ children }: { children: ReactNode }) => (
 // have access to, show forbidden page.
 type SecuredRouteProps = { route: RouteDef };
 const SecuredRoute = ({ route }: SecuredRouteProps) => {
+  const { setRealm } = useRealm();
+  const { realm } = useParams<{ realm: string }>();
+  useEffect(() => {
+    if (realm) {
+      setRealm(realm);
+    }
+  }, []);
   const { hasAccess } = useAccess();
 
   if (hasAccess(route.access)) return <route.component />;

--- a/src/KeycloakAdminConsole.tsx
+++ b/src/KeycloakAdminConsole.tsx
@@ -14,12 +14,12 @@ export const KeycloakAdminConsole = ({
   adminClient,
 }: KeycloakAdminConsoleProps) => {
   return (
-    <AdminClient.Provider value={adminClient}>
-      <WhoAmIContextProvider>
-        <RealmContextProvider>
+    <RealmContextProvider>
+      <AdminClient.Provider value={adminClient}>
+        <WhoAmIContextProvider>
           <App />
-        </RealmContextProvider>
-      </WhoAmIContextProvider>
-    </AdminClient.Provider>
+        </WhoAmIContextProvider>
+      </AdminClient.Provider>
+    </RealmContextProvider>
   );
 };

--- a/src/PageNav.tsx
+++ b/src/PageNav.tsx
@@ -9,6 +9,7 @@ import {
   PageSidebar,
 } from "@patternfly/react-core";
 import { RealmSelector } from "./components/realm-selector/RealmSelector";
+import { useRealm } from "./context/realm-context/RealmContext";
 import { DataLoader } from "./components/data-loader/DataLoader";
 import { useAdminClient } from "./context/auth/AdminClient";
 import { useAccess } from "./context/access/Access";
@@ -44,13 +45,16 @@ export const PageNav: React.FunctionComponent = () => {
 
   type LeftNavProps = { title: string; path: string };
   const LeftNav = ({ title, path }: LeftNavProps) => {
-    const route = routes(() => {}).find((route) => route.path === path);
+    const { realm } = useRealm();
+    const route = routes(() => {}).find(
+      (route) => route.path.substr("/:realm".length) === path
+    );
     if (!route || !hasAccess(route.access)) return <></>;
 
     return (
       <NavItem
         id={"nav-item" + path.replace("/", "-")}
-        to={path}
+        to={`/${realm}${path}`}
         isActive={activeItem === path}
       >
         {t(title)}

--- a/src/client-scopes/ClientScopesSection.tsx
+++ b/src/client-scopes/ClientScopesSection.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
-import { Link, useHistory } from "react-router-dom";
+import { Link, useHistory, useRouteMatch } from "react-router-dom";
 import { Button, PageSection } from "@patternfly/react-core";
 import ClientScopeRepresentation from "keycloak-admin/lib/defs/clientScopeRepresentation";
 
@@ -11,6 +11,7 @@ import { KeycloakDataTable } from "../components/table-toolbar/KeycloakDataTable
 export const ClientScopesSection = () => {
   const { t } = useTranslation("client-scopes");
   const history = useHistory();
+  const { url } = useRouteMatch();
 
   const adminClient = useAdminClient();
 
@@ -18,7 +19,7 @@ export const ClientScopesSection = () => {
 
   const ClientScopeDetailLink = (clientScope: ClientScopeRepresentation) => (
     <>
-      <Link key={clientScope.id} to={`/client-scopes/${clientScope.id}`}>
+      <Link key={clientScope.id} to={`${url}/${clientScope.id}`}>
         {clientScope.name}
       </Link>
     </>
@@ -35,7 +36,7 @@ export const ClientScopesSection = () => {
           ariaLabelKey="client-scopes:clientScopeList"
           searchPlaceholderKey="client-scopes:searchFor"
           toolbarItem={
-            <Button onClick={() => history.push("/client-scopes/new")}>
+            <Button onClick={() => history.push(`${url}/new`)}>
               {t("createClientScope")}
             </Button>
           }

--- a/src/client-scopes/add/__tests__/__snapshots__/MapperDialog.test.tsx.snap
+++ b/src/client-scopes/add/__tests__/__snapshots__/MapperDialog.test.tsx.snap
@@ -21,14 +21,14 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
             isDisabled={true}
             onClick={[Function]}
           >
-            Add
+            add
           </Button>,
           <Button
             id="modal-cancel"
             onClick={[Function]}
             variant="secondary"
           >
-            Cancel
+            cancel
           </Button>,
         ]
       }
@@ -42,7 +42,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
       onClose={[Function]}
       ouiaSafe={true}
       showClose={true}
-      title="Choose a mapper type"
+      title="chooseAMapperType"
       titleIconVariant={null}
       titleLabel=""
       variant="medium"
@@ -101,7 +101,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                       <span
                         class="pf-c-modal-box__title-text"
                       >
-                        Choose a mapper type
+                        chooseAMapperType
                       </span>
                     </h1>
                   </header>
@@ -116,11 +116,11 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                         class=""
                         data-pf-content="true"
                       >
-                        Choose one of the predefined mappings from this table
+                        predefinedMappingDescription
                       </p>
                     </div>
                     <table
-                      aria-label="Choose a mapper type"
+                      aria-label="chooseAMapperType"
                       class="pf-c-table pf-m-grid-md pf-m-compact"
                       data-ouia-component-id="OUIA-Generated-Table-2"
                       data-ouia-component-type="PF4/Table"
@@ -145,18 +145,18 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                           <th
                             class=""
                             data-key="1"
-                            data-label="Name"
+                            data-label="name"
                             scope="col"
                           >
-                            Name
+                            name
                           </th>
                           <th
                             class=""
                             data-key="2"
-                            data-label="Description"
+                            data-label="description"
                             scope="col"
                           >
-                            Description
+                            description
                           </th>
                         </tr>
                       </thead>
@@ -183,14 +183,14 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                           <td
                             class=""
                             data-key="1"
-                            data-label="Name"
+                            data-label="name"
                           >
                             zoneinfo
                           </td>
                           <td
                             class=""
                             data-key="2"
-                            data-label="Description"
+                            data-label="description"
                           >
                             Map a custom user attribute to a token claim.
                           </td>
@@ -214,14 +214,14 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                           <td
                             class=""
                             data-key="1"
-                            data-label="Name"
+                            data-label="name"
                           >
                             birthdate
                           </td>
                           <td
                             class=""
                             data-key="2"
-                            data-label="Description"
+                            data-label="description"
                           >
                             Map a custom user attribute to a token claim.
                           </td>
@@ -245,14 +245,14 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                           <td
                             class=""
                             data-key="1"
-                            data-label="Name"
+                            data-label="name"
                           >
                             family name
                           </td>
                           <td
                             class=""
                             data-key="2"
-                            data-label="Description"
+                            data-label="description"
                           >
                             Map a built in user property (email, firstName, lastName) to a token claim.
                           </td>
@@ -276,14 +276,14 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                           <td
                             class=""
                             data-key="1"
-                            data-label="Name"
+                            data-label="name"
                           >
                             gender
                           </td>
                           <td
                             class=""
                             data-key="2"
-                            data-label="Description"
+                            data-label="description"
                           >
                             Map a custom user attribute to a token claim.
                           </td>
@@ -307,14 +307,14 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                           <td
                             class=""
                             data-key="1"
-                            data-label="Name"
+                            data-label="name"
                           >
                             Impersonator Username
                           </td>
                           <td
                             class=""
                             data-key="2"
-                            data-label="Description"
+                            data-label="description"
                           >
                             Map a custom user session note to a token claim.
                           </td>
@@ -338,14 +338,14 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                           <td
                             class=""
                             data-key="1"
-                            data-label="Name"
+                            data-label="name"
                           >
                             phone number verified
                           </td>
                           <td
                             class=""
                             data-key="2"
-                            data-label="Description"
+                            data-label="description"
                           >
                             Map a custom user attribute to a token claim.
                           </td>
@@ -369,14 +369,14 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                           <td
                             class=""
                             data-key="1"
-                            data-label="Name"
+                            data-label="name"
                           >
                             locale
                           </td>
                           <td
                             class=""
                             data-key="2"
-                            data-label="Description"
+                            data-label="description"
                           >
                             Map a custom user attribute to a token claim.
                           </td>
@@ -400,14 +400,14 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                           <td
                             class=""
                             data-key="1"
-                            data-label="Name"
+                            data-label="name"
                           >
                             gss delegation credential
                           </td>
                           <td
                             class=""
                             data-key="2"
-                            data-label="Description"
+                            data-label="description"
                           >
                             Map a custom user session note to a token claim.
                           </td>
@@ -431,14 +431,14 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                           <td
                             class=""
                             data-key="1"
-                            data-label="Name"
+                            data-label="name"
                           >
                             allowed web origins
                           </td>
                           <td
                             class=""
                             data-key="2"
-                            data-label="Description"
+                            data-label="description"
                           >
                             Adds all allowed web origins to the 'allowed-origins' claim in the token
                           </td>
@@ -462,14 +462,14 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                           <td
                             class=""
                             data-key="1"
-                            data-label="Name"
+                            data-label="name"
                           >
                             middle name
                           </td>
                           <td
                             class=""
                             data-key="2"
-                            data-label="Description"
+                            data-label="description"
                           >
                             Map a custom user attribute to a token claim.
                           </td>
@@ -493,14 +493,14 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                           <td
                             class=""
                             data-key="1"
-                            data-label="Name"
+                            data-label="name"
                           >
                             nickname
                           </td>
                           <td
                             class=""
                             data-key="2"
-                            data-label="Description"
+                            data-label="description"
                           >
                             Map a custom user attribute to a token claim.
                           </td>
@@ -524,14 +524,14 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                           <td
                             class=""
                             data-key="1"
-                            data-label="Name"
+                            data-label="name"
                           >
                             updated at
                           </td>
                           <td
                             class=""
                             data-key="2"
-                            data-label="Description"
+                            data-label="description"
                           >
                             Map a custom user attribute to a token claim.
                           </td>
@@ -555,14 +555,14 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                           <td
                             class=""
                             data-key="1"
-                            data-label="Name"
+                            data-label="name"
                           >
                             email verified
                           </td>
                           <td
                             class=""
                             data-key="2"
-                            data-label="Description"
+                            data-label="description"
                           >
                             Map a built in user property (email, firstName, lastName) to a token claim.
                           </td>
@@ -586,14 +586,14 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                           <td
                             class=""
                             data-key="1"
-                            data-label="Name"
+                            data-label="name"
                           >
                             email
                           </td>
                           <td
                             class=""
                             data-key="2"
-                            data-label="Description"
+                            data-label="description"
                           >
                             Map a built in user property (email, firstName, lastName) to a token claim.
                           </td>
@@ -617,14 +617,14 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                           <td
                             class=""
                             data-key="1"
-                            data-label="Name"
+                            data-label="name"
                           >
                             client roles
                           </td>
                           <td
                             class=""
                             data-key="2"
-                            data-label="Description"
+                            data-label="description"
                           >
                             Map a user client role to a token claim.
                           </td>
@@ -648,14 +648,14 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                           <td
                             class=""
                             data-key="1"
-                            data-label="Name"
+                            data-label="name"
                           >
                             Impersonator User ID
                           </td>
                           <td
                             class=""
                             data-key="2"
-                            data-label="Description"
+                            data-label="description"
                           >
                             Map a custom user session note to a token claim.
                           </td>
@@ -679,14 +679,14 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                           <td
                             class=""
                             data-key="1"
-                            data-label="Name"
+                            data-label="name"
                           >
                             website
                           </td>
                           <td
                             class=""
                             data-key="2"
-                            data-label="Description"
+                            data-label="description"
                           >
                             Map a custom user attribute to a token claim.
                           </td>
@@ -710,14 +710,14 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                           <td
                             class=""
                             data-key="1"
-                            data-label="Name"
+                            data-label="name"
                           >
                             address
                           </td>
                           <td
                             class=""
                             data-key="2"
-                            data-label="Description"
+                            data-label="description"
                           >
                             Maps user address attributes (street, locality, region, postal_code, and country) to the OpenID Connect 'address' claim.
                           </td>
@@ -741,14 +741,14 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                           <td
                             class=""
                             data-key="1"
-                            data-label="Name"
+                            data-label="name"
                           >
                             given name
                           </td>
                           <td
                             class=""
                             data-key="2"
-                            data-label="Description"
+                            data-label="description"
                           >
                             Map a built in user property (email, firstName, lastName) to a token claim.
                           </td>
@@ -772,14 +772,14 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                           <td
                             class=""
                             data-key="1"
-                            data-label="Name"
+                            data-label="name"
                           >
                             profile
                           </td>
                           <td
                             class=""
                             data-key="2"
-                            data-label="Description"
+                            data-label="description"
                           >
                             Map a custom user attribute to a token claim.
                           </td>
@@ -803,14 +803,14 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                           <td
                             class=""
                             data-key="1"
-                            data-label="Name"
+                            data-label="name"
                           >
                             groups
                           </td>
                           <td
                             class=""
                             data-key="2"
-                            data-label="Description"
+                            data-label="description"
                           >
                             Map a user realm role to a token claim.
                           </td>
@@ -834,14 +834,14 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                           <td
                             class=""
                             data-key="1"
-                            data-label="Name"
+                            data-label="name"
                           >
                             phone number
                           </td>
                           <td
                             class=""
                             data-key="2"
-                            data-label="Description"
+                            data-label="description"
                           >
                             Map a custom user attribute to a token claim.
                           </td>
@@ -865,14 +865,14 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                           <td
                             class=""
                             data-key="1"
-                            data-label="Name"
+                            data-label="name"
                           >
                             full name
                           </td>
                           <td
                             class=""
                             data-key="2"
-                            data-label="Description"
+                            data-label="description"
                           >
                             Maps the user's first and last name to the OpenID Connect 'name' claim. Format is &lt;first&gt; + ' ' + &lt;last&gt;
                           </td>
@@ -896,14 +896,14 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                           <td
                             class=""
                             data-key="1"
-                            data-label="Name"
+                            data-label="name"
                           >
                             audience resolve
                           </td>
                           <td
                             class=""
                             data-key="2"
-                            data-label="Description"
+                            data-label="description"
                           >
                             Adds all client_ids of "allowed" clients to the audience field of the token. Allowed client means the client
  for which user has at least one client role
@@ -928,14 +928,14 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                           <td
                             class=""
                             data-key="1"
-                            data-label="Name"
+                            data-label="name"
                           >
                             picture
                           </td>
                           <td
                             class=""
                             data-key="2"
-                            data-label="Description"
+                            data-label="description"
                           >
                             Map a custom user attribute to a token claim.
                           </td>
@@ -959,14 +959,14 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                           <td
                             class=""
                             data-key="1"
-                            data-label="Name"
+                            data-label="name"
                           >
                             upn
                           </td>
                           <td
                             class=""
                             data-key="2"
-                            data-label="Description"
+                            data-label="description"
                           >
                             Map a built in user property (email, firstName, lastName) to a token claim.
                           </td>
@@ -990,14 +990,14 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                           <td
                             class=""
                             data-key="1"
-                            data-label="Name"
+                            data-label="name"
                           >
                             realm roles
                           </td>
                           <td
                             class=""
                             data-key="2"
-                            data-label="Description"
+                            data-label="description"
                           >
                             Map a user realm role to a token claim.
                           </td>
@@ -1021,14 +1021,14 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                           <td
                             class=""
                             data-key="1"
-                            data-label="Name"
+                            data-label="name"
                           >
                             username
                           </td>
                           <td
                             class=""
                             data-key="2"
-                            data-label="Description"
+                            data-label="description"
                           >
                             Map a built in user property (email, firstName, lastName) to a token claim.
                           </td>
@@ -1049,7 +1049,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                       id="modal-confirm"
                       type="button"
                     >
-                      Add
+                      add
                     </button>
                     <button
                       aria-disabled="false"
@@ -1060,7 +1060,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                       id="modal-cancel"
                       type="button"
                     >
-                      Cancel
+                      cancel
                     </button>
                   </footer>
                 </div>
@@ -1077,14 +1077,14 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                 isDisabled={true}
                 onClick={[Function]}
               >
-                Add
+                add
               </Button>,
               <Button
                 id="modal-cancel"
                 onClick={[Function]}
                 variant="secondary"
               >
-                Cancel
+                cancel
               </Button>,
             ]
           }
@@ -1101,7 +1101,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
           ouiaId="OUIA-Generated-Modal-medium-1"
           ouiaSafe={true}
           showClose={true}
-          title="Choose a mapper type"
+          title="chooseAMapperType"
           titleIconVariant={null}
           titleLabel=""
           variant="medium"
@@ -1204,7 +1204,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                         >
                           <ModalBoxTitle
                             id="pf-modal-part-1"
-                            title="Choose a mapper type"
+                            title="chooseAMapperType"
                             titleIconVariant={null}
                             titleLabel=""
                           >
@@ -1215,7 +1215,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                               <span
                                 className="pf-c-modal-box__title-text"
                               >
-                                Choose a mapper type
+                                chooseAMapperType
                               </span>
                             </h1>
                           </ModalBoxTitle>
@@ -1237,19 +1237,19 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                   className=""
                                   data-pf-content={true}
                                 >
-                                  Choose one of the predefined mappings from this table
+                                  predefinedMappingDescription
                                 </p>
                               </Text>
                             </div>
                           </TextContent>
                           <Table
-                            aria-label="Choose a mapper type"
+                            aria-label="chooseAMapperType"
                             borders={true}
                             canSelectAll={false}
                             cells={
                               Array [
-                                "Name",
-                                "Description",
+                                "name",
+                                "description",
                               ]
                             }
                             className=""
@@ -1840,7 +1840,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                             variant="compact"
                           >
                             <Provider
-                              aria-label="Choose a mapper type"
+                              aria-label="chooseAMapperType"
                               borders={true}
                               className=""
                               columns={
@@ -1922,7 +1922,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                     },
                                     "header": Object {
                                       "formatters": Array [],
-                                      "label": "Name",
+                                      "label": "name",
                                       "transforms": Array [
                                         [Function],
                                         [Function],
@@ -1931,7 +1931,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                     "property": "name",
                                     "props": Object {
                                       "data-key": 1,
-                                      "data-label": "Name",
+                                      "data-label": "name",
                                     },
                                   },
                                   Object {
@@ -1966,7 +1966,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                     },
                                     "header": Object {
                                       "formatters": Array [],
-                                      "label": "Description",
+                                      "label": "description",
                                       "transforms": Array [
                                         [Function],
                                         [Function],
@@ -1975,7 +1975,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                     "property": "description",
                                     "props": Object {
                                       "data-key": 2,
-                                      "data-label": "Description",
+                                      "data-label": "description",
                                     },
                                   },
                                 ]
@@ -1999,7 +1999,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                               variant="compact"
                             >
                               <TableComposable
-                                aria-label="Choose a mapper type"
+                                aria-label="chooseAMapperType"
                                 borders={true}
                                 className=""
                                 gridBreakPoint="grid-md"
@@ -2009,7 +2009,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                 variant="compact"
                               >
                                 <TableComposableBase
-                                  aria-label="Choose a mapper type"
+                                  aria-label="chooseAMapperType"
                                   borders={true}
                                   className=""
                                   gridBreakPoint="grid-md"
@@ -2020,7 +2020,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                   variant="compact"
                                 >
                                   <table
-                                    aria-label="Choose a mapper type"
+                                    aria-label="chooseAMapperType"
                                     className="pf-c-table pf-m-grid-md pf-m-compact"
                                     data-ouia-component-id="OUIA-Generated-Table-2"
                                     data-ouia-component-type="PF4/Table"
@@ -2116,7 +2116,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                   },
                                                   "header": Object {
                                                     "formatters": Array [],
-                                                    "label": "Name",
+                                                    "label": "name",
                                                     "transforms": Array [
                                                       [Function],
                                                       [Function],
@@ -2125,7 +2125,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                   "property": "name",
                                                   "props": Object {
                                                     "data-key": 1,
-                                                    "data-label": "Name",
+                                                    "data-label": "name",
                                                   },
                                                 },
                                                 Object {
@@ -2160,7 +2160,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                   },
                                                   "header": Object {
                                                     "formatters": Array [],
-                                                    "label": "Description",
+                                                    "label": "description",
                                                     "transforms": Array [
                                                       [Function],
                                                       [Function],
@@ -2169,7 +2169,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                   "property": "description",
                                                   "props": Object {
                                                     "data-key": 2,
-                                                    "data-label": "Description",
+                                                    "data-label": "description",
                                                   },
                                                 },
                                               ]
@@ -2309,7 +2309,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                           },
                                                           "header": Object {
                                                             "formatters": Array [],
-                                                            "label": "Name",
+                                                            "label": "name",
                                                             "transforms": Array [
                                                               [Function],
                                                               [Function],
@@ -2318,7 +2318,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                           "property": "name",
                                                           "props": Object {
                                                             "data-key": 1,
-                                                            "data-label": "Name",
+                                                            "data-label": "name",
                                                           },
                                                         },
                                                         Object {
@@ -2353,7 +2353,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                           },
                                                           "header": Object {
                                                             "formatters": Array [],
-                                                            "label": "Description",
+                                                            "label": "description",
                                                             "transforms": Array [
                                                               [Function],
                                                               [Function],
@@ -2362,7 +2362,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                           "property": "description",
                                                           "props": Object {
                                                             "data-key": 2,
-                                                            "data-label": "Description",
+                                                            "data-label": "description",
                                                           },
                                                         },
                                                       ]
@@ -2419,7 +2419,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                           </HeaderCell>
                                                           <HeaderCell
                                                             data-key={1}
-                                                            data-label="Name"
+                                                            data-label="name"
                                                             key="1-header"
                                                             scope="col"
                                                           >
@@ -2427,7 +2427,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                               className=""
                                                               component="th"
                                                               data-key={1}
-                                                              data-label="Name"
+                                                              data-label="name"
                                                               onMouseEnter={[Function]}
                                                               scope="col"
                                                               textCenter={false}
@@ -2437,7 +2437,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                 className=""
                                                                 component="th"
                                                                 data-key={1}
-                                                                data-label="Name"
+                                                                data-label="name"
                                                                 innerRef={null}
                                                                 onMouseEnter={[Function]}
                                                                 scope="col"
@@ -2447,18 +2447,18 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                 <th
                                                                   className=""
                                                                   data-key={1}
-                                                                  data-label="Name"
+                                                                  data-label="name"
                                                                   onMouseEnter={[Function]}
                                                                   scope="col"
                                                                 >
-                                                                  Name
+                                                                  name
                                                                 </th>
                                                               </ThBase>
                                                             </Th>
                                                           </HeaderCell>
                                                           <HeaderCell
                                                             data-key={2}
-                                                            data-label="Description"
+                                                            data-label="description"
                                                             key="2-header"
                                                             scope="col"
                                                           >
@@ -2466,7 +2466,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                               className=""
                                                               component="th"
                                                               data-key={2}
-                                                              data-label="Description"
+                                                              data-label="description"
                                                               onMouseEnter={[Function]}
                                                               scope="col"
                                                               textCenter={false}
@@ -2476,7 +2476,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                 className=""
                                                                 component="th"
                                                                 data-key={2}
-                                                                data-label="Description"
+                                                                data-label="description"
                                                                 innerRef={null}
                                                                 onMouseEnter={[Function]}
                                                                 scope="col"
@@ -2486,11 +2486,11 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                 <th
                                                                   className=""
                                                                   data-key={2}
-                                                                  data-label="Description"
+                                                                  data-label="description"
                                                                   onMouseEnter={[Function]}
                                                                   scope="col"
                                                                 >
-                                                                  Description
+                                                                  description
                                                                 </th>
                                                               </ThBase>
                                                             </Th>
@@ -2588,7 +2588,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                               },
                                               "header": Object {
                                                 "formatters": Array [],
-                                                "label": "Name",
+                                                "label": "name",
                                                 "transforms": Array [
                                                   [Function],
                                                   [Function],
@@ -2597,7 +2597,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                               "property": "name",
                                               "props": Object {
                                                 "data-key": 1,
-                                                "data-label": "Name",
+                                                "data-label": "name",
                                               },
                                             },
                                             Object {
@@ -2632,7 +2632,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                               },
                                               "header": Object {
                                                 "formatters": Array [],
-                                                "label": "Description",
+                                                "label": "description",
                                                 "transforms": Array [
                                                   [Function],
                                                   [Function],
@@ -2641,7 +2641,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                               "property": "description",
                                               "props": Object {
                                                 "data-key": 2,
-                                                "data-label": "Description",
+                                                "data-label": "description",
                                               },
                                             },
                                           ]
@@ -5635,7 +5635,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                   },
                                                   "header": Object {
                                                     "formatters": Array [],
-                                                    "label": "Name",
+                                                    "label": "name",
                                                     "transforms": Array [
                                                       [Function],
                                                       [Function],
@@ -5644,7 +5644,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                   "property": "name",
                                                   "props": Object {
                                                     "data-key": 1,
-                                                    "data-label": "Name",
+                                                    "data-label": "name",
                                                   },
                                                 },
                                                 Object {
@@ -5679,7 +5679,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                   },
                                                   "header": Object {
                                                     "formatters": Array [],
-                                                    "label": "Description",
+                                                    "label": "description",
                                                     "transforms": Array [
                                                       [Function],
                                                       [Function],
@@ -5688,7 +5688,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                   "property": "description",
                                                   "props": Object {
                                                     "data-key": 2,
-                                                    "data-label": "Description",
+                                                    "data-label": "description",
                                                   },
                                                 },
                                               ]
@@ -9305,7 +9305,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             },
                                                             "header": Object {
                                                               "formatters": Array [],
-                                                              "label": "Name",
+                                                              "label": "name",
                                                               "transforms": Array [
                                                                 [Function],
                                                                 [Function],
@@ -9314,7 +9314,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             "property": "name",
                                                             "props": Object {
                                                               "data-key": 1,
-                                                              "data-label": "Name",
+                                                              "data-label": "name",
                                                             },
                                                           },
                                                           Object {
@@ -9349,7 +9349,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             },
                                                             "header": Object {
                                                               "formatters": Array [],
-                                                              "label": "Description",
+                                                              "label": "description",
                                                               "transforms": Array [
                                                                 [Function],
                                                                 [Function],
@@ -9358,7 +9358,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             "property": "description",
                                                             "props": Object {
                                                               "data-key": 2,
-                                                              "data-label": "Description",
+                                                              "data-label": "description",
                                                             },
                                                           },
                                                         ]
@@ -9542,7 +9542,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                               </BodyCell>
                                                               <BodyCell
                                                                 data-key={1}
-                                                                data-label="Name"
+                                                                data-label="name"
                                                                 isVisible={true}
                                                                 key="col-1-row-0"
                                                               >
@@ -9550,7 +9550,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                   className=""
                                                                   component="td"
                                                                   data-key={1}
-                                                                  dataLabel="Name"
+                                                                  dataLabel="name"
                                                                   onMouseEnter={[Function]}
                                                                   textCenter={false}
                                                                 >
@@ -9558,7 +9558,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     className=""
                                                                     component="td"
                                                                     data-key={1}
-                                                                    dataLabel="Name"
+                                                                    dataLabel="name"
                                                                     innerRef={null}
                                                                     onMouseEnter={[Function]}
                                                                     textCenter={false}
@@ -9566,7 +9566,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     <td
                                                                       className=""
                                                                       data-key={1}
-                                                                      data-label="Name"
+                                                                      data-label="name"
                                                                       onMouseEnter={[Function]}
                                                                     >
                                                                       zoneinfo
@@ -9576,7 +9576,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                               </BodyCell>
                                                               <BodyCell
                                                                 data-key={2}
-                                                                data-label="Description"
+                                                                data-label="description"
                                                                 isVisible={true}
                                                                 key="col-2-row-0"
                                                               >
@@ -9584,7 +9584,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                   className=""
                                                                   component="td"
                                                                   data-key={2}
-                                                                  dataLabel="Description"
+                                                                  dataLabel="description"
                                                                   onMouseEnter={[Function]}
                                                                   textCenter={false}
                                                                 >
@@ -9592,7 +9592,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     className=""
                                                                     component="td"
                                                                     data-key={2}
-                                                                    dataLabel="Description"
+                                                                    dataLabel="description"
                                                                     innerRef={null}
                                                                     onMouseEnter={[Function]}
                                                                     textCenter={false}
@@ -9600,7 +9600,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     <td
                                                                       className=""
                                                                       data-key={2}
-                                                                      data-label="Description"
+                                                                      data-label="description"
                                                                       onMouseEnter={[Function]}
                                                                     >
                                                                       Map a custom user attribute to a token claim.
@@ -9693,7 +9693,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             },
                                                             "header": Object {
                                                               "formatters": Array [],
-                                                              "label": "Name",
+                                                              "label": "name",
                                                               "transforms": Array [
                                                                 [Function],
                                                                 [Function],
@@ -9702,7 +9702,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             "property": "name",
                                                             "props": Object {
                                                               "data-key": 1,
-                                                              "data-label": "Name",
+                                                              "data-label": "name",
                                                             },
                                                           },
                                                           Object {
@@ -9737,7 +9737,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             },
                                                             "header": Object {
                                                               "formatters": Array [],
-                                                              "label": "Description",
+                                                              "label": "description",
                                                               "transforms": Array [
                                                                 [Function],
                                                                 [Function],
@@ -9746,7 +9746,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             "property": "description",
                                                             "props": Object {
                                                               "data-key": 2,
-                                                              "data-label": "Description",
+                                                              "data-label": "description",
                                                             },
                                                           },
                                                         ]
@@ -9930,7 +9930,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                               </BodyCell>
                                                               <BodyCell
                                                                 data-key={1}
-                                                                data-label="Name"
+                                                                data-label="name"
                                                                 isVisible={true}
                                                                 key="col-1-row-1"
                                                               >
@@ -9938,7 +9938,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                   className=""
                                                                   component="td"
                                                                   data-key={1}
-                                                                  dataLabel="Name"
+                                                                  dataLabel="name"
                                                                   onMouseEnter={[Function]}
                                                                   textCenter={false}
                                                                 >
@@ -9946,7 +9946,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     className=""
                                                                     component="td"
                                                                     data-key={1}
-                                                                    dataLabel="Name"
+                                                                    dataLabel="name"
                                                                     innerRef={null}
                                                                     onMouseEnter={[Function]}
                                                                     textCenter={false}
@@ -9954,7 +9954,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     <td
                                                                       className=""
                                                                       data-key={1}
-                                                                      data-label="Name"
+                                                                      data-label="name"
                                                                       onMouseEnter={[Function]}
                                                                     >
                                                                       birthdate
@@ -9964,7 +9964,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                               </BodyCell>
                                                               <BodyCell
                                                                 data-key={2}
-                                                                data-label="Description"
+                                                                data-label="description"
                                                                 isVisible={true}
                                                                 key="col-2-row-1"
                                                               >
@@ -9972,7 +9972,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                   className=""
                                                                   component="td"
                                                                   data-key={2}
-                                                                  dataLabel="Description"
+                                                                  dataLabel="description"
                                                                   onMouseEnter={[Function]}
                                                                   textCenter={false}
                                                                 >
@@ -9980,7 +9980,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     className=""
                                                                     component="td"
                                                                     data-key={2}
-                                                                    dataLabel="Description"
+                                                                    dataLabel="description"
                                                                     innerRef={null}
                                                                     onMouseEnter={[Function]}
                                                                     textCenter={false}
@@ -9988,7 +9988,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     <td
                                                                       className=""
                                                                       data-key={2}
-                                                                      data-label="Description"
+                                                                      data-label="description"
                                                                       onMouseEnter={[Function]}
                                                                     >
                                                                       Map a custom user attribute to a token claim.
@@ -10081,7 +10081,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             },
                                                             "header": Object {
                                                               "formatters": Array [],
-                                                              "label": "Name",
+                                                              "label": "name",
                                                               "transforms": Array [
                                                                 [Function],
                                                                 [Function],
@@ -10090,7 +10090,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             "property": "name",
                                                             "props": Object {
                                                               "data-key": 1,
-                                                              "data-label": "Name",
+                                                              "data-label": "name",
                                                             },
                                                           },
                                                           Object {
@@ -10125,7 +10125,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             },
                                                             "header": Object {
                                                               "formatters": Array [],
-                                                              "label": "Description",
+                                                              "label": "description",
                                                               "transforms": Array [
                                                                 [Function],
                                                                 [Function],
@@ -10134,7 +10134,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             "property": "description",
                                                             "props": Object {
                                                               "data-key": 2,
-                                                              "data-label": "Description",
+                                                              "data-label": "description",
                                                             },
                                                           },
                                                         ]
@@ -10318,7 +10318,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                               </BodyCell>
                                                               <BodyCell
                                                                 data-key={1}
-                                                                data-label="Name"
+                                                                data-label="name"
                                                                 isVisible={true}
                                                                 key="col-1-row-2"
                                                               >
@@ -10326,7 +10326,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                   className=""
                                                                   component="td"
                                                                   data-key={1}
-                                                                  dataLabel="Name"
+                                                                  dataLabel="name"
                                                                   onMouseEnter={[Function]}
                                                                   textCenter={false}
                                                                 >
@@ -10334,7 +10334,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     className=""
                                                                     component="td"
                                                                     data-key={1}
-                                                                    dataLabel="Name"
+                                                                    dataLabel="name"
                                                                     innerRef={null}
                                                                     onMouseEnter={[Function]}
                                                                     textCenter={false}
@@ -10342,7 +10342,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     <td
                                                                       className=""
                                                                       data-key={1}
-                                                                      data-label="Name"
+                                                                      data-label="name"
                                                                       onMouseEnter={[Function]}
                                                                     >
                                                                       family name
@@ -10352,7 +10352,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                               </BodyCell>
                                                               <BodyCell
                                                                 data-key={2}
-                                                                data-label="Description"
+                                                                data-label="description"
                                                                 isVisible={true}
                                                                 key="col-2-row-2"
                                                               >
@@ -10360,7 +10360,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                   className=""
                                                                   component="td"
                                                                   data-key={2}
-                                                                  dataLabel="Description"
+                                                                  dataLabel="description"
                                                                   onMouseEnter={[Function]}
                                                                   textCenter={false}
                                                                 >
@@ -10368,7 +10368,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     className=""
                                                                     component="td"
                                                                     data-key={2}
-                                                                    dataLabel="Description"
+                                                                    dataLabel="description"
                                                                     innerRef={null}
                                                                     onMouseEnter={[Function]}
                                                                     textCenter={false}
@@ -10376,7 +10376,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     <td
                                                                       className=""
                                                                       data-key={2}
-                                                                      data-label="Description"
+                                                                      data-label="description"
                                                                       onMouseEnter={[Function]}
                                                                     >
                                                                       Map a built in user property (email, firstName, lastName) to a token claim.
@@ -10469,7 +10469,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             },
                                                             "header": Object {
                                                               "formatters": Array [],
-                                                              "label": "Name",
+                                                              "label": "name",
                                                               "transforms": Array [
                                                                 [Function],
                                                                 [Function],
@@ -10478,7 +10478,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             "property": "name",
                                                             "props": Object {
                                                               "data-key": 1,
-                                                              "data-label": "Name",
+                                                              "data-label": "name",
                                                             },
                                                           },
                                                           Object {
@@ -10513,7 +10513,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             },
                                                             "header": Object {
                                                               "formatters": Array [],
-                                                              "label": "Description",
+                                                              "label": "description",
                                                               "transforms": Array [
                                                                 [Function],
                                                                 [Function],
@@ -10522,7 +10522,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             "property": "description",
                                                             "props": Object {
                                                               "data-key": 2,
-                                                              "data-label": "Description",
+                                                              "data-label": "description",
                                                             },
                                                           },
                                                         ]
@@ -10706,7 +10706,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                               </BodyCell>
                                                               <BodyCell
                                                                 data-key={1}
-                                                                data-label="Name"
+                                                                data-label="name"
                                                                 isVisible={true}
                                                                 key="col-1-row-3"
                                                               >
@@ -10714,7 +10714,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                   className=""
                                                                   component="td"
                                                                   data-key={1}
-                                                                  dataLabel="Name"
+                                                                  dataLabel="name"
                                                                   onMouseEnter={[Function]}
                                                                   textCenter={false}
                                                                 >
@@ -10722,7 +10722,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     className=""
                                                                     component="td"
                                                                     data-key={1}
-                                                                    dataLabel="Name"
+                                                                    dataLabel="name"
                                                                     innerRef={null}
                                                                     onMouseEnter={[Function]}
                                                                     textCenter={false}
@@ -10730,7 +10730,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     <td
                                                                       className=""
                                                                       data-key={1}
-                                                                      data-label="Name"
+                                                                      data-label="name"
                                                                       onMouseEnter={[Function]}
                                                                     >
                                                                       gender
@@ -10740,7 +10740,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                               </BodyCell>
                                                               <BodyCell
                                                                 data-key={2}
-                                                                data-label="Description"
+                                                                data-label="description"
                                                                 isVisible={true}
                                                                 key="col-2-row-3"
                                                               >
@@ -10748,7 +10748,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                   className=""
                                                                   component="td"
                                                                   data-key={2}
-                                                                  dataLabel="Description"
+                                                                  dataLabel="description"
                                                                   onMouseEnter={[Function]}
                                                                   textCenter={false}
                                                                 >
@@ -10756,7 +10756,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     className=""
                                                                     component="td"
                                                                     data-key={2}
-                                                                    dataLabel="Description"
+                                                                    dataLabel="description"
                                                                     innerRef={null}
                                                                     onMouseEnter={[Function]}
                                                                     textCenter={false}
@@ -10764,7 +10764,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     <td
                                                                       className=""
                                                                       data-key={2}
-                                                                      data-label="Description"
+                                                                      data-label="description"
                                                                       onMouseEnter={[Function]}
                                                                     >
                                                                       Map a custom user attribute to a token claim.
@@ -10857,7 +10857,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             },
                                                             "header": Object {
                                                               "formatters": Array [],
-                                                              "label": "Name",
+                                                              "label": "name",
                                                               "transforms": Array [
                                                                 [Function],
                                                                 [Function],
@@ -10866,7 +10866,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             "property": "name",
                                                             "props": Object {
                                                               "data-key": 1,
-                                                              "data-label": "Name",
+                                                              "data-label": "name",
                                                             },
                                                           },
                                                           Object {
@@ -10901,7 +10901,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             },
                                                             "header": Object {
                                                               "formatters": Array [],
-                                                              "label": "Description",
+                                                              "label": "description",
                                                               "transforms": Array [
                                                                 [Function],
                                                                 [Function],
@@ -10910,7 +10910,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             "property": "description",
                                                             "props": Object {
                                                               "data-key": 2,
-                                                              "data-label": "Description",
+                                                              "data-label": "description",
                                                             },
                                                           },
                                                         ]
@@ -11092,7 +11092,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                               </BodyCell>
                                                               <BodyCell
                                                                 data-key={1}
-                                                                data-label="Name"
+                                                                data-label="name"
                                                                 isVisible={true}
                                                                 key="col-1-row-4"
                                                               >
@@ -11100,7 +11100,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                   className=""
                                                                   component="td"
                                                                   data-key={1}
-                                                                  dataLabel="Name"
+                                                                  dataLabel="name"
                                                                   onMouseEnter={[Function]}
                                                                   textCenter={false}
                                                                 >
@@ -11108,7 +11108,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     className=""
                                                                     component="td"
                                                                     data-key={1}
-                                                                    dataLabel="Name"
+                                                                    dataLabel="name"
                                                                     innerRef={null}
                                                                     onMouseEnter={[Function]}
                                                                     textCenter={false}
@@ -11116,7 +11116,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     <td
                                                                       className=""
                                                                       data-key={1}
-                                                                      data-label="Name"
+                                                                      data-label="name"
                                                                       onMouseEnter={[Function]}
                                                                     >
                                                                       Impersonator Username
@@ -11126,7 +11126,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                               </BodyCell>
                                                               <BodyCell
                                                                 data-key={2}
-                                                                data-label="Description"
+                                                                data-label="description"
                                                                 isVisible={true}
                                                                 key="col-2-row-4"
                                                               >
@@ -11134,7 +11134,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                   className=""
                                                                   component="td"
                                                                   data-key={2}
-                                                                  dataLabel="Description"
+                                                                  dataLabel="description"
                                                                   onMouseEnter={[Function]}
                                                                   textCenter={false}
                                                                 >
@@ -11142,7 +11142,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     className=""
                                                                     component="td"
                                                                     data-key={2}
-                                                                    dataLabel="Description"
+                                                                    dataLabel="description"
                                                                     innerRef={null}
                                                                     onMouseEnter={[Function]}
                                                                     textCenter={false}
@@ -11150,7 +11150,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     <td
                                                                       className=""
                                                                       data-key={2}
-                                                                      data-label="Description"
+                                                                      data-label="description"
                                                                       onMouseEnter={[Function]}
                                                                     >
                                                                       Map a custom user session note to a token claim.
@@ -11243,7 +11243,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             },
                                                             "header": Object {
                                                               "formatters": Array [],
-                                                              "label": "Name",
+                                                              "label": "name",
                                                               "transforms": Array [
                                                                 [Function],
                                                                 [Function],
@@ -11252,7 +11252,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             "property": "name",
                                                             "props": Object {
                                                               "data-key": 1,
-                                                              "data-label": "Name",
+                                                              "data-label": "name",
                                                             },
                                                           },
                                                           Object {
@@ -11287,7 +11287,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             },
                                                             "header": Object {
                                                               "formatters": Array [],
-                                                              "label": "Description",
+                                                              "label": "description",
                                                               "transforms": Array [
                                                                 [Function],
                                                                 [Function],
@@ -11296,7 +11296,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             "property": "description",
                                                             "props": Object {
                                                               "data-key": 2,
-                                                              "data-label": "Description",
+                                                              "data-label": "description",
                                                             },
                                                           },
                                                         ]
@@ -11480,7 +11480,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                               </BodyCell>
                                                               <BodyCell
                                                                 data-key={1}
-                                                                data-label="Name"
+                                                                data-label="name"
                                                                 isVisible={true}
                                                                 key="col-1-row-5"
                                                               >
@@ -11488,7 +11488,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                   className=""
                                                                   component="td"
                                                                   data-key={1}
-                                                                  dataLabel="Name"
+                                                                  dataLabel="name"
                                                                   onMouseEnter={[Function]}
                                                                   textCenter={false}
                                                                 >
@@ -11496,7 +11496,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     className=""
                                                                     component="td"
                                                                     data-key={1}
-                                                                    dataLabel="Name"
+                                                                    dataLabel="name"
                                                                     innerRef={null}
                                                                     onMouseEnter={[Function]}
                                                                     textCenter={false}
@@ -11504,7 +11504,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     <td
                                                                       className=""
                                                                       data-key={1}
-                                                                      data-label="Name"
+                                                                      data-label="name"
                                                                       onMouseEnter={[Function]}
                                                                     >
                                                                       phone number verified
@@ -11514,7 +11514,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                               </BodyCell>
                                                               <BodyCell
                                                                 data-key={2}
-                                                                data-label="Description"
+                                                                data-label="description"
                                                                 isVisible={true}
                                                                 key="col-2-row-5"
                                                               >
@@ -11522,7 +11522,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                   className=""
                                                                   component="td"
                                                                   data-key={2}
-                                                                  dataLabel="Description"
+                                                                  dataLabel="description"
                                                                   onMouseEnter={[Function]}
                                                                   textCenter={false}
                                                                 >
@@ -11530,7 +11530,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     className=""
                                                                     component="td"
                                                                     data-key={2}
-                                                                    dataLabel="Description"
+                                                                    dataLabel="description"
                                                                     innerRef={null}
                                                                     onMouseEnter={[Function]}
                                                                     textCenter={false}
@@ -11538,7 +11538,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     <td
                                                                       className=""
                                                                       data-key={2}
-                                                                      data-label="Description"
+                                                                      data-label="description"
                                                                       onMouseEnter={[Function]}
                                                                     >
                                                                       Map a custom user attribute to a token claim.
@@ -11631,7 +11631,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             },
                                                             "header": Object {
                                                               "formatters": Array [],
-                                                              "label": "Name",
+                                                              "label": "name",
                                                               "transforms": Array [
                                                                 [Function],
                                                                 [Function],
@@ -11640,7 +11640,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             "property": "name",
                                                             "props": Object {
                                                               "data-key": 1,
-                                                              "data-label": "Name",
+                                                              "data-label": "name",
                                                             },
                                                           },
                                                           Object {
@@ -11675,7 +11675,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             },
                                                             "header": Object {
                                                               "formatters": Array [],
-                                                              "label": "Description",
+                                                              "label": "description",
                                                               "transforms": Array [
                                                                 [Function],
                                                                 [Function],
@@ -11684,7 +11684,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             "property": "description",
                                                             "props": Object {
                                                               "data-key": 2,
-                                                              "data-label": "Description",
+                                                              "data-label": "description",
                                                             },
                                                           },
                                                         ]
@@ -11868,7 +11868,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                               </BodyCell>
                                                               <BodyCell
                                                                 data-key={1}
-                                                                data-label="Name"
+                                                                data-label="name"
                                                                 isVisible={true}
                                                                 key="col-1-row-6"
                                                               >
@@ -11876,7 +11876,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                   className=""
                                                                   component="td"
                                                                   data-key={1}
-                                                                  dataLabel="Name"
+                                                                  dataLabel="name"
                                                                   onMouseEnter={[Function]}
                                                                   textCenter={false}
                                                                 >
@@ -11884,7 +11884,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     className=""
                                                                     component="td"
                                                                     data-key={1}
-                                                                    dataLabel="Name"
+                                                                    dataLabel="name"
                                                                     innerRef={null}
                                                                     onMouseEnter={[Function]}
                                                                     textCenter={false}
@@ -11892,7 +11892,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     <td
                                                                       className=""
                                                                       data-key={1}
-                                                                      data-label="Name"
+                                                                      data-label="name"
                                                                       onMouseEnter={[Function]}
                                                                     >
                                                                       locale
@@ -11902,7 +11902,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                               </BodyCell>
                                                               <BodyCell
                                                                 data-key={2}
-                                                                data-label="Description"
+                                                                data-label="description"
                                                                 isVisible={true}
                                                                 key="col-2-row-6"
                                                               >
@@ -11910,7 +11910,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                   className=""
                                                                   component="td"
                                                                   data-key={2}
-                                                                  dataLabel="Description"
+                                                                  dataLabel="description"
                                                                   onMouseEnter={[Function]}
                                                                   textCenter={false}
                                                                 >
@@ -11918,7 +11918,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     className=""
                                                                     component="td"
                                                                     data-key={2}
-                                                                    dataLabel="Description"
+                                                                    dataLabel="description"
                                                                     innerRef={null}
                                                                     onMouseEnter={[Function]}
                                                                     textCenter={false}
@@ -11926,7 +11926,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     <td
                                                                       className=""
                                                                       data-key={2}
-                                                                      data-label="Description"
+                                                                      data-label="description"
                                                                       onMouseEnter={[Function]}
                                                                     >
                                                                       Map a custom user attribute to a token claim.
@@ -12019,7 +12019,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             },
                                                             "header": Object {
                                                               "formatters": Array [],
-                                                              "label": "Name",
+                                                              "label": "name",
                                                               "transforms": Array [
                                                                 [Function],
                                                                 [Function],
@@ -12028,7 +12028,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             "property": "name",
                                                             "props": Object {
                                                               "data-key": 1,
-                                                              "data-label": "Name",
+                                                              "data-label": "name",
                                                             },
                                                           },
                                                           Object {
@@ -12063,7 +12063,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             },
                                                             "header": Object {
                                                               "formatters": Array [],
-                                                              "label": "Description",
+                                                              "label": "description",
                                                               "transforms": Array [
                                                                 [Function],
                                                                 [Function],
@@ -12072,7 +12072,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             "property": "description",
                                                             "props": Object {
                                                               "data-key": 2,
-                                                              "data-label": "Description",
+                                                              "data-label": "description",
                                                             },
                                                           },
                                                         ]
@@ -12252,7 +12252,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                               </BodyCell>
                                                               <BodyCell
                                                                 data-key={1}
-                                                                data-label="Name"
+                                                                data-label="name"
                                                                 isVisible={true}
                                                                 key="col-1-row-7"
                                                               >
@@ -12260,7 +12260,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                   className=""
                                                                   component="td"
                                                                   data-key={1}
-                                                                  dataLabel="Name"
+                                                                  dataLabel="name"
                                                                   onMouseEnter={[Function]}
                                                                   textCenter={false}
                                                                 >
@@ -12268,7 +12268,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     className=""
                                                                     component="td"
                                                                     data-key={1}
-                                                                    dataLabel="Name"
+                                                                    dataLabel="name"
                                                                     innerRef={null}
                                                                     onMouseEnter={[Function]}
                                                                     textCenter={false}
@@ -12276,7 +12276,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     <td
                                                                       className=""
                                                                       data-key={1}
-                                                                      data-label="Name"
+                                                                      data-label="name"
                                                                       onMouseEnter={[Function]}
                                                                     >
                                                                       gss delegation credential
@@ -12286,7 +12286,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                               </BodyCell>
                                                               <BodyCell
                                                                 data-key={2}
-                                                                data-label="Description"
+                                                                data-label="description"
                                                                 isVisible={true}
                                                                 key="col-2-row-7"
                                                               >
@@ -12294,7 +12294,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                   className=""
                                                                   component="td"
                                                                   data-key={2}
-                                                                  dataLabel="Description"
+                                                                  dataLabel="description"
                                                                   onMouseEnter={[Function]}
                                                                   textCenter={false}
                                                                 >
@@ -12302,7 +12302,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     className=""
                                                                     component="td"
                                                                     data-key={2}
-                                                                    dataLabel="Description"
+                                                                    dataLabel="description"
                                                                     innerRef={null}
                                                                     onMouseEnter={[Function]}
                                                                     textCenter={false}
@@ -12310,7 +12310,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     <td
                                                                       className=""
                                                                       data-key={2}
-                                                                      data-label="Description"
+                                                                      data-label="description"
                                                                       onMouseEnter={[Function]}
                                                                     >
                                                                       Map a custom user session note to a token claim.
@@ -12403,7 +12403,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             },
                                                             "header": Object {
                                                               "formatters": Array [],
-                                                              "label": "Name",
+                                                              "label": "name",
                                                               "transforms": Array [
                                                                 [Function],
                                                                 [Function],
@@ -12412,7 +12412,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             "property": "name",
                                                             "props": Object {
                                                               "data-key": 1,
-                                                              "data-label": "Name",
+                                                              "data-label": "name",
                                                             },
                                                           },
                                                           Object {
@@ -12447,7 +12447,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             },
                                                             "header": Object {
                                                               "formatters": Array [],
-                                                              "label": "Description",
+                                                              "label": "description",
                                                               "transforms": Array [
                                                                 [Function],
                                                                 [Function],
@@ -12456,7 +12456,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             "property": "description",
                                                             "props": Object {
                                                               "data-key": 2,
-                                                              "data-label": "Description",
+                                                              "data-label": "description",
                                                             },
                                                           },
                                                         ]
@@ -12626,7 +12626,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                               </BodyCell>
                                                               <BodyCell
                                                                 data-key={1}
-                                                                data-label="Name"
+                                                                data-label="name"
                                                                 isVisible={true}
                                                                 key="col-1-row-8"
                                                               >
@@ -12634,7 +12634,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                   className=""
                                                                   component="td"
                                                                   data-key={1}
-                                                                  dataLabel="Name"
+                                                                  dataLabel="name"
                                                                   onMouseEnter={[Function]}
                                                                   textCenter={false}
                                                                 >
@@ -12642,7 +12642,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     className=""
                                                                     component="td"
                                                                     data-key={1}
-                                                                    dataLabel="Name"
+                                                                    dataLabel="name"
                                                                     innerRef={null}
                                                                     onMouseEnter={[Function]}
                                                                     textCenter={false}
@@ -12650,7 +12650,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     <td
                                                                       className=""
                                                                       data-key={1}
-                                                                      data-label="Name"
+                                                                      data-label="name"
                                                                       onMouseEnter={[Function]}
                                                                     >
                                                                       allowed web origins
@@ -12660,7 +12660,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                               </BodyCell>
                                                               <BodyCell
                                                                 data-key={2}
-                                                                data-label="Description"
+                                                                data-label="description"
                                                                 isVisible={true}
                                                                 key="col-2-row-8"
                                                               >
@@ -12668,7 +12668,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                   className=""
                                                                   component="td"
                                                                   data-key={2}
-                                                                  dataLabel="Description"
+                                                                  dataLabel="description"
                                                                   onMouseEnter={[Function]}
                                                                   textCenter={false}
                                                                 >
@@ -12676,7 +12676,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     className=""
                                                                     component="td"
                                                                     data-key={2}
-                                                                    dataLabel="Description"
+                                                                    dataLabel="description"
                                                                     innerRef={null}
                                                                     onMouseEnter={[Function]}
                                                                     textCenter={false}
@@ -12684,7 +12684,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     <td
                                                                       className=""
                                                                       data-key={2}
-                                                                      data-label="Description"
+                                                                      data-label="description"
                                                                       onMouseEnter={[Function]}
                                                                     >
                                                                       Adds all allowed web origins to the 'allowed-origins' claim in the token
@@ -12777,7 +12777,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             },
                                                             "header": Object {
                                                               "formatters": Array [],
-                                                              "label": "Name",
+                                                              "label": "name",
                                                               "transforms": Array [
                                                                 [Function],
                                                                 [Function],
@@ -12786,7 +12786,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             "property": "name",
                                                             "props": Object {
                                                               "data-key": 1,
-                                                              "data-label": "Name",
+                                                              "data-label": "name",
                                                             },
                                                           },
                                                           Object {
@@ -12821,7 +12821,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             },
                                                             "header": Object {
                                                               "formatters": Array [],
-                                                              "label": "Description",
+                                                              "label": "description",
                                                               "transforms": Array [
                                                                 [Function],
                                                                 [Function],
@@ -12830,7 +12830,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             "property": "description",
                                                             "props": Object {
                                                               "data-key": 2,
-                                                              "data-label": "Description",
+                                                              "data-label": "description",
                                                             },
                                                           },
                                                         ]
@@ -13014,7 +13014,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                               </BodyCell>
                                                               <BodyCell
                                                                 data-key={1}
-                                                                data-label="Name"
+                                                                data-label="name"
                                                                 isVisible={true}
                                                                 key="col-1-row-9"
                                                               >
@@ -13022,7 +13022,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                   className=""
                                                                   component="td"
                                                                   data-key={1}
-                                                                  dataLabel="Name"
+                                                                  dataLabel="name"
                                                                   onMouseEnter={[Function]}
                                                                   textCenter={false}
                                                                 >
@@ -13030,7 +13030,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     className=""
                                                                     component="td"
                                                                     data-key={1}
-                                                                    dataLabel="Name"
+                                                                    dataLabel="name"
                                                                     innerRef={null}
                                                                     onMouseEnter={[Function]}
                                                                     textCenter={false}
@@ -13038,7 +13038,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     <td
                                                                       className=""
                                                                       data-key={1}
-                                                                      data-label="Name"
+                                                                      data-label="name"
                                                                       onMouseEnter={[Function]}
                                                                     >
                                                                       middle name
@@ -13048,7 +13048,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                               </BodyCell>
                                                               <BodyCell
                                                                 data-key={2}
-                                                                data-label="Description"
+                                                                data-label="description"
                                                                 isVisible={true}
                                                                 key="col-2-row-9"
                                                               >
@@ -13056,7 +13056,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                   className=""
                                                                   component="td"
                                                                   data-key={2}
-                                                                  dataLabel="Description"
+                                                                  dataLabel="description"
                                                                   onMouseEnter={[Function]}
                                                                   textCenter={false}
                                                                 >
@@ -13064,7 +13064,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     className=""
                                                                     component="td"
                                                                     data-key={2}
-                                                                    dataLabel="Description"
+                                                                    dataLabel="description"
                                                                     innerRef={null}
                                                                     onMouseEnter={[Function]}
                                                                     textCenter={false}
@@ -13072,7 +13072,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     <td
                                                                       className=""
                                                                       data-key={2}
-                                                                      data-label="Description"
+                                                                      data-label="description"
                                                                       onMouseEnter={[Function]}
                                                                     >
                                                                       Map a custom user attribute to a token claim.
@@ -13165,7 +13165,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             },
                                                             "header": Object {
                                                               "formatters": Array [],
-                                                              "label": "Name",
+                                                              "label": "name",
                                                               "transforms": Array [
                                                                 [Function],
                                                                 [Function],
@@ -13174,7 +13174,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             "property": "name",
                                                             "props": Object {
                                                               "data-key": 1,
-                                                              "data-label": "Name",
+                                                              "data-label": "name",
                                                             },
                                                           },
                                                           Object {
@@ -13209,7 +13209,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             },
                                                             "header": Object {
                                                               "formatters": Array [],
-                                                              "label": "Description",
+                                                              "label": "description",
                                                               "transforms": Array [
                                                                 [Function],
                                                                 [Function],
@@ -13218,7 +13218,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             "property": "description",
                                                             "props": Object {
                                                               "data-key": 2,
-                                                              "data-label": "Description",
+                                                              "data-label": "description",
                                                             },
                                                           },
                                                         ]
@@ -13402,7 +13402,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                               </BodyCell>
                                                               <BodyCell
                                                                 data-key={1}
-                                                                data-label="Name"
+                                                                data-label="name"
                                                                 isVisible={true}
                                                                 key="col-1-row-10"
                                                               >
@@ -13410,7 +13410,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                   className=""
                                                                   component="td"
                                                                   data-key={1}
-                                                                  dataLabel="Name"
+                                                                  dataLabel="name"
                                                                   onMouseEnter={[Function]}
                                                                   textCenter={false}
                                                                 >
@@ -13418,7 +13418,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     className=""
                                                                     component="td"
                                                                     data-key={1}
-                                                                    dataLabel="Name"
+                                                                    dataLabel="name"
                                                                     innerRef={null}
                                                                     onMouseEnter={[Function]}
                                                                     textCenter={false}
@@ -13426,7 +13426,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     <td
                                                                       className=""
                                                                       data-key={1}
-                                                                      data-label="Name"
+                                                                      data-label="name"
                                                                       onMouseEnter={[Function]}
                                                                     >
                                                                       nickname
@@ -13436,7 +13436,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                               </BodyCell>
                                                               <BodyCell
                                                                 data-key={2}
-                                                                data-label="Description"
+                                                                data-label="description"
                                                                 isVisible={true}
                                                                 key="col-2-row-10"
                                                               >
@@ -13444,7 +13444,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                   className=""
                                                                   component="td"
                                                                   data-key={2}
-                                                                  dataLabel="Description"
+                                                                  dataLabel="description"
                                                                   onMouseEnter={[Function]}
                                                                   textCenter={false}
                                                                 >
@@ -13452,7 +13452,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     className=""
                                                                     component="td"
                                                                     data-key={2}
-                                                                    dataLabel="Description"
+                                                                    dataLabel="description"
                                                                     innerRef={null}
                                                                     onMouseEnter={[Function]}
                                                                     textCenter={false}
@@ -13460,7 +13460,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     <td
                                                                       className=""
                                                                       data-key={2}
-                                                                      data-label="Description"
+                                                                      data-label="description"
                                                                       onMouseEnter={[Function]}
                                                                     >
                                                                       Map a custom user attribute to a token claim.
@@ -13553,7 +13553,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             },
                                                             "header": Object {
                                                               "formatters": Array [],
-                                                              "label": "Name",
+                                                              "label": "name",
                                                               "transforms": Array [
                                                                 [Function],
                                                                 [Function],
@@ -13562,7 +13562,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             "property": "name",
                                                             "props": Object {
                                                               "data-key": 1,
-                                                              "data-label": "Name",
+                                                              "data-label": "name",
                                                             },
                                                           },
                                                           Object {
@@ -13597,7 +13597,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             },
                                                             "header": Object {
                                                               "formatters": Array [],
-                                                              "label": "Description",
+                                                              "label": "description",
                                                               "transforms": Array [
                                                                 [Function],
                                                                 [Function],
@@ -13606,7 +13606,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             "property": "description",
                                                             "props": Object {
                                                               "data-key": 2,
-                                                              "data-label": "Description",
+                                                              "data-label": "description",
                                                             },
                                                           },
                                                         ]
@@ -13790,7 +13790,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                               </BodyCell>
                                                               <BodyCell
                                                                 data-key={1}
-                                                                data-label="Name"
+                                                                data-label="name"
                                                                 isVisible={true}
                                                                 key="col-1-row-11"
                                                               >
@@ -13798,7 +13798,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                   className=""
                                                                   component="td"
                                                                   data-key={1}
-                                                                  dataLabel="Name"
+                                                                  dataLabel="name"
                                                                   onMouseEnter={[Function]}
                                                                   textCenter={false}
                                                                 >
@@ -13806,7 +13806,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     className=""
                                                                     component="td"
                                                                     data-key={1}
-                                                                    dataLabel="Name"
+                                                                    dataLabel="name"
                                                                     innerRef={null}
                                                                     onMouseEnter={[Function]}
                                                                     textCenter={false}
@@ -13814,7 +13814,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     <td
                                                                       className=""
                                                                       data-key={1}
-                                                                      data-label="Name"
+                                                                      data-label="name"
                                                                       onMouseEnter={[Function]}
                                                                     >
                                                                       updated at
@@ -13824,7 +13824,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                               </BodyCell>
                                                               <BodyCell
                                                                 data-key={2}
-                                                                data-label="Description"
+                                                                data-label="description"
                                                                 isVisible={true}
                                                                 key="col-2-row-11"
                                                               >
@@ -13832,7 +13832,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                   className=""
                                                                   component="td"
                                                                   data-key={2}
-                                                                  dataLabel="Description"
+                                                                  dataLabel="description"
                                                                   onMouseEnter={[Function]}
                                                                   textCenter={false}
                                                                 >
@@ -13840,7 +13840,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     className=""
                                                                     component="td"
                                                                     data-key={2}
-                                                                    dataLabel="Description"
+                                                                    dataLabel="description"
                                                                     innerRef={null}
                                                                     onMouseEnter={[Function]}
                                                                     textCenter={false}
@@ -13848,7 +13848,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     <td
                                                                       className=""
                                                                       data-key={2}
-                                                                      data-label="Description"
+                                                                      data-label="description"
                                                                       onMouseEnter={[Function]}
                                                                     >
                                                                       Map a custom user attribute to a token claim.
@@ -13941,7 +13941,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             },
                                                             "header": Object {
                                                               "formatters": Array [],
-                                                              "label": "Name",
+                                                              "label": "name",
                                                               "transforms": Array [
                                                                 [Function],
                                                                 [Function],
@@ -13950,7 +13950,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             "property": "name",
                                                             "props": Object {
                                                               "data-key": 1,
-                                                              "data-label": "Name",
+                                                              "data-label": "name",
                                                             },
                                                           },
                                                           Object {
@@ -13985,7 +13985,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             },
                                                             "header": Object {
                                                               "formatters": Array [],
-                                                              "label": "Description",
+                                                              "label": "description",
                                                               "transforms": Array [
                                                                 [Function],
                                                                 [Function],
@@ -13994,7 +13994,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             "property": "description",
                                                             "props": Object {
                                                               "data-key": 2,
-                                                              "data-label": "Description",
+                                                              "data-label": "description",
                                                             },
                                                           },
                                                         ]
@@ -14178,7 +14178,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                               </BodyCell>
                                                               <BodyCell
                                                                 data-key={1}
-                                                                data-label="Name"
+                                                                data-label="name"
                                                                 isVisible={true}
                                                                 key="col-1-row-12"
                                                               >
@@ -14186,7 +14186,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                   className=""
                                                                   component="td"
                                                                   data-key={1}
-                                                                  dataLabel="Name"
+                                                                  dataLabel="name"
                                                                   onMouseEnter={[Function]}
                                                                   textCenter={false}
                                                                 >
@@ -14194,7 +14194,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     className=""
                                                                     component="td"
                                                                     data-key={1}
-                                                                    dataLabel="Name"
+                                                                    dataLabel="name"
                                                                     innerRef={null}
                                                                     onMouseEnter={[Function]}
                                                                     textCenter={false}
@@ -14202,7 +14202,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     <td
                                                                       className=""
                                                                       data-key={1}
-                                                                      data-label="Name"
+                                                                      data-label="name"
                                                                       onMouseEnter={[Function]}
                                                                     >
                                                                       email verified
@@ -14212,7 +14212,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                               </BodyCell>
                                                               <BodyCell
                                                                 data-key={2}
-                                                                data-label="Description"
+                                                                data-label="description"
                                                                 isVisible={true}
                                                                 key="col-2-row-12"
                                                               >
@@ -14220,7 +14220,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                   className=""
                                                                   component="td"
                                                                   data-key={2}
-                                                                  dataLabel="Description"
+                                                                  dataLabel="description"
                                                                   onMouseEnter={[Function]}
                                                                   textCenter={false}
                                                                 >
@@ -14228,7 +14228,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     className=""
                                                                     component="td"
                                                                     data-key={2}
-                                                                    dataLabel="Description"
+                                                                    dataLabel="description"
                                                                     innerRef={null}
                                                                     onMouseEnter={[Function]}
                                                                     textCenter={false}
@@ -14236,7 +14236,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     <td
                                                                       className=""
                                                                       data-key={2}
-                                                                      data-label="Description"
+                                                                      data-label="description"
                                                                       onMouseEnter={[Function]}
                                                                     >
                                                                       Map a built in user property (email, firstName, lastName) to a token claim.
@@ -14329,7 +14329,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             },
                                                             "header": Object {
                                                               "formatters": Array [],
-                                                              "label": "Name",
+                                                              "label": "name",
                                                               "transforms": Array [
                                                                 [Function],
                                                                 [Function],
@@ -14338,7 +14338,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             "property": "name",
                                                             "props": Object {
                                                               "data-key": 1,
-                                                              "data-label": "Name",
+                                                              "data-label": "name",
                                                             },
                                                           },
                                                           Object {
@@ -14373,7 +14373,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             },
                                                             "header": Object {
                                                               "formatters": Array [],
-                                                              "label": "Description",
+                                                              "label": "description",
                                                               "transforms": Array [
                                                                 [Function],
                                                                 [Function],
@@ -14382,7 +14382,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             "property": "description",
                                                             "props": Object {
                                                               "data-key": 2,
-                                                              "data-label": "Description",
+                                                              "data-label": "description",
                                                             },
                                                           },
                                                         ]
@@ -14566,7 +14566,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                               </BodyCell>
                                                               <BodyCell
                                                                 data-key={1}
-                                                                data-label="Name"
+                                                                data-label="name"
                                                                 isVisible={true}
                                                                 key="col-1-row-13"
                                                               >
@@ -14574,7 +14574,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                   className=""
                                                                   component="td"
                                                                   data-key={1}
-                                                                  dataLabel="Name"
+                                                                  dataLabel="name"
                                                                   onMouseEnter={[Function]}
                                                                   textCenter={false}
                                                                 >
@@ -14582,7 +14582,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     className=""
                                                                     component="td"
                                                                     data-key={1}
-                                                                    dataLabel="Name"
+                                                                    dataLabel="name"
                                                                     innerRef={null}
                                                                     onMouseEnter={[Function]}
                                                                     textCenter={false}
@@ -14590,7 +14590,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     <td
                                                                       className=""
                                                                       data-key={1}
-                                                                      data-label="Name"
+                                                                      data-label="name"
                                                                       onMouseEnter={[Function]}
                                                                     >
                                                                       email
@@ -14600,7 +14600,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                               </BodyCell>
                                                               <BodyCell
                                                                 data-key={2}
-                                                                data-label="Description"
+                                                                data-label="description"
                                                                 isVisible={true}
                                                                 key="col-2-row-13"
                                                               >
@@ -14608,7 +14608,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                   className=""
                                                                   component="td"
                                                                   data-key={2}
-                                                                  dataLabel="Description"
+                                                                  dataLabel="description"
                                                                   onMouseEnter={[Function]}
                                                                   textCenter={false}
                                                                 >
@@ -14616,7 +14616,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     className=""
                                                                     component="td"
                                                                     data-key={2}
-                                                                    dataLabel="Description"
+                                                                    dataLabel="description"
                                                                     innerRef={null}
                                                                     onMouseEnter={[Function]}
                                                                     textCenter={false}
@@ -14624,7 +14624,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     <td
                                                                       className=""
                                                                       data-key={2}
-                                                                      data-label="Description"
+                                                                      data-label="description"
                                                                       onMouseEnter={[Function]}
                                                                     >
                                                                       Map a built in user property (email, firstName, lastName) to a token claim.
@@ -14717,7 +14717,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             },
                                                             "header": Object {
                                                               "formatters": Array [],
-                                                              "label": "Name",
+                                                              "label": "name",
                                                               "transforms": Array [
                                                                 [Function],
                                                                 [Function],
@@ -14726,7 +14726,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             "property": "name",
                                                             "props": Object {
                                                               "data-key": 1,
-                                                              "data-label": "Name",
+                                                              "data-label": "name",
                                                             },
                                                           },
                                                           Object {
@@ -14761,7 +14761,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             },
                                                             "header": Object {
                                                               "formatters": Array [],
-                                                              "label": "Description",
+                                                              "label": "description",
                                                               "transforms": Array [
                                                                 [Function],
                                                                 [Function],
@@ -14770,7 +14770,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             "property": "description",
                                                             "props": Object {
                                                               "data-key": 2,
-                                                              "data-label": "Description",
+                                                              "data-label": "description",
                                                             },
                                                           },
                                                         ]
@@ -14952,7 +14952,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                               </BodyCell>
                                                               <BodyCell
                                                                 data-key={1}
-                                                                data-label="Name"
+                                                                data-label="name"
                                                                 isVisible={true}
                                                                 key="col-1-row-14"
                                                               >
@@ -14960,7 +14960,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                   className=""
                                                                   component="td"
                                                                   data-key={1}
-                                                                  dataLabel="Name"
+                                                                  dataLabel="name"
                                                                   onMouseEnter={[Function]}
                                                                   textCenter={false}
                                                                 >
@@ -14968,7 +14968,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     className=""
                                                                     component="td"
                                                                     data-key={1}
-                                                                    dataLabel="Name"
+                                                                    dataLabel="name"
                                                                     innerRef={null}
                                                                     onMouseEnter={[Function]}
                                                                     textCenter={false}
@@ -14976,7 +14976,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     <td
                                                                       className=""
                                                                       data-key={1}
-                                                                      data-label="Name"
+                                                                      data-label="name"
                                                                       onMouseEnter={[Function]}
                                                                     >
                                                                       client roles
@@ -14986,7 +14986,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                               </BodyCell>
                                                               <BodyCell
                                                                 data-key={2}
-                                                                data-label="Description"
+                                                                data-label="description"
                                                                 isVisible={true}
                                                                 key="col-2-row-14"
                                                               >
@@ -14994,7 +14994,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                   className=""
                                                                   component="td"
                                                                   data-key={2}
-                                                                  dataLabel="Description"
+                                                                  dataLabel="description"
                                                                   onMouseEnter={[Function]}
                                                                   textCenter={false}
                                                                 >
@@ -15002,7 +15002,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     className=""
                                                                     component="td"
                                                                     data-key={2}
-                                                                    dataLabel="Description"
+                                                                    dataLabel="description"
                                                                     innerRef={null}
                                                                     onMouseEnter={[Function]}
                                                                     textCenter={false}
@@ -15010,7 +15010,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     <td
                                                                       className=""
                                                                       data-key={2}
-                                                                      data-label="Description"
+                                                                      data-label="description"
                                                                       onMouseEnter={[Function]}
                                                                     >
                                                                       Map a user client role to a token claim.
@@ -15103,7 +15103,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             },
                                                             "header": Object {
                                                               "formatters": Array [],
-                                                              "label": "Name",
+                                                              "label": "name",
                                                               "transforms": Array [
                                                                 [Function],
                                                                 [Function],
@@ -15112,7 +15112,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             "property": "name",
                                                             "props": Object {
                                                               "data-key": 1,
-                                                              "data-label": "Name",
+                                                              "data-label": "name",
                                                             },
                                                           },
                                                           Object {
@@ -15147,7 +15147,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             },
                                                             "header": Object {
                                                               "formatters": Array [],
-                                                              "label": "Description",
+                                                              "label": "description",
                                                               "transforms": Array [
                                                                 [Function],
                                                                 [Function],
@@ -15156,7 +15156,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             "property": "description",
                                                             "props": Object {
                                                               "data-key": 2,
-                                                              "data-label": "Description",
+                                                              "data-label": "description",
                                                             },
                                                           },
                                                         ]
@@ -15338,7 +15338,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                               </BodyCell>
                                                               <BodyCell
                                                                 data-key={1}
-                                                                data-label="Name"
+                                                                data-label="name"
                                                                 isVisible={true}
                                                                 key="col-1-row-15"
                                                               >
@@ -15346,7 +15346,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                   className=""
                                                                   component="td"
                                                                   data-key={1}
-                                                                  dataLabel="Name"
+                                                                  dataLabel="name"
                                                                   onMouseEnter={[Function]}
                                                                   textCenter={false}
                                                                 >
@@ -15354,7 +15354,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     className=""
                                                                     component="td"
                                                                     data-key={1}
-                                                                    dataLabel="Name"
+                                                                    dataLabel="name"
                                                                     innerRef={null}
                                                                     onMouseEnter={[Function]}
                                                                     textCenter={false}
@@ -15362,7 +15362,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     <td
                                                                       className=""
                                                                       data-key={1}
-                                                                      data-label="Name"
+                                                                      data-label="name"
                                                                       onMouseEnter={[Function]}
                                                                     >
                                                                       Impersonator User ID
@@ -15372,7 +15372,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                               </BodyCell>
                                                               <BodyCell
                                                                 data-key={2}
-                                                                data-label="Description"
+                                                                data-label="description"
                                                                 isVisible={true}
                                                                 key="col-2-row-15"
                                                               >
@@ -15380,7 +15380,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                   className=""
                                                                   component="td"
                                                                   data-key={2}
-                                                                  dataLabel="Description"
+                                                                  dataLabel="description"
                                                                   onMouseEnter={[Function]}
                                                                   textCenter={false}
                                                                 >
@@ -15388,7 +15388,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     className=""
                                                                     component="td"
                                                                     data-key={2}
-                                                                    dataLabel="Description"
+                                                                    dataLabel="description"
                                                                     innerRef={null}
                                                                     onMouseEnter={[Function]}
                                                                     textCenter={false}
@@ -15396,7 +15396,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     <td
                                                                       className=""
                                                                       data-key={2}
-                                                                      data-label="Description"
+                                                                      data-label="description"
                                                                       onMouseEnter={[Function]}
                                                                     >
                                                                       Map a custom user session note to a token claim.
@@ -15489,7 +15489,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             },
                                                             "header": Object {
                                                               "formatters": Array [],
-                                                              "label": "Name",
+                                                              "label": "name",
                                                               "transforms": Array [
                                                                 [Function],
                                                                 [Function],
@@ -15498,7 +15498,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             "property": "name",
                                                             "props": Object {
                                                               "data-key": 1,
-                                                              "data-label": "Name",
+                                                              "data-label": "name",
                                                             },
                                                           },
                                                           Object {
@@ -15533,7 +15533,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             },
                                                             "header": Object {
                                                               "formatters": Array [],
-                                                              "label": "Description",
+                                                              "label": "description",
                                                               "transforms": Array [
                                                                 [Function],
                                                                 [Function],
@@ -15542,7 +15542,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             "property": "description",
                                                             "props": Object {
                                                               "data-key": 2,
-                                                              "data-label": "Description",
+                                                              "data-label": "description",
                                                             },
                                                           },
                                                         ]
@@ -15726,7 +15726,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                               </BodyCell>
                                                               <BodyCell
                                                                 data-key={1}
-                                                                data-label="Name"
+                                                                data-label="name"
                                                                 isVisible={true}
                                                                 key="col-1-row-16"
                                                               >
@@ -15734,7 +15734,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                   className=""
                                                                   component="td"
                                                                   data-key={1}
-                                                                  dataLabel="Name"
+                                                                  dataLabel="name"
                                                                   onMouseEnter={[Function]}
                                                                   textCenter={false}
                                                                 >
@@ -15742,7 +15742,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     className=""
                                                                     component="td"
                                                                     data-key={1}
-                                                                    dataLabel="Name"
+                                                                    dataLabel="name"
                                                                     innerRef={null}
                                                                     onMouseEnter={[Function]}
                                                                     textCenter={false}
@@ -15750,7 +15750,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     <td
                                                                       className=""
                                                                       data-key={1}
-                                                                      data-label="Name"
+                                                                      data-label="name"
                                                                       onMouseEnter={[Function]}
                                                                     >
                                                                       website
@@ -15760,7 +15760,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                               </BodyCell>
                                                               <BodyCell
                                                                 data-key={2}
-                                                                data-label="Description"
+                                                                data-label="description"
                                                                 isVisible={true}
                                                                 key="col-2-row-16"
                                                               >
@@ -15768,7 +15768,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                   className=""
                                                                   component="td"
                                                                   data-key={2}
-                                                                  dataLabel="Description"
+                                                                  dataLabel="description"
                                                                   onMouseEnter={[Function]}
                                                                   textCenter={false}
                                                                 >
@@ -15776,7 +15776,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     className=""
                                                                     component="td"
                                                                     data-key={2}
-                                                                    dataLabel="Description"
+                                                                    dataLabel="description"
                                                                     innerRef={null}
                                                                     onMouseEnter={[Function]}
                                                                     textCenter={false}
@@ -15784,7 +15784,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     <td
                                                                       className=""
                                                                       data-key={2}
-                                                                      data-label="Description"
+                                                                      data-label="description"
                                                                       onMouseEnter={[Function]}
                                                                     >
                                                                       Map a custom user attribute to a token claim.
@@ -15877,7 +15877,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             },
                                                             "header": Object {
                                                               "formatters": Array [],
-                                                              "label": "Name",
+                                                              "label": "name",
                                                               "transforms": Array [
                                                                 [Function],
                                                                 [Function],
@@ -15886,7 +15886,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             "property": "name",
                                                             "props": Object {
                                                               "data-key": 1,
-                                                              "data-label": "Name",
+                                                              "data-label": "name",
                                                             },
                                                           },
                                                           Object {
@@ -15921,7 +15921,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             },
                                                             "header": Object {
                                                               "formatters": Array [],
-                                                              "label": "Description",
+                                                              "label": "description",
                                                               "transforms": Array [
                                                                 [Function],
                                                                 [Function],
@@ -15930,7 +15930,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             "property": "description",
                                                             "props": Object {
                                                               "data-key": 2,
-                                                              "data-label": "Description",
+                                                              "data-label": "description",
                                                             },
                                                           },
                                                         ]
@@ -16120,7 +16120,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                               </BodyCell>
                                                               <BodyCell
                                                                 data-key={1}
-                                                                data-label="Name"
+                                                                data-label="name"
                                                                 isVisible={true}
                                                                 key="col-1-row-17"
                                                               >
@@ -16128,7 +16128,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                   className=""
                                                                   component="td"
                                                                   data-key={1}
-                                                                  dataLabel="Name"
+                                                                  dataLabel="name"
                                                                   onMouseEnter={[Function]}
                                                                   textCenter={false}
                                                                 >
@@ -16136,7 +16136,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     className=""
                                                                     component="td"
                                                                     data-key={1}
-                                                                    dataLabel="Name"
+                                                                    dataLabel="name"
                                                                     innerRef={null}
                                                                     onMouseEnter={[Function]}
                                                                     textCenter={false}
@@ -16144,7 +16144,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     <td
                                                                       className=""
                                                                       data-key={1}
-                                                                      data-label="Name"
+                                                                      data-label="name"
                                                                       onMouseEnter={[Function]}
                                                                     >
                                                                       address
@@ -16154,7 +16154,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                               </BodyCell>
                                                               <BodyCell
                                                                 data-key={2}
-                                                                data-label="Description"
+                                                                data-label="description"
                                                                 isVisible={true}
                                                                 key="col-2-row-17"
                                                               >
@@ -16162,7 +16162,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                   className=""
                                                                   component="td"
                                                                   data-key={2}
-                                                                  dataLabel="Description"
+                                                                  dataLabel="description"
                                                                   onMouseEnter={[Function]}
                                                                   textCenter={false}
                                                                 >
@@ -16170,7 +16170,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     className=""
                                                                     component="td"
                                                                     data-key={2}
-                                                                    dataLabel="Description"
+                                                                    dataLabel="description"
                                                                     innerRef={null}
                                                                     onMouseEnter={[Function]}
                                                                     textCenter={false}
@@ -16178,7 +16178,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     <td
                                                                       className=""
                                                                       data-key={2}
-                                                                      data-label="Description"
+                                                                      data-label="description"
                                                                       onMouseEnter={[Function]}
                                                                     >
                                                                       Maps user address attributes (street, locality, region, postal_code, and country) to the OpenID Connect 'address' claim.
@@ -16271,7 +16271,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             },
                                                             "header": Object {
                                                               "formatters": Array [],
-                                                              "label": "Name",
+                                                              "label": "name",
                                                               "transforms": Array [
                                                                 [Function],
                                                                 [Function],
@@ -16280,7 +16280,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             "property": "name",
                                                             "props": Object {
                                                               "data-key": 1,
-                                                              "data-label": "Name",
+                                                              "data-label": "name",
                                                             },
                                                           },
                                                           Object {
@@ -16315,7 +16315,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             },
                                                             "header": Object {
                                                               "formatters": Array [],
-                                                              "label": "Description",
+                                                              "label": "description",
                                                               "transforms": Array [
                                                                 [Function],
                                                                 [Function],
@@ -16324,7 +16324,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             "property": "description",
                                                             "props": Object {
                                                               "data-key": 2,
-                                                              "data-label": "Description",
+                                                              "data-label": "description",
                                                             },
                                                           },
                                                         ]
@@ -16508,7 +16508,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                               </BodyCell>
                                                               <BodyCell
                                                                 data-key={1}
-                                                                data-label="Name"
+                                                                data-label="name"
                                                                 isVisible={true}
                                                                 key="col-1-row-18"
                                                               >
@@ -16516,7 +16516,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                   className=""
                                                                   component="td"
                                                                   data-key={1}
-                                                                  dataLabel="Name"
+                                                                  dataLabel="name"
                                                                   onMouseEnter={[Function]}
                                                                   textCenter={false}
                                                                 >
@@ -16524,7 +16524,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     className=""
                                                                     component="td"
                                                                     data-key={1}
-                                                                    dataLabel="Name"
+                                                                    dataLabel="name"
                                                                     innerRef={null}
                                                                     onMouseEnter={[Function]}
                                                                     textCenter={false}
@@ -16532,7 +16532,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     <td
                                                                       className=""
                                                                       data-key={1}
-                                                                      data-label="Name"
+                                                                      data-label="name"
                                                                       onMouseEnter={[Function]}
                                                                     >
                                                                       given name
@@ -16542,7 +16542,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                               </BodyCell>
                                                               <BodyCell
                                                                 data-key={2}
-                                                                data-label="Description"
+                                                                data-label="description"
                                                                 isVisible={true}
                                                                 key="col-2-row-18"
                                                               >
@@ -16550,7 +16550,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                   className=""
                                                                   component="td"
                                                                   data-key={2}
-                                                                  dataLabel="Description"
+                                                                  dataLabel="description"
                                                                   onMouseEnter={[Function]}
                                                                   textCenter={false}
                                                                 >
@@ -16558,7 +16558,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     className=""
                                                                     component="td"
                                                                     data-key={2}
-                                                                    dataLabel="Description"
+                                                                    dataLabel="description"
                                                                     innerRef={null}
                                                                     onMouseEnter={[Function]}
                                                                     textCenter={false}
@@ -16566,7 +16566,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     <td
                                                                       className=""
                                                                       data-key={2}
-                                                                      data-label="Description"
+                                                                      data-label="description"
                                                                       onMouseEnter={[Function]}
                                                                     >
                                                                       Map a built in user property (email, firstName, lastName) to a token claim.
@@ -16659,7 +16659,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             },
                                                             "header": Object {
                                                               "formatters": Array [],
-                                                              "label": "Name",
+                                                              "label": "name",
                                                               "transforms": Array [
                                                                 [Function],
                                                                 [Function],
@@ -16668,7 +16668,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             "property": "name",
                                                             "props": Object {
                                                               "data-key": 1,
-                                                              "data-label": "Name",
+                                                              "data-label": "name",
                                                             },
                                                           },
                                                           Object {
@@ -16703,7 +16703,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             },
                                                             "header": Object {
                                                               "formatters": Array [],
-                                                              "label": "Description",
+                                                              "label": "description",
                                                               "transforms": Array [
                                                                 [Function],
                                                                 [Function],
@@ -16712,7 +16712,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             "property": "description",
                                                             "props": Object {
                                                               "data-key": 2,
-                                                              "data-label": "Description",
+                                                              "data-label": "description",
                                                             },
                                                           },
                                                         ]
@@ -16896,7 +16896,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                               </BodyCell>
                                                               <BodyCell
                                                                 data-key={1}
-                                                                data-label="Name"
+                                                                data-label="name"
                                                                 isVisible={true}
                                                                 key="col-1-row-19"
                                                               >
@@ -16904,7 +16904,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                   className=""
                                                                   component="td"
                                                                   data-key={1}
-                                                                  dataLabel="Name"
+                                                                  dataLabel="name"
                                                                   onMouseEnter={[Function]}
                                                                   textCenter={false}
                                                                 >
@@ -16912,7 +16912,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     className=""
                                                                     component="td"
                                                                     data-key={1}
-                                                                    dataLabel="Name"
+                                                                    dataLabel="name"
                                                                     innerRef={null}
                                                                     onMouseEnter={[Function]}
                                                                     textCenter={false}
@@ -16920,7 +16920,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     <td
                                                                       className=""
                                                                       data-key={1}
-                                                                      data-label="Name"
+                                                                      data-label="name"
                                                                       onMouseEnter={[Function]}
                                                                     >
                                                                       profile
@@ -16930,7 +16930,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                               </BodyCell>
                                                               <BodyCell
                                                                 data-key={2}
-                                                                data-label="Description"
+                                                                data-label="description"
                                                                 isVisible={true}
                                                                 key="col-2-row-19"
                                                               >
@@ -16938,7 +16938,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                   className=""
                                                                   component="td"
                                                                   data-key={2}
-                                                                  dataLabel="Description"
+                                                                  dataLabel="description"
                                                                   onMouseEnter={[Function]}
                                                                   textCenter={false}
                                                                 >
@@ -16946,7 +16946,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     className=""
                                                                     component="td"
                                                                     data-key={2}
-                                                                    dataLabel="Description"
+                                                                    dataLabel="description"
                                                                     innerRef={null}
                                                                     onMouseEnter={[Function]}
                                                                     textCenter={false}
@@ -16954,7 +16954,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     <td
                                                                       className=""
                                                                       data-key={2}
-                                                                      data-label="Description"
+                                                                      data-label="description"
                                                                       onMouseEnter={[Function]}
                                                                     >
                                                                       Map a custom user attribute to a token claim.
@@ -17047,7 +17047,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             },
                                                             "header": Object {
                                                               "formatters": Array [],
-                                                              "label": "Name",
+                                                              "label": "name",
                                                               "transforms": Array [
                                                                 [Function],
                                                                 [Function],
@@ -17056,7 +17056,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             "property": "name",
                                                             "props": Object {
                                                               "data-key": 1,
-                                                              "data-label": "Name",
+                                                              "data-label": "name",
                                                             },
                                                           },
                                                           Object {
@@ -17091,7 +17091,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             },
                                                             "header": Object {
                                                               "formatters": Array [],
-                                                              "label": "Description",
+                                                              "label": "description",
                                                               "transforms": Array [
                                                                 [Function],
                                                                 [Function],
@@ -17100,7 +17100,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             "property": "description",
                                                             "props": Object {
                                                               "data-key": 2,
-                                                              "data-label": "Description",
+                                                              "data-label": "description",
                                                             },
                                                           },
                                                         ]
@@ -17284,7 +17284,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                               </BodyCell>
                                                               <BodyCell
                                                                 data-key={1}
-                                                                data-label="Name"
+                                                                data-label="name"
                                                                 isVisible={true}
                                                                 key="col-1-row-20"
                                                               >
@@ -17292,7 +17292,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                   className=""
                                                                   component="td"
                                                                   data-key={1}
-                                                                  dataLabel="Name"
+                                                                  dataLabel="name"
                                                                   onMouseEnter={[Function]}
                                                                   textCenter={false}
                                                                 >
@@ -17300,7 +17300,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     className=""
                                                                     component="td"
                                                                     data-key={1}
-                                                                    dataLabel="Name"
+                                                                    dataLabel="name"
                                                                     innerRef={null}
                                                                     onMouseEnter={[Function]}
                                                                     textCenter={false}
@@ -17308,7 +17308,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     <td
                                                                       className=""
                                                                       data-key={1}
-                                                                      data-label="Name"
+                                                                      data-label="name"
                                                                       onMouseEnter={[Function]}
                                                                     >
                                                                       groups
@@ -17318,7 +17318,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                               </BodyCell>
                                                               <BodyCell
                                                                 data-key={2}
-                                                                data-label="Description"
+                                                                data-label="description"
                                                                 isVisible={true}
                                                                 key="col-2-row-20"
                                                               >
@@ -17326,7 +17326,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                   className=""
                                                                   component="td"
                                                                   data-key={2}
-                                                                  dataLabel="Description"
+                                                                  dataLabel="description"
                                                                   onMouseEnter={[Function]}
                                                                   textCenter={false}
                                                                 >
@@ -17334,7 +17334,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     className=""
                                                                     component="td"
                                                                     data-key={2}
-                                                                    dataLabel="Description"
+                                                                    dataLabel="description"
                                                                     innerRef={null}
                                                                     onMouseEnter={[Function]}
                                                                     textCenter={false}
@@ -17342,7 +17342,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     <td
                                                                       className=""
                                                                       data-key={2}
-                                                                      data-label="Description"
+                                                                      data-label="description"
                                                                       onMouseEnter={[Function]}
                                                                     >
                                                                       Map a user realm role to a token claim.
@@ -17435,7 +17435,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             },
                                                             "header": Object {
                                                               "formatters": Array [],
-                                                              "label": "Name",
+                                                              "label": "name",
                                                               "transforms": Array [
                                                                 [Function],
                                                                 [Function],
@@ -17444,7 +17444,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             "property": "name",
                                                             "props": Object {
                                                               "data-key": 1,
-                                                              "data-label": "Name",
+                                                              "data-label": "name",
                                                             },
                                                           },
                                                           Object {
@@ -17479,7 +17479,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             },
                                                             "header": Object {
                                                               "formatters": Array [],
-                                                              "label": "Description",
+                                                              "label": "description",
                                                               "transforms": Array [
                                                                 [Function],
                                                                 [Function],
@@ -17488,7 +17488,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             "property": "description",
                                                             "props": Object {
                                                               "data-key": 2,
-                                                              "data-label": "Description",
+                                                              "data-label": "description",
                                                             },
                                                           },
                                                         ]
@@ -17672,7 +17672,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                               </BodyCell>
                                                               <BodyCell
                                                                 data-key={1}
-                                                                data-label="Name"
+                                                                data-label="name"
                                                                 isVisible={true}
                                                                 key="col-1-row-21"
                                                               >
@@ -17680,7 +17680,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                   className=""
                                                                   component="td"
                                                                   data-key={1}
-                                                                  dataLabel="Name"
+                                                                  dataLabel="name"
                                                                   onMouseEnter={[Function]}
                                                                   textCenter={false}
                                                                 >
@@ -17688,7 +17688,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     className=""
                                                                     component="td"
                                                                     data-key={1}
-                                                                    dataLabel="Name"
+                                                                    dataLabel="name"
                                                                     innerRef={null}
                                                                     onMouseEnter={[Function]}
                                                                     textCenter={false}
@@ -17696,7 +17696,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     <td
                                                                       className=""
                                                                       data-key={1}
-                                                                      data-label="Name"
+                                                                      data-label="name"
                                                                       onMouseEnter={[Function]}
                                                                     >
                                                                       phone number
@@ -17706,7 +17706,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                               </BodyCell>
                                                               <BodyCell
                                                                 data-key={2}
-                                                                data-label="Description"
+                                                                data-label="description"
                                                                 isVisible={true}
                                                                 key="col-2-row-21"
                                                               >
@@ -17714,7 +17714,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                   className=""
                                                                   component="td"
                                                                   data-key={2}
-                                                                  dataLabel="Description"
+                                                                  dataLabel="description"
                                                                   onMouseEnter={[Function]}
                                                                   textCenter={false}
                                                                 >
@@ -17722,7 +17722,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     className=""
                                                                     component="td"
                                                                     data-key={2}
-                                                                    dataLabel="Description"
+                                                                    dataLabel="description"
                                                                     innerRef={null}
                                                                     onMouseEnter={[Function]}
                                                                     textCenter={false}
@@ -17730,7 +17730,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     <td
                                                                       className=""
                                                                       data-key={2}
-                                                                      data-label="Description"
+                                                                      data-label="description"
                                                                       onMouseEnter={[Function]}
                                                                     >
                                                                       Map a custom user attribute to a token claim.
@@ -17823,7 +17823,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             },
                                                             "header": Object {
                                                               "formatters": Array [],
-                                                              "label": "Name",
+                                                              "label": "name",
                                                               "transforms": Array [
                                                                 [Function],
                                                                 [Function],
@@ -17832,7 +17832,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             "property": "name",
                                                             "props": Object {
                                                               "data-key": 1,
-                                                              "data-label": "Name",
+                                                              "data-label": "name",
                                                             },
                                                           },
                                                           Object {
@@ -17867,7 +17867,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             },
                                                             "header": Object {
                                                               "formatters": Array [],
-                                                              "label": "Description",
+                                                              "label": "description",
                                                               "transforms": Array [
                                                                 [Function],
                                                                 [Function],
@@ -17876,7 +17876,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             "property": "description",
                                                             "props": Object {
                                                               "data-key": 2,
-                                                              "data-label": "Description",
+                                                              "data-label": "description",
                                                             },
                                                           },
                                                         ]
@@ -18054,7 +18054,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                               </BodyCell>
                                                               <BodyCell
                                                                 data-key={1}
-                                                                data-label="Name"
+                                                                data-label="name"
                                                                 isVisible={true}
                                                                 key="col-1-row-22"
                                                               >
@@ -18062,7 +18062,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                   className=""
                                                                   component="td"
                                                                   data-key={1}
-                                                                  dataLabel="Name"
+                                                                  dataLabel="name"
                                                                   onMouseEnter={[Function]}
                                                                   textCenter={false}
                                                                 >
@@ -18070,7 +18070,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     className=""
                                                                     component="td"
                                                                     data-key={1}
-                                                                    dataLabel="Name"
+                                                                    dataLabel="name"
                                                                     innerRef={null}
                                                                     onMouseEnter={[Function]}
                                                                     textCenter={false}
@@ -18078,7 +18078,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     <td
                                                                       className=""
                                                                       data-key={1}
-                                                                      data-label="Name"
+                                                                      data-label="name"
                                                                       onMouseEnter={[Function]}
                                                                     >
                                                                       full name
@@ -18088,7 +18088,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                               </BodyCell>
                                                               <BodyCell
                                                                 data-key={2}
-                                                                data-label="Description"
+                                                                data-label="description"
                                                                 isVisible={true}
                                                                 key="col-2-row-22"
                                                               >
@@ -18096,7 +18096,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                   className=""
                                                                   component="td"
                                                                   data-key={2}
-                                                                  dataLabel="Description"
+                                                                  dataLabel="description"
                                                                   onMouseEnter={[Function]}
                                                                   textCenter={false}
                                                                 >
@@ -18104,7 +18104,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     className=""
                                                                     component="td"
                                                                     data-key={2}
-                                                                    dataLabel="Description"
+                                                                    dataLabel="description"
                                                                     innerRef={null}
                                                                     onMouseEnter={[Function]}
                                                                     textCenter={false}
@@ -18112,7 +18112,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     <td
                                                                       className=""
                                                                       data-key={2}
-                                                                      data-label="Description"
+                                                                      data-label="description"
                                                                       onMouseEnter={[Function]}
                                                                     >
                                                                       Maps the user's first and last name to the OpenID Connect 'name' claim. Format is &lt;first&gt; + ' ' + &lt;last&gt;
@@ -18205,7 +18205,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             },
                                                             "header": Object {
                                                               "formatters": Array [],
-                                                              "label": "Name",
+                                                              "label": "name",
                                                               "transforms": Array [
                                                                 [Function],
                                                                 [Function],
@@ -18214,7 +18214,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             "property": "name",
                                                             "props": Object {
                                                               "data-key": 1,
-                                                              "data-label": "Name",
+                                                              "data-label": "name",
                                                             },
                                                           },
                                                           Object {
@@ -18249,7 +18249,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             },
                                                             "header": Object {
                                                               "formatters": Array [],
-                                                              "label": "Description",
+                                                              "label": "description",
                                                               "transforms": Array [
                                                                 [Function],
                                                                 [Function],
@@ -18258,7 +18258,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             "property": "description",
                                                             "props": Object {
                                                               "data-key": 2,
-                                                              "data-label": "Description",
+                                                              "data-label": "description",
                                                             },
                                                           },
                                                         ]
@@ -18432,7 +18432,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                               </BodyCell>
                                                               <BodyCell
                                                                 data-key={1}
-                                                                data-label="Name"
+                                                                data-label="name"
                                                                 isVisible={true}
                                                                 key="col-1-row-23"
                                                               >
@@ -18440,7 +18440,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                   className=""
                                                                   component="td"
                                                                   data-key={1}
-                                                                  dataLabel="Name"
+                                                                  dataLabel="name"
                                                                   onMouseEnter={[Function]}
                                                                   textCenter={false}
                                                                 >
@@ -18448,7 +18448,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     className=""
                                                                     component="td"
                                                                     data-key={1}
-                                                                    dataLabel="Name"
+                                                                    dataLabel="name"
                                                                     innerRef={null}
                                                                     onMouseEnter={[Function]}
                                                                     textCenter={false}
@@ -18456,7 +18456,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     <td
                                                                       className=""
                                                                       data-key={1}
-                                                                      data-label="Name"
+                                                                      data-label="name"
                                                                       onMouseEnter={[Function]}
                                                                     >
                                                                       audience resolve
@@ -18466,7 +18466,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                               </BodyCell>
                                                               <BodyCell
                                                                 data-key={2}
-                                                                data-label="Description"
+                                                                data-label="description"
                                                                 isVisible={true}
                                                                 key="col-2-row-23"
                                                               >
@@ -18474,7 +18474,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                   className=""
                                                                   component="td"
                                                                   data-key={2}
-                                                                  dataLabel="Description"
+                                                                  dataLabel="description"
                                                                   onMouseEnter={[Function]}
                                                                   textCenter={false}
                                                                 >
@@ -18482,7 +18482,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     className=""
                                                                     component="td"
                                                                     data-key={2}
-                                                                    dataLabel="Description"
+                                                                    dataLabel="description"
                                                                     innerRef={null}
                                                                     onMouseEnter={[Function]}
                                                                     textCenter={false}
@@ -18490,7 +18490,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     <td
                                                                       className=""
                                                                       data-key={2}
-                                                                      data-label="Description"
+                                                                      data-label="description"
                                                                       onMouseEnter={[Function]}
                                                                     >
                                                                       Adds all client_ids of "allowed" clients to the audience field of the token. Allowed client means the client
@@ -18584,7 +18584,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             },
                                                             "header": Object {
                                                               "formatters": Array [],
-                                                              "label": "Name",
+                                                              "label": "name",
                                                               "transforms": Array [
                                                                 [Function],
                                                                 [Function],
@@ -18593,7 +18593,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             "property": "name",
                                                             "props": Object {
                                                               "data-key": 1,
-                                                              "data-label": "Name",
+                                                              "data-label": "name",
                                                             },
                                                           },
                                                           Object {
@@ -18628,7 +18628,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             },
                                                             "header": Object {
                                                               "formatters": Array [],
-                                                              "label": "Description",
+                                                              "label": "description",
                                                               "transforms": Array [
                                                                 [Function],
                                                                 [Function],
@@ -18637,7 +18637,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             "property": "description",
                                                             "props": Object {
                                                               "data-key": 2,
-                                                              "data-label": "Description",
+                                                              "data-label": "description",
                                                             },
                                                           },
                                                         ]
@@ -18821,7 +18821,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                               </BodyCell>
                                                               <BodyCell
                                                                 data-key={1}
-                                                                data-label="Name"
+                                                                data-label="name"
                                                                 isVisible={true}
                                                                 key="col-1-row-24"
                                                               >
@@ -18829,7 +18829,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                   className=""
                                                                   component="td"
                                                                   data-key={1}
-                                                                  dataLabel="Name"
+                                                                  dataLabel="name"
                                                                   onMouseEnter={[Function]}
                                                                   textCenter={false}
                                                                 >
@@ -18837,7 +18837,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     className=""
                                                                     component="td"
                                                                     data-key={1}
-                                                                    dataLabel="Name"
+                                                                    dataLabel="name"
                                                                     innerRef={null}
                                                                     onMouseEnter={[Function]}
                                                                     textCenter={false}
@@ -18845,7 +18845,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     <td
                                                                       className=""
                                                                       data-key={1}
-                                                                      data-label="Name"
+                                                                      data-label="name"
                                                                       onMouseEnter={[Function]}
                                                                     >
                                                                       picture
@@ -18855,7 +18855,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                               </BodyCell>
                                                               <BodyCell
                                                                 data-key={2}
-                                                                data-label="Description"
+                                                                data-label="description"
                                                                 isVisible={true}
                                                                 key="col-2-row-24"
                                                               >
@@ -18863,7 +18863,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                   className=""
                                                                   component="td"
                                                                   data-key={2}
-                                                                  dataLabel="Description"
+                                                                  dataLabel="description"
                                                                   onMouseEnter={[Function]}
                                                                   textCenter={false}
                                                                 >
@@ -18871,7 +18871,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     className=""
                                                                     component="td"
                                                                     data-key={2}
-                                                                    dataLabel="Description"
+                                                                    dataLabel="description"
                                                                     innerRef={null}
                                                                     onMouseEnter={[Function]}
                                                                     textCenter={false}
@@ -18879,7 +18879,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     <td
                                                                       className=""
                                                                       data-key={2}
-                                                                      data-label="Description"
+                                                                      data-label="description"
                                                                       onMouseEnter={[Function]}
                                                                     >
                                                                       Map a custom user attribute to a token claim.
@@ -18972,7 +18972,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             },
                                                             "header": Object {
                                                               "formatters": Array [],
-                                                              "label": "Name",
+                                                              "label": "name",
                                                               "transforms": Array [
                                                                 [Function],
                                                                 [Function],
@@ -18981,7 +18981,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             "property": "name",
                                                             "props": Object {
                                                               "data-key": 1,
-                                                              "data-label": "Name",
+                                                              "data-label": "name",
                                                             },
                                                           },
                                                           Object {
@@ -19016,7 +19016,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             },
                                                             "header": Object {
                                                               "formatters": Array [],
-                                                              "label": "Description",
+                                                              "label": "description",
                                                               "transforms": Array [
                                                                 [Function],
                                                                 [Function],
@@ -19025,7 +19025,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             "property": "description",
                                                             "props": Object {
                                                               "data-key": 2,
-                                                              "data-label": "Description",
+                                                              "data-label": "description",
                                                             },
                                                           },
                                                         ]
@@ -19209,7 +19209,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                               </BodyCell>
                                                               <BodyCell
                                                                 data-key={1}
-                                                                data-label="Name"
+                                                                data-label="name"
                                                                 isVisible={true}
                                                                 key="col-1-row-25"
                                                               >
@@ -19217,7 +19217,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                   className=""
                                                                   component="td"
                                                                   data-key={1}
-                                                                  dataLabel="Name"
+                                                                  dataLabel="name"
                                                                   onMouseEnter={[Function]}
                                                                   textCenter={false}
                                                                 >
@@ -19225,7 +19225,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     className=""
                                                                     component="td"
                                                                     data-key={1}
-                                                                    dataLabel="Name"
+                                                                    dataLabel="name"
                                                                     innerRef={null}
                                                                     onMouseEnter={[Function]}
                                                                     textCenter={false}
@@ -19233,7 +19233,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     <td
                                                                       className=""
                                                                       data-key={1}
-                                                                      data-label="Name"
+                                                                      data-label="name"
                                                                       onMouseEnter={[Function]}
                                                                     >
                                                                       upn
@@ -19243,7 +19243,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                               </BodyCell>
                                                               <BodyCell
                                                                 data-key={2}
-                                                                data-label="Description"
+                                                                data-label="description"
                                                                 isVisible={true}
                                                                 key="col-2-row-25"
                                                               >
@@ -19251,7 +19251,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                   className=""
                                                                   component="td"
                                                                   data-key={2}
-                                                                  dataLabel="Description"
+                                                                  dataLabel="description"
                                                                   onMouseEnter={[Function]}
                                                                   textCenter={false}
                                                                 >
@@ -19259,7 +19259,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     className=""
                                                                     component="td"
                                                                     data-key={2}
-                                                                    dataLabel="Description"
+                                                                    dataLabel="description"
                                                                     innerRef={null}
                                                                     onMouseEnter={[Function]}
                                                                     textCenter={false}
@@ -19267,7 +19267,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     <td
                                                                       className=""
                                                                       data-key={2}
-                                                                      data-label="Description"
+                                                                      data-label="description"
                                                                       onMouseEnter={[Function]}
                                                                     >
                                                                       Map a built in user property (email, firstName, lastName) to a token claim.
@@ -19360,7 +19360,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             },
                                                             "header": Object {
                                                               "formatters": Array [],
-                                                              "label": "Name",
+                                                              "label": "name",
                                                               "transforms": Array [
                                                                 [Function],
                                                                 [Function],
@@ -19369,7 +19369,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             "property": "name",
                                                             "props": Object {
                                                               "data-key": 1,
-                                                              "data-label": "Name",
+                                                              "data-label": "name",
                                                             },
                                                           },
                                                           Object {
@@ -19404,7 +19404,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             },
                                                             "header": Object {
                                                               "formatters": Array [],
-                                                              "label": "Description",
+                                                              "label": "description",
                                                               "transforms": Array [
                                                                 [Function],
                                                                 [Function],
@@ -19413,7 +19413,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             "property": "description",
                                                             "props": Object {
                                                               "data-key": 2,
-                                                              "data-label": "Description",
+                                                              "data-label": "description",
                                                             },
                                                           },
                                                         ]
@@ -19595,7 +19595,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                               </BodyCell>
                                                               <BodyCell
                                                                 data-key={1}
-                                                                data-label="Name"
+                                                                data-label="name"
                                                                 isVisible={true}
                                                                 key="col-1-row-26"
                                                               >
@@ -19603,7 +19603,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                   className=""
                                                                   component="td"
                                                                   data-key={1}
-                                                                  dataLabel="Name"
+                                                                  dataLabel="name"
                                                                   onMouseEnter={[Function]}
                                                                   textCenter={false}
                                                                 >
@@ -19611,7 +19611,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     className=""
                                                                     component="td"
                                                                     data-key={1}
-                                                                    dataLabel="Name"
+                                                                    dataLabel="name"
                                                                     innerRef={null}
                                                                     onMouseEnter={[Function]}
                                                                     textCenter={false}
@@ -19619,7 +19619,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     <td
                                                                       className=""
                                                                       data-key={1}
-                                                                      data-label="Name"
+                                                                      data-label="name"
                                                                       onMouseEnter={[Function]}
                                                                     >
                                                                       realm roles
@@ -19629,7 +19629,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                               </BodyCell>
                                                               <BodyCell
                                                                 data-key={2}
-                                                                data-label="Description"
+                                                                data-label="description"
                                                                 isVisible={true}
                                                                 key="col-2-row-26"
                                                               >
@@ -19637,7 +19637,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                   className=""
                                                                   component="td"
                                                                   data-key={2}
-                                                                  dataLabel="Description"
+                                                                  dataLabel="description"
                                                                   onMouseEnter={[Function]}
                                                                   textCenter={false}
                                                                 >
@@ -19645,7 +19645,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     className=""
                                                                     component="td"
                                                                     data-key={2}
-                                                                    dataLabel="Description"
+                                                                    dataLabel="description"
                                                                     innerRef={null}
                                                                     onMouseEnter={[Function]}
                                                                     textCenter={false}
@@ -19653,7 +19653,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     <td
                                                                       className=""
                                                                       data-key={2}
-                                                                      data-label="Description"
+                                                                      data-label="description"
                                                                       onMouseEnter={[Function]}
                                                                     >
                                                                       Map a user realm role to a token claim.
@@ -19746,7 +19746,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             },
                                                             "header": Object {
                                                               "formatters": Array [],
-                                                              "label": "Name",
+                                                              "label": "name",
                                                               "transforms": Array [
                                                                 [Function],
                                                                 [Function],
@@ -19755,7 +19755,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             "property": "name",
                                                             "props": Object {
                                                               "data-key": 1,
-                                                              "data-label": "Name",
+                                                              "data-label": "name",
                                                             },
                                                           },
                                                           Object {
@@ -19790,7 +19790,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             },
                                                             "header": Object {
                                                               "formatters": Array [],
-                                                              "label": "Description",
+                                                              "label": "description",
                                                               "transforms": Array [
                                                                 [Function],
                                                                 [Function],
@@ -19799,7 +19799,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                             "property": "description",
                                                             "props": Object {
                                                               "data-key": 2,
-                                                              "data-label": "Description",
+                                                              "data-label": "description",
                                                             },
                                                           },
                                                         ]
@@ -19983,7 +19983,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                               </BodyCell>
                                                               <BodyCell
                                                                 data-key={1}
-                                                                data-label="Name"
+                                                                data-label="name"
                                                                 isVisible={true}
                                                                 key="col-1-row-27"
                                                               >
@@ -19991,7 +19991,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                   className=""
                                                                   component="td"
                                                                   data-key={1}
-                                                                  dataLabel="Name"
+                                                                  dataLabel="name"
                                                                   onMouseEnter={[Function]}
                                                                   textCenter={false}
                                                                 >
@@ -19999,7 +19999,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     className=""
                                                                     component="td"
                                                                     data-key={1}
-                                                                    dataLabel="Name"
+                                                                    dataLabel="name"
                                                                     innerRef={null}
                                                                     onMouseEnter={[Function]}
                                                                     textCenter={false}
@@ -20007,7 +20007,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     <td
                                                                       className=""
                                                                       data-key={1}
-                                                                      data-label="Name"
+                                                                      data-label="name"
                                                                       onMouseEnter={[Function]}
                                                                     >
                                                                       username
@@ -20017,7 +20017,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                               </BodyCell>
                                                               <BodyCell
                                                                 data-key={2}
-                                                                data-label="Description"
+                                                                data-label="description"
                                                                 isVisible={true}
                                                                 key="col-2-row-27"
                                                               >
@@ -20025,7 +20025,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                   className=""
                                                                   component="td"
                                                                   data-key={2}
-                                                                  dataLabel="Description"
+                                                                  dataLabel="description"
                                                                   onMouseEnter={[Function]}
                                                                   textCenter={false}
                                                                 >
@@ -20033,7 +20033,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     className=""
                                                                     component="td"
                                                                     data-key={2}
-                                                                    dataLabel="Description"
+                                                                    dataLabel="description"
                                                                     innerRef={null}
                                                                     onMouseEnter={[Function]}
                                                                     textCenter={false}
@@ -20041,7 +20041,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                                                                     <td
                                                                       className=""
                                                                       data-key={2}
-                                                                      data-label="Description"
+                                                                      data-label="description"
                                                                       onMouseEnter={[Function]}
                                                                     >
                                                                       Map a built in user property (email, firstName, lastName) to a token claim.
@@ -20093,7 +20093,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                               tabIndex={null}
                               type="button"
                             >
-                              Add
+                              add
                             </button>
                           </Button>
                           <Button
@@ -20115,7 +20115,7 @@ exports[`<MapperDialog/> should have disabled add button when nothing is selecte
                               role={null}
                               type="button"
                             >
-                              Cancel
+                              cancel
                             </button>
                           </Button>
                         </footer>
@@ -20176,7 +20176,7 @@ exports[`<MapperDialog/> should return selected protocol mapping type on click 1
       onClose={[Function]}
       ouiaSafe={true}
       showClose={true}
-      title="Choose a mapper type"
+      title="chooseAMapperType"
       titleIconVariant={null}
       titleLabel=""
       variant="medium"
@@ -20235,7 +20235,7 @@ exports[`<MapperDialog/> should return selected protocol mapping type on click 1
                       <span
                         class="pf-c-modal-box__title-text"
                       >
-                        Choose a mapper type
+                        chooseAMapperType
                       </span>
                     </h1>
                   </header>
@@ -20250,11 +20250,11 @@ exports[`<MapperDialog/> should return selected protocol mapping type on click 1
                         class=""
                         data-pf-content="true"
                       >
-                        Choose one of the predefined mappings from this table
+                        predefinedMappingDescription
                       </p>
                     </div>
                     <ul
-                      aria-label="Choose a mapper type"
+                      aria-label="chooseAMapperType"
                       class="pf-c-data-list pf-m-compact pf-m-grid-md"
                     >
                       <li
@@ -20656,7 +20656,7 @@ exports[`<MapperDialog/> should return selected protocol mapping type on click 1
           ouiaId="OUIA-Generated-Modal-medium-3"
           ouiaSafe={true}
           showClose={true}
-          title="Choose a mapper type"
+          title="chooseAMapperType"
           titleIconVariant={null}
           titleLabel=""
           variant="medium"
@@ -20759,7 +20759,7 @@ exports[`<MapperDialog/> should return selected protocol mapping type on click 1
                         >
                           <ModalBoxTitle
                             id="pf-modal-part-3"
-                            title="Choose a mapper type"
+                            title="chooseAMapperType"
                             titleIconVariant={null}
                             titleLabel=""
                           >
@@ -20770,7 +20770,7 @@ exports[`<MapperDialog/> should return selected protocol mapping type on click 1
                               <span
                                 className="pf-c-modal-box__title-text"
                               >
-                                Choose a mapper type
+                                chooseAMapperType
                               </span>
                             </h1>
                           </ModalBoxTitle>
@@ -20792,13 +20792,13 @@ exports[`<MapperDialog/> should return selected protocol mapping type on click 1
                                   className=""
                                   data-pf-content={true}
                                 >
-                                  Choose one of the predefined mappings from this table
+                                  predefinedMappingDescription
                                 </p>
                               </Text>
                             </div>
                           </TextContent>
                           <DataList
-                            aria-label="Choose a mapper type"
+                            aria-label="chooseAMapperType"
                             className=""
                             gridBreakpoint="md"
                             isCompact={true}
@@ -20807,7 +20807,7 @@ exports[`<MapperDialog/> should return selected protocol mapping type on click 1
                             wrapModifier={null}
                           >
                             <ul
-                              aria-label="Choose a mapper type"
+                              aria-label="chooseAMapperType"
                               className="pf-c-data-list pf-m-compact pf-m-grid-md"
                               style={Object {}}
                             >

--- a/src/client-scopes/details/MapperList.tsx
+++ b/src/client-scopes/details/MapperList.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Link, useHistory } from "react-router-dom";
+import { Link, useHistory, useRouteMatch } from "react-router-dom";
 import {
   AlertVariant,
   ButtonVariant,
@@ -44,6 +44,7 @@ export const MapperList = ({ clientScope, refresh }: MapperListProps) => {
   const adminClient = useAdminClient();
   const { addAlert } = useAlerts();
   const history = useHistory();
+  const { url } = useRouteMatch();
 
   const [filteredData, setFilteredData] = useState<
     { mapper: ProtocolMapperRepresentation; cells: Row }[]
@@ -70,7 +71,7 @@ export const MapperList = ({ clientScope, refresh }: MapperListProps) => {
   ): Promise<void> => {
     if (filter === undefined) {
       const mapper = mappers as ProtocolMapperTypeRepresentation;
-      history.push(`/client-scopes/${clientScope.id}/${mapper.id}`);
+      history.push(`${url}/${mapper.id}`);
     } else {
       try {
         await adminClient.clientScopes.addMultipleProtocolMappers(
@@ -122,7 +123,7 @@ export const MapperList = ({ clientScope, refresh }: MapperListProps) => {
         cells: {
           name: (
             <>
-              <Link to={`/client-scopes/${clientScope.id}/${mapper.id}`}>
+              <Link to={`${url}/${clientScope.id}/${mapper.id}`}>
                 {mapper.name}
               </Link>
             </>

--- a/src/client-scopes/details/MappingDetails.tsx
+++ b/src/client-scopes/details/MappingDetails.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { useHistory, useParams } from "react-router-dom";
+import { useHistory, useParams, useRouteMatch } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import {
   ActionGroup,
@@ -52,6 +52,7 @@ export const MappingDetails = () => {
 
   const history = useHistory();
   const serverInfo = useServerInfo();
+  const { url } = useRouteMatch();
   const isGuid = /^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$/;
 
   useEffect(() => {
@@ -94,7 +95,7 @@ export const MappingDetails = () => {
           []
         );
         addAlert(t("mappingDeletedSuccess"), AlertVariant.success);
-        history.push(`/client-scopes/${scopeId}`);
+        history.push(`${url}/${scopeId}`);
       } catch (error) {
         addAlert(t("mappingDeletedError", { error }), AlertVariant.danger);
       }

--- a/src/client-scopes/form/ClientScopeForm.tsx
+++ b/src/client-scopes/form/ClientScopeForm.tsx
@@ -303,7 +303,11 @@ export const ClientScopeForm = () => {
               </ActionGroup>
             </Form>
           </Tab>
-          <Tab eventKey={1} title={<TabTitleText>{t("mappers")}</TabTitleText>}>
+          <Tab
+            isHidden={!id}
+            eventKey={1}
+            title={<TabTitleText>{t("mappers")}</TabTitleText>}
+          >
             {clientScope && (
               <MapperList clientScope={clientScope} refresh={load} />
             )}

--- a/src/clients/ClientsSection.tsx
+++ b/src/clients/ClientsSection.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Link, useHistory } from "react-router-dom";
+import { Link, useHistory, useRouteMatch } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import {
   AlertVariant,
@@ -21,6 +21,7 @@ export const ClientsSection = () => {
   const { t } = useTranslation("clients");
   const { addAlert } = useAlerts();
   const history = useHistory();
+  const { url } = useRouteMatch();
 
   const adminClient = useAdminClient();
   const baseUrl = adminClient.keycloak
@@ -51,7 +52,7 @@ export const ClientsSection = () => {
 
   const ClientDetailLink = (client: ClientRepresentation) => (
     <>
-      <Link key={client.id} to={`/clients/${client.id}`}>
+      <Link key={client.id} to={`${url}/${client.id}`}>
         {client.clientId}
         {!client.enabled && <Badge isRead>Disabled</Badge>}
       </Link>
@@ -71,11 +72,11 @@ export const ClientsSection = () => {
           searchPlaceholderKey="clients:searchForClient"
           toolbarItem={
             <>
-              <Button onClick={() => history.push("/add-client")}>
+              <Button onClick={() => history.push(`${url}/add-client`)}>
                 {t("createClient")}
               </Button>
               <Button
-                onClick={() => history.push("/import-client")}
+                onClick={() => history.push(`${url}/import-client`)}
                 variant="link"
               >
                 {t("importClient")}

--- a/src/clients/add/NewClientForm.tsx
+++ b/src/clients/add/NewClientForm.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { useHistory } from "react-router-dom";
+import { useHistory, useRouteMatch } from "react-router-dom";
 import {
   PageSection,
   Wizard,
@@ -89,6 +89,7 @@ export const NewClientForm = () => {
   );
 
   const title = t("createClient");
+  const { url } = useRouteMatch();
   return (
     <>
       <ViewHeader
@@ -97,7 +98,7 @@ export const NewClientForm = () => {
       />
       <PageSection variant="light">
         <Wizard
-          onClose={() => history.push("/clients")}
+          onClose={() => history.push(`${url}/clients`)}
           navAriaLabel={`${title} steps`}
           mainAriaLabel={`${title} content`}
           steps={[

--- a/src/components/bread-crumb/PageBreadCrumbs.tsx
+++ b/src/components/bread-crumb/PageBreadCrumbs.tsx
@@ -4,11 +4,15 @@ import useBreadcrumbs from "use-react-router-breadcrumbs";
 import { useTranslation } from "react-i18next";
 import { Breadcrumb, BreadcrumbItem } from "@patternfly/react-core";
 
+import { useRealm } from "../../context/realm-context/RealmContext";
 import { routes } from "../../route-config";
 
 export const PageBreadCrumbs = () => {
   const { t } = useTranslation();
-  const crumbs = useBreadcrumbs(routes(t), { excludePaths: ["/"] });
+  const { realm } = useRealm();
+  const crumbs = useBreadcrumbs(routes(t), {
+    excludePaths: ["/", `/${realm}`],
+  });
   return (
     <>
       {crumbs.length > 1 && (

--- a/src/components/bread-crumb/__tests__/PageBreadCrumbs.test.tsx
+++ b/src/components/bread-crumb/__tests__/PageBreadCrumbs.test.tsx
@@ -6,7 +6,7 @@ import { MemoryRouter } from "react-router-dom";
 describe("BreadCrumbs tests", () => {
   it("couple of crumbs", () => {
     const crumbs = mount(
-      <MemoryRouter initialEntries={["/clients/1234"]}>
+      <MemoryRouter initialEntries={["/master/clients/1234"]}>
         <PageBreadCrumbs />
       </MemoryRouter>
     );

--- a/src/components/bread-crumb/__tests__/__snapshots__/PageBreadCrumbs.test.tsx.snap
+++ b/src/components/bread-crumb/__tests__/__snapshots__/PageBreadCrumbs.test.tsx.snap
@@ -22,20 +22,20 @@ exports[`BreadCrumbs tests couple of crumbs 1`] = `
             className="pf-c-breadcrumb__item"
           >
             <Link
-              to="/clients"
+              to="/master"
             >
               <LinkAnchor
-                href="/clients"
+                href="/master"
                 navigate={[Function]}
               >
                 <a
-                  href="/clients"
+                  href="/master"
                   onClick={[Function]}
                 >
                   <span
-                    key="/clients"
+                    key="/master"
                   >
-                    Clients
+                    Home
                   </span>
                 </a>
               </LinkAnchor>
@@ -43,7 +43,7 @@ exports[`BreadCrumbs tests couple of crumbs 1`] = `
           </li>
         </BreadcrumbItem>
         <BreadcrumbItem
-          isActive={true}
+          isActive={false}
           key=".$1"
           showDivider={true}
         >
@@ -78,8 +78,65 @@ exports[`BreadCrumbs tests couple of crumbs 1`] = `
                 </svg>
               </AngleRightIcon>
             </span>
+            <Link
+              to="/master/clients"
+            >
+              <LinkAnchor
+                href="/master/clients"
+                navigate={[Function]}
+              >
+                <a
+                  href="/master/clients"
+                  onClick={[Function]}
+                >
+                  <span
+                    key="/master/clients"
+                  >
+                    Clients
+                  </span>
+                </a>
+              </LinkAnchor>
+            </Link>
+          </li>
+        </BreadcrumbItem>
+        <BreadcrumbItem
+          isActive={true}
+          key=".$2"
+          showDivider={true}
+        >
+          <li
+            className="pf-c-breadcrumb__item"
+          >
             <span
-              key="/clients/1234"
+              className="pf-c-breadcrumb__item-divider"
+            >
+              <AngleRightIcon
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
+              >
+                <svg
+                  aria-hidden={true}
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 256 512"
+                  width="1em"
+                >
+                  <path
+                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                  />
+                </svg>
+              </AngleRightIcon>
+            </span>
+            <span
+              key="/master/clients/1234"
             >
               Client details
             </span>

--- a/src/components/keycloak-card/KeycloakCard.tsx
+++ b/src/components/keycloak-card/KeycloakCard.tsx
@@ -13,7 +13,7 @@ import {
   FlexItem,
 } from "@patternfly/react-core";
 import "./keycloak-card.css";
-import { useHistory } from "react-router-dom";
+import { useHistory, useRouteMatch } from "react-router-dom";
 
 export type KeycloakCardProps = {
   id: string;
@@ -38,6 +38,7 @@ export const KeycloakCard = ({
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
   const history = useHistory();
+  const { url } = useRouteMatch();
 
   const onDropdownToggle = () => {
     setIsDropdownOpen(!isDropdownOpen);
@@ -48,11 +49,7 @@ export const KeycloakCard = ({
   };
 
   const openSettings = () => {
-    if (providerId === "kerberos") {
-      history.push(`/user-federation/Kerberos/${id}`);
-    } else {
-      history.push(`/user-federation/LDAP/${id}`);
-    }
+    history.push(`${url}/${providerId}/${id}`);
   };
 
   return (

--- a/src/components/realm-selector/RealmSelector.tsx
+++ b/src/components/realm-selector/RealmSelector.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useContext, useEffect } from "react";
-import { useHistory, useParams } from "react-router-dom";
+import { useHistory, useParams, useRouteMatch } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 
 import {
@@ -33,11 +33,7 @@ export const RealmSelector = ({ realmList }: RealmSelectorProps) => {
   const [filteredItems, setFilteredItems] = useState(realmList);
   const history = useHistory();
   const { t } = useTranslation("common");
-
-  const params = useParams<{ realm: string }>();
-  useEffect(() => {
-    setRealm(params.realm);
-  }, []);
+  const { url } = useRouteMatch();
 
   const toUpperCase = (realmName: string) =>
     realmName.charAt(0).toUpperCase() + realmName.slice(1);
@@ -53,7 +49,7 @@ export const RealmSelector = ({ realmList }: RealmSelectorProps) => {
     <Button
       component="div"
       isBlock
-      onClick={() => history.push("/add-realm")}
+      onClick={() => history.push(`${url}/add-realm"`)}
       className={className}
     >
       {t("createRealm")}

--- a/src/components/realm-selector/RealmSelector.tsx
+++ b/src/components/realm-selector/RealmSelector.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useContext, useEffect } from "react";
-import { useHistory } from "react-router-dom";
+import { useHistory, useParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 
 import {
@@ -16,7 +16,7 @@ import {
 import { CheckIcon } from "@patternfly/react-icons";
 
 import RealmRepresentation from "keycloak-admin/lib/defs/realmRepresentation";
-import { RealmContext } from "../../context/realm-context/RealmContext";
+import { useRealm } from "../../context/realm-context/RealmContext";
 import { WhoAmIContext } from "../../context/whoami/WhoAmI";
 
 import "./realm-selector.css";
@@ -26,13 +26,18 @@ type RealmSelectorProps = {
 };
 
 export const RealmSelector = ({ realmList }: RealmSelectorProps) => {
-  const { realm, setRealm } = useContext(RealmContext);
+  const { realm, setRealm } = useRealm();
   const whoami = useContext(WhoAmIContext);
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
   const [filteredItems, setFilteredItems] = useState(realmList);
   const history = useHistory();
   const { t } = useTranslation("common");
+
+  const params = useParams<{ realm: string }>();
+  useEffect(() => {
+    setRealm(params.realm);
+  }, []);
 
   const toUpperCase = (realmName: string) =>
     realmName.charAt(0).toUpperCase() + realmName.slice(1);
@@ -74,6 +79,7 @@ export const RealmSelector = ({ realmList }: RealmSelectorProps) => {
       key={`realm-dropdown-item-${r.realm}`}
       onClick={() => {
         setRealm(r.realm!);
+        history.push(`/${r.realm}`);
         setOpen(!open);
       }}
     >

--- a/src/components/realm-selector/RealmSelector.tsx
+++ b/src/components/realm-selector/RealmSelector.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useContext, useEffect } from "react";
-import { useHistory, useParams, useRouteMatch } from "react-router-dom";
+import { useHistory, useRouteMatch } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 
 import {

--- a/src/components/realm-selector/__tests__/RealmSelector.test.tsx
+++ b/src/components/realm-selector/__tests__/RealmSelector.test.tsx
@@ -4,20 +4,23 @@ import { act } from "@testing-library/react";
 
 import { RealmSelector } from "../RealmSelector";
 import { RealmContextProvider } from "../../../context/realm-context/RealmContext";
+import { MemoryRouter } from "react-router-dom";
 
 it("renders realm selector", async () => {
   const wrapper = mount(
-    <RealmContextProvider>
-      <RealmSelector realmList={[{ id: "321", realm: "another" }]} />
-    </RealmContextProvider>
+    <MemoryRouter>
+      <RealmContextProvider>
+        <div id="realm">
+          <RealmSelector realmList={[{ id: "321", realm: "another" }]} />
+        </div>
+      </RealmContextProvider>
+    </MemoryRouter>
   );
-
-  expect(wrapper.text()).toBe("Master");
 
   const expandButton = wrapper.find("button");
   act(() => {
     expandButton!.simulate("click");
   });
 
-  expect(wrapper).toMatchSnapshot();
+  expect(wrapper.find("#realm")).toMatchSnapshot();
 });

--- a/src/components/realm-selector/__tests__/__snapshots__/RealmSelector.test.tsx.snap
+++ b/src/components/realm-selector/__tests__/__snapshots__/RealmSelector.test.tsx.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders realm selector 1`] = `
-<RealmContextProvider>
+<div
+  id="realm"
+>
   <RealmSelector
     realmList={
       Array [
@@ -34,7 +36,7 @@ exports[`renders realm selector 1`] = `
           id="realm-select-toggle"
           onToggle={[Function]}
         >
-          Master
+          
         </DropdownToggle>
       }
     >
@@ -67,7 +69,7 @@ exports[`renders realm selector 1`] = `
             id="realm-select-toggle"
             onToggle={[Function]}
           >
-            Master
+            
           </DropdownToggle>
         }
       >
@@ -107,11 +109,7 @@ exports[`renders realm selector 1`] = `
                     id="realm-select-toggle"
                     type="button"
                   >
-                    <span
-                      class="pf-c-dropdown__toggle-text"
-                    >
-                      Master
-                    </span>
+                    
                     <span
                       class="pf-c-dropdown__toggle-icon"
                     >
@@ -201,11 +199,7 @@ exports[`renders realm selector 1`] = `
                       id="realm-select-toggle"
                       type="button"
                     >
-                      <span
-                        class="pf-c-dropdown__toggle-text"
-                      >
-                        Master
-                      </span>
+                      
                       <span
                         class="pf-c-dropdown__toggle-icon"
                       >
@@ -273,11 +267,6 @@ exports[`renders realm selector 1`] = `
                 type="button"
               >
                 <span
-                  className="pf-c-dropdown__toggle-text"
-                >
-                  Master
-                </span>
-                <span
                   className="pf-c-dropdown__toggle-icon"
                 >
                   <CaretDownIcon
@@ -312,5 +301,5 @@ exports[`renders realm selector 1`] = `
       </DropdownWithContext>
     </Dropdown>
   </RealmSelector>
-</RealmContextProvider>
+</div>
 `;

--- a/src/context/realm-context/RealmContext.tsx
+++ b/src/context/realm-context/RealmContext.tsx
@@ -1,9 +1,13 @@
-import React, { useState, useContext } from "react";
-import { WhoAmIContext } from "../../context/whoami/WhoAmI";
+import React, { useContext, useState } from "react";
 
-export const RealmContext = React.createContext({
+type RealmContextType = {
+  realm: string;
+  setRealm: (realm: string) => void;
+};
+
+export const RealmContext = React.createContext<RealmContextType>({
   realm: "",
-  setRealm: (realm: string) => {},
+  setRealm: () => {},
 });
 
 type RealmContextProviderProps = { children: React.ReactNode };
@@ -11,8 +15,7 @@ type RealmContextProviderProps = { children: React.ReactNode };
 export const RealmContextProvider = ({
   children,
 }: RealmContextProviderProps) => {
-  const homeRealm = useContext(WhoAmIContext).getHomeRealm();
-  const [realm, setRealm] = useState(homeRealm);
+  const [realm, setRealm] = useState("");
 
   return (
     <RealmContext.Provider value={{ realm, setRealm }}>
@@ -20,3 +23,5 @@ export const RealmContextProvider = ({
     </RealmContext.Provider>
   );
 };
+
+export const useRealm = () => useContext(RealmContext);

--- a/src/groups/GroupsSection.tsx
+++ b/src/groups/GroupsSection.tsx
@@ -21,7 +21,7 @@ import { useAlerts } from "../components/alert/Alerts";
 import { KeycloakDataTable } from "../components/table-toolbar/KeycloakDataTable";
 
 import "./GroupsSection.css";
-import { Link } from "react-router-dom";
+import { Link, useRouteMatch } from "react-router-dom";
 
 type GroupTableData = GroupRepresentation & {
   membersLength?: number;
@@ -35,6 +35,7 @@ export const GroupsSection = () => {
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
   const [selectedRows, setSelectedRows] = useState<GroupRepresentation[]>([]);
   const { addAlert } = useAlerts();
+  const { url } = useRouteMatch();
   const [key, setKey] = useState("");
   const refresh = () => setKey(`${new Date().getTime()}`);
 
@@ -82,7 +83,7 @@ export const GroupsSection = () => {
 
   const GroupNameCell = (group: GroupTableData) => (
     <>
-      <Link key={group.id} to={`/groups/${group.id}`}>
+      <Link key={group.id} to={`${url}/${group.id}`}>
         {group.name}
       </Link>
     </>

--- a/src/realm-roles/RealmRoleForm.tsx
+++ b/src/realm-roles/RealmRoleForm.tsx
@@ -27,6 +27,7 @@ import { ViewHeader } from "../components/view-header/ViewHeader";
 import { useAdminClient } from "../context/auth/AdminClient";
 import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
 import { RoleAttributes } from "./RoleAttributes";
+import { useRealm } from "../context/realm-context/RealmContext";
 
 type RoleFormType = {
   form?: UseFormMethods;
@@ -37,6 +38,7 @@ type RoleFormType = {
 export const RoleForm = ({ form, save, editMode }: RoleFormType) => {
   const { t } = useTranslation("roles");
   const history = useHistory();
+  const { realm } = useRealm();
   return (
     <FormAccess
       isHorizontal
@@ -90,7 +92,7 @@ export const RoleForm = ({ form, save, editMode }: RoleFormType) => {
         <Button variant="primary" type="submit">
           {t("common:save")}
         </Button>
-        <Button variant="link" onClick={() => history.push("/roles/")}>
+        <Button variant="link" onClick={() => history.push(`/${realm}/roles`)}>
           {editMode ? t("common:reload") : t("common:cancel")}
         </Button>
       </ActionGroup>
@@ -104,6 +106,7 @@ export const RealmRolesForm = () => {
   const adminClient = useAdminClient();
   const { addAlert } = useAlerts();
   const history = useHistory();
+  const { realm } = useRealm();
 
   const { id } = useParams<{ id: string }>();
   const [name, setName] = useState("");
@@ -136,7 +139,7 @@ export const RealmRolesForm = () => {
         const createdRole = await adminClient.roles.findOneByName({
           name: role.name!,
         });
-        history.push(`/roles/${createdRole.id}`);
+        history.push(`/${realm}/roles/${createdRole.id}`);
       }
       addAlert(t(id ? "roleSaveSuccess" : "roleCreated"), AlertVariant.success);
     } catch (error) {
@@ -156,7 +159,7 @@ export const RealmRolesForm = () => {
       try {
         await adminClient.roles.delById({ id });
         addAlert(t("roleDeletedSuccess"), AlertVariant.success);
-        history.push("/roles");
+        history.push(`/${realm}/roles`);
       } catch (error) {
         addAlert(`${t("roleDeleteError")} ${error}`, AlertVariant.danger);
       }

--- a/src/realm-roles/RealmRoleTabs.tsx
+++ b/src/realm-roles/RealmRoleTabs.tsx
@@ -21,6 +21,7 @@ import { useAdminClient } from "../context/auth/AdminClient";
 import RoleRepresentation from "keycloak-admin/lib/defs/roleRepresentation";
 import { RoleAttributes } from "./RoleAttributes";
 import "./RealmRolesSection.css";
+import { useRealm } from "../context/realm-context/RealmContext";
 
 export const RolesTabs = () => {
   const { t } = useTranslation("roles");
@@ -29,6 +30,7 @@ export const RolesTabs = () => {
   const [name, setName] = useState("");
   const adminClient = useAdminClient();
   const [activeTab, setActiveTab] = useState(0);
+  const { realm } = useRealm();
 
   const { id } = useParams<{ id: string }>();
 
@@ -116,7 +118,10 @@ export const RolesTabs = () => {
               <Button variant="primary" type="submit">
                 {t("common:save")}
               </Button>
-              <Button variant="link" onClick={() => history.push("/roles/")}>
+              <Button
+                variant="link"
+                onClick={() => history.push(`/${realm}/roles`)}
+              >
                 {t("common:reload")}
               </Button>
             </ActionGroup>
@@ -131,7 +136,10 @@ export const RolesTabs = () => {
             <Button variant="primary" type="submit">
               {t("common:save")}
             </Button>
-            <Button variant="link" onClick={() => history.push("/roles/")}>
+            <Button
+              variant="link"
+              onClick={() => history.push(`/${realm}/roles`)}
+            >
               {t("common:reload")}
             </Button>
           </ActionGroup>

--- a/src/realm-roles/RealmRolesSection.tsx
+++ b/src/realm-roles/RealmRolesSection.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Link, useHistory } from "react-router-dom";
+import { Link, useHistory, useRouteMatch } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import {
   AlertVariant,
@@ -23,6 +23,7 @@ export const RealmRolesSection = () => {
   const history = useHistory();
   const adminClient = useAdminClient();
   const { addAlert } = useAlerts();
+  const { url } = useRouteMatch();
 
   const [selectedRole, setSelectedRole] = useState<RoleRepresentation>();
 
@@ -37,7 +38,7 @@ export const RealmRolesSection = () => {
 
   const RoleDetailLink = (role: RoleRepresentation) => (
     <>
-      <Link key={role.id} to={`/roles/${role.id}`}>
+      <Link key={role.id} to={`${url}/${role.id}`}>
         {role.name}
       </Link>
     </>
@@ -81,7 +82,7 @@ export const RealmRolesSection = () => {
     },
   });
 
-  const goToCreate = () => history.push("/roles/add-role");
+  const goToCreate = () => history.push(`${url}/add-role`);
   return (
     <>
       <ViewHeader titleKey="roles:title" subKey="roles:roleExplain" />

--- a/src/route-config.ts
+++ b/src/route-config.ts
@@ -41,28 +41,28 @@ export const routes: RoutesFn = (t) => [
     access: "manage-realm",
   },
   {
-    path: "/:realm/clients/:id",
-    component: ClientDetails,
-    breadcrumb: t("clients:clientSettings"),
-    access: "view-clients",
-  },
-  {
     path: "/:realm/clients",
     component: ClientsSection,
     breadcrumb: t("clients:clientList"),
     access: "query-clients",
   },
   {
-    path: "/:realm/add-client",
+    path: "/:realm/clients/add-client",
     component: NewClientForm,
     breadcrumb: t("clients:createClient"),
     access: "manage-clients",
   },
   {
-    path: "/:realm/import-client",
+    path: "/:realm/clients/import-client",
     component: ImportForm,
     breadcrumb: t("clients:importClient"),
     access: "manage-clients",
+  },
+  {
+    path: "/:realm/clients/:id",
+    component: ClientDetails,
+    breadcrumb: t("clients:clientSettings"),
+    access: "view-clients",
   },
   {
     path: "/:realm/client-scopes/new",

--- a/src/route-config.ts
+++ b/src/route-config.ts
@@ -27,7 +27,7 @@ import { RoleMappingForm } from "./client-scopes/add/RoleMappingForm";
 export type RouteDef = {
   path: string;
   component: () => JSX.Element;
-  breadcrumb?: TFunction;
+  breadcrumb: TFunction | null;
   access: AccessType;
 };
 
@@ -169,11 +169,13 @@ export const routes: RoutesFn = (t) => [
   {
     path: "/:realm/user-federation/kerberos",
     component: UserFederationSection,
+    breadcrumb: null,
     access: "view-realm",
   },
   {
     path: "/:realm/user-federation/ldap",
     component: UserFederationSection,
+    breadcrumb: null,
     access: "view-realm",
   },
   {
@@ -197,6 +199,7 @@ export const routes: RoutesFn = (t) => [
   {
     path: "*",
     component: PageNotFoundSection,
+    breadcrumb: null,
     access: "anyone",
   },
 ];

--- a/src/route-config.ts
+++ b/src/route-config.ts
@@ -27,171 +27,169 @@ import { RoleMappingForm } from "./client-scopes/add/RoleMappingForm";
 export type RouteDef = {
   path: string;
   component: () => JSX.Element;
-  breadcrumb: TFunction | "";
+  breadcrumb?: TFunction;
   access: AccessType;
 };
 
 type RoutesFn = (t: TFunction) => RouteDef[];
 
-export const routes: RoutesFn = (t: any) => [
+export const routes: RoutesFn = (t) => [
   {
-    path: "/add-realm",
+    path: "/:realm/add-realm",
     component: NewRealmForm,
     breadcrumb: t("realm:createRealm"),
     access: "manage-realm",
   },
   {
-    path: "/clients/:id",
+    path: "/:realm/clients/:id",
     component: ClientDetails,
     breadcrumb: t("clients:clientSettings"),
     access: "view-clients",
   },
   {
-    path: "/clients",
+    path: "/:realm/clients",
     component: ClientsSection,
     breadcrumb: t("clients:clientList"),
     access: "query-clients",
   },
   {
-    path: "/add-client",
+    path: "/:realm/add-client",
     component: NewClientForm,
     breadcrumb: t("clients:createClient"),
     access: "manage-clients",
   },
   {
-    path: "/import-client",
+    path: "/:realm/import-client",
     component: ImportForm,
     breadcrumb: t("clients:importClient"),
     access: "manage-clients",
   },
   {
-    path: "/client-scopes/new",
+    path: "/:realm/client-scopes/new",
     component: ClientScopeForm,
     breadcrumb: t("client-scopes:createClientScope"),
     access: "manage-clients",
   },
   {
-    path: "/client-scopes/:id",
+    path: "/:realm/client-scopes/:id",
     component: ClientScopeForm,
     breadcrumb: t("client-scopes:clientScopeDetails"),
     access: "view-clients",
   },
   {
-    path: "/client-scopes/:scopeId/oidc-role-name-mapper",
+    path: "/:realm/client-scopes/:scopeId/oidc-role-name-mapper",
     component: RoleMappingForm,
     breadcrumb: t("client-scopes:mappingDetails"),
     access: "view-clients",
   },
   {
-    path: "/client-scopes/:scopeId/:id",
+    path: "/:realm/client-scopes/:scopeId/:id",
     component: MappingDetails,
     breadcrumb: t("client-scopes:mappingDetails"),
     access: "view-clients",
   },
   {
-    path: "/client-scopes/:id",
+    path: "/:realm/client-scopes/:id",
     component: ClientScopeForm,
     breadcrumb: t("client-scopes:clientScopeDetails"),
     access: "view-clients",
   },
   {
-    path: "/client-scopes",
+    path: "/:realm/client-scopes",
     component: ClientScopesSection,
     breadcrumb: t("client-scopes:clientScopeList"),
     access: "view-clients",
   },
   {
-    path: "/roles",
+    path: "/:realm/roles",
     component: RealmRolesSection,
     breadcrumb: t("roles:roleList"),
     access: "view-realm",
   },
   {
-    path: "/roles/add-role",
+    path: "/:realm/roles/add-role",
     component: RealmRolesForm,
     breadcrumb: t("roles:createRole"),
     access: "manage-realm",
   },
   {
-    path: "/roles/:id",
+    path: "/:realm/roles/:id",
     component: RealmRolesForm,
     breadcrumb: t("roles:roleDetails"),
     access: "view-realm",
   },
   {
-    path: "/users",
+    path: "/:realm/users",
     component: UsersSection,
     breadcrumb: t("users:title"),
     access: "query-users",
   },
   {
-    path: "/groups",
+    path: "/:realm/groups",
     component: GroupsSection,
     breadcrumb: t("groups"),
     access: "query-groups",
   },
   {
-    path: "/sessions",
+    path: "/:realm/sessions",
     component: SessionsSection,
     breadcrumb: t("sessions:title"),
     access: "view-realm",
   },
   {
-    path: "/events",
+    path: "/:realm/events",
     component: EventsSection,
     breadcrumb: t("events:title"),
     access: "view-events",
   },
   {
-    path: "/realm-settings",
+    path: "/:realm/realm-settings",
     component: RealmSettingsSection,
     breadcrumb: t("realmSettings"),
     access: "view-realm",
   },
   {
-    path: "/authentication",
+    path: "/:realm/authentication",
     component: AuthenticationSection,
     breadcrumb: t("authentication"),
     access: "view-realm",
   },
   {
-    path: "/identity-providers",
+    path: "/:realm/identity-providers",
     component: IdentityProvidersSection,
     breadcrumb: t("identityProviders"),
     access: "view-identity-providers",
   },
   {
-    path: "/user-federation",
+    path: "/:realm/user-federation",
     component: UserFederationSection,
     breadcrumb: t("userFederation"),
     access: "view-realm",
   },
   {
-    path: "/user-federation/kerberos",
+    path: "/:realm/user-federation/kerberos",
     component: UserFederationSection,
-    breadcrumb: null,
     access: "view-realm",
   },
   {
-    path: "/user-federation/ldap",
+    path: "/:realm/user-federation/ldap",
     component: UserFederationSection,
-    breadcrumb: null,
     access: "view-realm",
   },
   {
-    path: "/user-federation/kerberos/:id",
+    path: "/:realm/user-federation/kerberos/:id",
     component: UserFederationKerberosSettings,
     breadcrumb: t("common:settings"),
     access: "view-realm",
   },
   {
-    path: "/user-federation/ldap/:id",
+    path: "/:realm/user-federation/ldap/:id",
     component: UserFederationLdapSettings,
     breadcrumb: t("common:settings"),
     access: "view-realm",
   },
   {
-    path: "/",
+    path: "/:realm/",
     component: ClientsSection,
     breadcrumb: t("common:home"),
     access: "anyone",
@@ -199,7 +197,6 @@ export const routes: RoutesFn = (t: any) => [
   {
     path: "*",
     component: PageNotFoundSection,
-    breadcrumb: "",
     access: "anyone",
   },
 ];

--- a/src/route-config.ts
+++ b/src/route-config.ts
@@ -196,6 +196,12 @@ export const routes: RoutesFn = (t) => [
     access: "anyone",
   },
   {
+    path: "/",
+    component: ClientsSection,
+    breadcrumb: t("common:home"),
+    access: "anyone",
+  },
+  {
     path: "*",
     component: PageNotFoundSection,
     breadcrumb: null,

--- a/src/route-config.ts
+++ b/src/route-config.ts
@@ -23,11 +23,10 @@ import { ClientDetails } from "./clients/ClientDetails";
 import { UserFederationKerberosSettings } from "./user-federation/UserFederationKerberosSettings";
 import { UserFederationLdapSettings } from "./user-federation/UserFederationLdapSettings";
 import { RoleMappingForm } from "./client-scopes/add/RoleMappingForm";
+import { BreadcrumbsRoute } from "use-react-router-breadcrumbs";
 
-export type RouteDef = {
-  path: string;
+export type RouteDef = BreadcrumbsRoute & {
   component: () => JSX.Element;
-  breadcrumb: TFunction | null;
   access: AccessType;
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -19357,9 +19357,9 @@ use-latest@^1.0.0:
     use-isomorphic-layout-effect "^1.0.0"
 
 use-react-router-breadcrumbs@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/use-react-router-breadcrumbs/-/use-react-router-breadcrumbs-1.0.4.tgz#12b67ba27ac7e6a00e6ae10896ea91e178e87ee2"
-  integrity sha512-SskKm+wFYPD7eiYrg89y1Wn8vMlY+DiZXNFuP4Wt5gMP2aolcahHGR6pRTWsfMW93CEQxdVkXv/ceHL7nfz2Fw==
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/use-react-router-breadcrumbs/-/use-react-router-breadcrumbs-1.0.5.tgz#3b39a2c2a6ab72544c2fc8984f6825d0f1122877"
+  integrity sha512-NDMgWr5MdksqnATRvp84RtZ0ABfuztlsgR4VWlsBV0D3TVV6xhbmkhTdV3cWnyRIZqNlMXZhwJhyRHoC6fbAsQ==
 
 use-sidecar@^1.0.1:
   version "1.0.3"


### PR DESCRIPTION
## Motivation
<!-- Add references to relevant tickets, issues, design specs and/or a short description of what motivated you to do it. -->
In order to create links that are "bookmarkable" we should add the realm name in the url

## Brief Description
<!-- Add a short answer for: 
What was done in this PR? (e.g Fix to prevent users from accessing feature X.)
Why it was done? (e.g Feature X was deprecated.)
-->
Update the code to create urls like: `/realm/section/` so that you could share links

## Verification Steps
<!--
Add the steps required to verify this change. Keep in mind that these steps should be written so groups unfamiliar with the 
new functionality can follow them, such as QE or documentation.

1. Go to `XX >> YY >> SS`.
2. Create a new item `N` with info `X`.
3. Right-click the item and select Delete.
4. Verify that the item is no longer present in the left navigation menu.
-->
Navigate to any page to see the realm name in the url

## Checklist:

- [x] Code has been tested locally by PR requester
- [N] User-visible strings are using the react-i18next framework (useTranslation)
- [N] Help has been implemented
- [N] axe report has been run and resulting a11y issues have been resolved
- [N] Unit tests have been created/updated
- [x] Formatting has been performed via prettier/eslint
- [x] Type checking has been performed via 'yarn check-types'

## Additional Notes
<!-- 
Add images and/or screen caps to illustrate what was changed if this pull request adds to or modifies existing user-visible appearance/output. 
-->