### PR TITLE
switches don't work in a `FormAccess` form

### DIFF
--- a/src/components/form-access/FormAccess.tsx
+++ b/src/components/form-access/FormAccess.tsx
@@ -69,8 +69,7 @@ export const FormAccess = ({
             render: (props: any) => {
               const renderElement = element.props.render(props);
               return cloneElement(renderElement, {
-                value: props.value,
-                onChange: props.onChange,
+                ...renderElement.props,
                 ...newProps,
               });
             },

--- a/src/components/form-access/__tests__/__snapshots__/FormAccess.test.tsx.snap
+++ b/src/components/form-access/__tests__/__snapshots__/FormAccess.test.tsx.snap
@@ -194,7 +194,6 @@ exports[`<FormAccess /> render normal form 1`] = `
               label="on"
               labelOff="off"
               onChange={[Function]}
-              value={false}
             >
               <label
                 className="pf-c-switch"
@@ -212,7 +211,6 @@ exports[`<FormAccess /> render normal form 1`] = `
                   id="kc-consent"
                   onChange={[Function]}
                   type="checkbox"
-                  value={false}
                 />
                 <span
                   className="pf-c-switch__toggle"


### PR DESCRIPTION
not all of their props where copied