### PR TITLE
update who am i on realm create as we need the accessTypes

### DIFF
--- a/src/PageHeader.tsx
+++ b/src/PageHeader.tsx
@@ -133,7 +133,7 @@ export const Header = () => {
   };
 
   const UserDropdown = () => {
-    const whoami = useContext(WhoAmIContext);
+    const { whoAmI } = useContext(WhoAmIContext);
     const [isDropdownOpen, setDropdownOpen] = useState(false);
 
     const onDropdownToggle = () => {
@@ -147,7 +147,7 @@ export const Header = () => {
         isOpen={isDropdownOpen}
         toggle={
           <DropdownToggle onToggle={onDropdownToggle}>
-            {whoami.getDisplayName()}
+            {whoAmI.getDisplayName()}
           </DropdownToggle>
         }
         dropdownItems={userDropdownItems}

--- a/src/PageNav.tsx
+++ b/src/PageNav.tsx
@@ -18,6 +18,7 @@ import { routes } from "./route-config";
 export const PageNav: React.FunctionComponent = () => {
   const { t } = useTranslation("common");
   const { hasAccess, hasSomeAccess } = useAccess();
+  const { realm } = useRealm();
   const adminClient = useAdminClient();
   const realmLoader = async () => {
     return await adminClient.realms.find();
@@ -81,10 +82,10 @@ export const PageNav: React.FunctionComponent = () => {
       nav={
         <Nav onSelect={onSelect}>
           <NavList>
-            <DataLoader loader={realmLoader}>
+            <DataLoader loader={realmLoader} deps={[realm]}>
               {(realmList) => (
                 <NavItem className="keycloak__page_nav__nav_item__realm-selector">
-                  <RealmSelector realmList={realmList.data || []} />
+                  <RealmSelector realmList={realmList || []} />
                 </NavItem>
               )}
             </DataLoader>

--- a/src/clients/service-account/ServiceAccount.tsx
+++ b/src/clients/service-account/ServiceAccount.tsx
@@ -137,7 +137,7 @@ export const ServiceAccount = ({ clientId }: ServiceAccountProps) => {
         </>
       }
     >
-      <DataLoader loader={loader}>
+      <DataLoader loader={loader} deps={[clientId]}>
         {(clientRoles) => (
           <>
             {hide ? "" : " "}
@@ -152,7 +152,7 @@ export const ServiceAccount = ({ clientId }: ServiceAccountProps) => {
                 },
                 { title: t("description"), cellFormatters: [emptyFormatter()] },
               ]}
-              rows={clientRoles.data}
+              rows={clientRoles}
               aria-label="roleList"
             >
               <TableHeader />

--- a/src/components/data-loader/DataLoader.tsx
+++ b/src/components/data-loader/DataLoader.tsx
@@ -1,37 +1,26 @@
-import React, { useEffect, useState } from "react";
+import React, { DependencyList, useEffect, useState } from "react";
 import { Spinner } from "@patternfly/react-core";
 import { asyncStateFetch } from "../../context/auth/AdminClient";
 
 type DataLoaderProps<T> = {
   loader: () => Promise<T>;
-  deps?: any[];
-  children: ((arg: Result<T>) => any) | React.ReactNode;
-};
-
-type Result<T> = {
-  data: T;
-  refresh: () => void;
+  deps?: DependencyList;
+  children: ((arg: T) => any) | React.ReactNode;
 };
 
 export function DataLoader<T>(props: DataLoaderProps<T>) {
-  const [data, setData] = useState<{ result: T } | undefined>(undefined);
-
-  const [key, setKey] = useState(0);
-  const refresh = () => setKey(new Date().getTime());
+  const [data, setData] = useState<T | undefined>();
 
   useEffect(() => {
     return asyncStateFetch(
       () => props.loader(),
-      (result) => setData({ result })
+      (result) => setData(result)
     );
-  }, [key]);
+  }, props.deps || []);
 
   if (data) {
     if (props.children instanceof Function) {
-      return props.children({
-        data: data.result,
-        refresh: refresh,
-      });
+      return props.children(data);
     }
     return props.children;
   }

--- a/src/components/data-loader/__tests__/DataLoader.test.tsx
+++ b/src/components/data-loader/__tests__/DataLoader.test.tsx
@@ -22,7 +22,7 @@ describe("<DataLoader />", () => {
         <DataLoader loader={loader}>
           {(result) => (
             <div>
-              {result.data.map((d, i) => (
+              {result.map((d, i) => (
                 <i key={i}>{d}</i>
               ))}
             </div>

--- a/src/components/form-access/__tests__/FormAccess.test.tsx
+++ b/src/components/form-access/__tests__/FormAccess.test.tsx
@@ -14,7 +14,9 @@ describe("<FormAccess />", () => {
   const Form = ({ realm }: { realm: string }) => {
     const { register, control } = useForm();
     return (
-      <WhoAmIContext.Provider value={new WhoAmI("master", whoami)}>
+      <WhoAmIContext.Provider
+        value={{ refresh: () => {}, whoAmI: new WhoAmI("master", whoami) }}
+      >
         <RealmContext.Provider value={{ realm, setRealm: () => {} }}>
           <AccessContextProvider>
             <FormAccess role="manage-clients">

--- a/src/components/realm-selector/RealmSelector.tsx
+++ b/src/components/realm-selector/RealmSelector.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useContext, useEffect } from "react";
-import { useHistory, useRouteMatch } from "react-router-dom";
+import { useHistory } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 
 import {
@@ -33,7 +33,6 @@ export const RealmSelector = ({ realmList }: RealmSelectorProps) => {
   const [filteredItems, setFilteredItems] = useState(realmList);
   const history = useHistory();
   const { t } = useTranslation("common");
-  const { url } = useRouteMatch();
 
   const toUpperCase = (realmName: string) =>
     realmName.charAt(0).toUpperCase() + realmName.slice(1);
@@ -49,7 +48,10 @@ export const RealmSelector = ({ realmList }: RealmSelectorProps) => {
     <Button
       component="div"
       isBlock
-      onClick={() => history.push(`${url}/add-realm"`)}
+      onClick={() => {
+        history.push(`/${realm}/add-realm`);
+        setOpen(!open);
+      }}
       className={className}
     >
       {t("createRealm")}
@@ -85,7 +87,7 @@ export const RealmSelector = ({ realmList }: RealmSelectorProps) => {
 
   const addRealmComponent = (
     <React.Fragment key="Add Realm">
-      {whoami.canCreateRealm() && (
+      {whoami.whoAmI.canCreateRealm() && (
         <>
           <Divider key="divider" />
           <DropdownItem key="add">

--- a/src/components/realm-selector/RealmSelector.tsx
+++ b/src/components/realm-selector/RealmSelector.tsx
@@ -27,7 +27,7 @@ type RealmSelectorProps = {
 
 export const RealmSelector = ({ realmList }: RealmSelectorProps) => {
   const { realm, setRealm } = useRealm();
-  const whoami = useContext(WhoAmIContext);
+  const { whoAmI } = useContext(WhoAmIContext);
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
   const [filteredItems, setFilteredItems] = useState(realmList);
@@ -87,7 +87,7 @@ export const RealmSelector = ({ realmList }: RealmSelectorProps) => {
 
   const addRealmComponent = (
     <React.Fragment key="Add Realm">
-      {whoami.whoAmI.canCreateRealm() && (
+      {whoAmI.canCreateRealm() && (
         <>
           <Divider key="divider" />
           <DropdownItem key="add">

--- a/src/context/access/Access.tsx
+++ b/src/context/access/Access.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext } from "react";
+import React, { createContext, useContext, useEffect, useState } from "react";
 import { AccessType } from "keycloak-admin/lib/defs/whoAmIRepresentation";
 
 import { RealmContext } from "../../context/realm-context/RealmContext";
@@ -18,17 +18,20 @@ export const useAccess = () => useContext(AccessContext);
 
 type AccessProviderProps = { children: React.ReactNode };
 export const AccessContextProvider = ({ children }: AccessProviderProps) => {
-  const whoami = useContext(WhoAmIContext);
+  const { whoAmI } = useContext(WhoAmIContext);
   const realmCtx = useContext(RealmContext);
+  const [access, setAccess] = useState<readonly AccessType[]>([]);
 
-  const access = () => whoami.getRealmAccess()[realmCtx.realm];
+  useEffect(() => {
+    setAccess(whoAmI.getRealmAccess()[realmCtx.realm]);
+  }, [whoAmI]);
 
   const hasAccess = (...types: AccessType[]) => {
-    return types.every((type) => type === "anyone" || access().includes(type));
+    return types.every((type) => type === "anyone" || access.includes(type));
   };
 
   const hasSomeAccess = (...types: AccessType[]) => {
-    return types.some((type) => type === "anyone" || access().includes(type));
+    return types.some((type) => type === "anyone" || access.includes(type));
   };
 
   return (

--- a/src/context/server-info/ServerInfoProvider.tsx
+++ b/src/context/server-info/ServerInfoProvider.tsx
@@ -23,7 +23,7 @@ export const ServerInfoProvider = ({ children }: { children: ReactNode }) => {
   return (
     <DataLoader loader={loader}>
       {(serverInfo) => (
-        <ServerInfoContext.Provider value={serverInfo.data}>
+        <ServerInfoContext.Provider value={serverInfo}>
           {children}
         </ServerInfoContext.Provider>
       )}

--- a/src/context/whoami/WhoAmI.tsx
+++ b/src/context/whoami/WhoAmI.tsx
@@ -1,8 +1,7 @@
-import React, { useContext } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import i18n from "../../i18n";
 
-import { DataLoader } from "../../components/data-loader/DataLoader";
-import { AdminClient } from "../auth/AdminClient";
+import { AdminClient, useFetch } from "../auth/AdminClient";
 import { RealmContext } from "../realm-context/RealmContext";
 import WhoAmIRepresentation, {
   AccessType,
@@ -50,31 +49,43 @@ export class WhoAmI {
   }
 }
 
-export const WhoAmIContext = React.createContext(new WhoAmI());
+type WhoAmIProps = {
+  refresh: () => void;
+  whoAmI: WhoAmI;
+};
+
+export const WhoAmIContext = React.createContext<WhoAmIProps>({
+  refresh: () => {},
+  whoAmI: new WhoAmI(),
+});
 
 type WhoAmIProviderProps = { children: React.ReactNode };
 export const WhoAmIContextProvider = ({ children }: WhoAmIProviderProps) => {
   const adminClient = useContext(AdminClient)!;
   const { realm, setRealm } = useContext(RealmContext);
+  const [whoAmI, setWhoAmI] = useState<WhoAmI>(new WhoAmI());
+  const [key, setKey] = useState(0);
 
-  const whoAmILoader = async () => {
-    const whoamiResponse = await adminClient.whoAmI.find({
-      realm: adminClient.keycloak?.realm,
-    });
-    const whoAmI = new WhoAmI(adminClient.keycloak?.realm, whoamiResponse);
-    if (!realm) {
-      setRealm(whoAmI.getHomeRealm());
-    }
-    return whoAmI;
-  };
+  useEffect(() => {
+    console.log("fetching who am i");
+    return useFetch(
+      () =>
+        adminClient.whoAmI.find({
+          realm: adminClient.keycloak?.realm,
+        }),
+      (me) => {
+        const whoAmI = new WhoAmI(adminClient.keycloak?.realm, me);
+        if (!realm) {
+          setRealm(whoAmI.getHomeRealm());
+        }
+        setWhoAmI(whoAmI);
+      }
+    );
+  }, [key]);
 
   return (
-    <DataLoader loader={whoAmILoader}>
-      {(whoami) => (
-        <WhoAmIContext.Provider value={whoami.data}>
-          {children}
-        </WhoAmIContext.Provider>
-      )}
-    </DataLoader>
+    <WhoAmIContext.Provider value={{ refresh: () => setKey(key + 1), whoAmI }}>
+      {children}
+    </WhoAmIContext.Provider>
   );
 };

--- a/src/context/whoami/WhoAmI.tsx
+++ b/src/context/whoami/WhoAmI.tsx
@@ -1,7 +1,7 @@
 import React, { useContext, useEffect, useState } from "react";
 import i18n from "../../i18n";
 
-import { AdminClient, useFetch } from "../auth/AdminClient";
+import { AdminClient, asyncStateFetch } from "../auth/AdminClient";
 import { RealmContext } from "../realm-context/RealmContext";
 import WhoAmIRepresentation, {
   AccessType,
@@ -67,7 +67,7 @@ export const WhoAmIContextProvider = ({ children }: WhoAmIProviderProps) => {
   const [key, setKey] = useState(0);
 
   useEffect(() => {
-    return useFetch(
+    return asyncStateFetch(
       () =>
         adminClient.whoAmI.find({
           realm: adminClient.keycloak?.realm,

--- a/src/context/whoami/WhoAmI.tsx
+++ b/src/context/whoami/WhoAmI.tsx
@@ -67,7 +67,6 @@ export const WhoAmIContextProvider = ({ children }: WhoAmIProviderProps) => {
   const [key, setKey] = useState(0);
 
   useEffect(() => {
-    console.log("fetching who am i");
     return useFetch(
       () =>
         adminClient.whoAmI.find({

--- a/src/realm/add/NewRealmForm.tsx
+++ b/src/realm/add/NewRealmForm.tsx
@@ -43,11 +43,11 @@ export const NewRealmForm = () => {
   const save = async (realm: RealmRepresentation) => {
     try {
       await adminClient.realms.create(realm);
-      refresh();
-      history.push(`/${realm.realm}`);
-      //force token update
-      await adminClient.keycloak.updateToken(Number.MAX_VALUE);
       addAlert(t("Realm created"), AlertVariant.success);
+      refresh();
+      //force token update
+      await adminClient.keycloak?.updateToken(Number.MAX_VALUE);
+      history.push(`/${realm.realm}`);
     } catch (error) {
       addAlert(
         `${t("Could not create realm:")} '${error}'`,

--- a/src/realm/add/NewRealmForm.tsx
+++ b/src/realm/add/NewRealmForm.tsx
@@ -1,4 +1,5 @@
-import React from "react";
+import React, { useContext } from "react";
+import { useHistory } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import {
   PageSection,
@@ -17,9 +18,12 @@ import { useForm, Controller } from "react-hook-form";
 import { ViewHeader } from "../../components/view-header/ViewHeader";
 import RealmRepresentation from "keycloak-admin/lib/defs/realmRepresentation";
 import { useAdminClient } from "../../context/auth/AdminClient";
+import { WhoAmIContext } from "../../context/whoami/WhoAmI";
 
 export const NewRealmForm = () => {
   const { t } = useTranslation("realm");
+  const history = useHistory();
+  const { refresh } = useContext(WhoAmIContext);
   const adminClient = useAdminClient();
   const { addAlert } = useAlerts();
 
@@ -39,6 +43,8 @@ export const NewRealmForm = () => {
   const save = async (realm: RealmRepresentation) => {
     try {
       await adminClient.realms.create(realm);
+      refresh();
+      history.push(`/${realm.realm}`);
       addAlert(t("Realm created"), AlertVariant.success);
     } catch (error) {
       addAlert(

--- a/src/realm/add/NewRealmForm.tsx
+++ b/src/realm/add/NewRealmForm.tsx
@@ -45,6 +45,8 @@ export const NewRealmForm = () => {
       await adminClient.realms.create(realm);
       refresh();
       history.push(`/${realm.realm}`);
+      //force token update
+      await adminClient.keycloak.updateToken(Number.MAX_VALUE);
       addAlert(t("Realm created"), AlertVariant.success);
     } catch (error) {
       addAlert(


### PR DESCRIPTION
## Motivation
<!-- Add references to relevant tickets, issues, design specs and/or a short description of what motivated you to do it. -->
The `WhoAmI` context contains the `AccessType[]` needed for all pages when we create a new realm this information need to be updated.

## Verification Steps
<!--
Add the steps required to verify this change. Keep in mind that these steps should be written so groups unfamiliar with the 
new functionality can follow them, such as QE or documentation.

1. Go to `XX >> YY >> SS`.
2. Create a new item `N` with info `X`.
3. Right-click the item and select Delete.
4. Verify that the item is no longer present in the left navigation menu.
-->
Now when we create a new realm we can switch to the newly created realm without a full reload

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated
- [x] Formatting has been performed via prettier/eslint
- [x] Type checking has been performed via 'yarn check-types'

## Additional Notes
<!-- 
Add images and/or screen caps to illustrate what was changed if this pull request adds to or modifies existing user-visible appearance/output. 
-->