### PR TITLE
[WIP] adds only layout and text for unlink users modal

### DIFF
--- a/src/user-federation/UserFederationLdapSettings.tsx
+++ b/src/user-federation/UserFederationLdapSettings.tsx
@@ -9,9 +9,25 @@ import { LdapSettingsSynchronization } from "./ldap/LdapSettingsSynchronization"
 import { LdapSettingsGeneral } from "./ldap/LdapSettingsGeneral";
 import { LdapSettingsConnection } from "./ldap/LdapSettingsConnection";
 import { LdapSettingsSearching } from "./ldap/LdapSettingsSearching";
+import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
 
 export const UserFederationLdapSettings = () => {
   const { t } = useTranslation("user-federation");
+
+  const [toggleDeleteDialog, DeleteConfirm] = useConfirmDialog({
+    titleKey: t("removeImportedUsers"),
+    messageKey: t("removeImportedUsersMessage"),
+    continueButtonLabel: "common:remove",
+    onConfirm: async () => {
+      // try {
+      //   await something? :-)
+      //   refresh();
+      //   addAlert(t("removeImportedUsersSuccess"), AlertVariant.success);
+      // } catch (error) {
+      //   addAlert(t("removeImportedUsersError", { error }), AlertVariant.danger);
+      // }
+    },
+  });
 
   return (
     <>

--- a/src/user-federation/messages.json
+++ b/src/user-federation/messages.json
@@ -81,6 +81,11 @@
     "userFedDeletedSuccess": "The user federation provider has been deleted.",
     "userFedDeleteError": "Could not delete user federation provider: '{{error}}'",
     "userFedDeleteConfirmTitle": "Delete user federation provider?",
-    "userFedDeleteConfirm": "If you delete this user federation provider, all associated data will be removed."
+    "userFedDeleteConfirm": "If you delete this user federation provider, all associated data will be removed.",
+
+    "removeImportedUsers": "Remove imported users?",
+    "removeImportedUsersMessage": "Do you really want to remove all imported users? The option \"Unlink users\" makes sense just for the Edit Mode \"Unsynced\" and there should be a warning that \"unlinked\" users without the password in the Keycloak database won't be able to authenticate.",
+    "removeImportedUsersSuccess": "Imported users have been removed",
+    "removeImportedUsersError": "Could not remove imported users: '{{error}}'"
   }
 }


### PR DESCRIPTION
## Motivation
Layout only of the "remove imported users" modal
https://marvelapp.com/prototype/ecjc94b/screen/72379134

## Brief Description
This adds the text and confirmation dialog but it's not hooked up to anything yet.
* This fails lint because it's defining something that is not yet used *

## Verification Steps
Check that the text looks correct

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated
- [ ] Formatting has been performed via prettier/eslint
- [ ] Type checking has been performed via 'yarn check-types'

## Additional Notes
@mfrances17 will be hooking this up to the functionality
