### PR TITLE
Add Save/Cancel buttons and logic to Kerberos settings

### DIFF
--- a/src/user-federation/UserFederationKerberosSettings.tsx
+++ b/src/user-federation/UserFederationKerberosSettings.tsx
@@ -1,9 +1,22 @@
-import { PageSection } from "@patternfly/react-core";
+import {
+  // ActionGroup,
+  // Button,
+  // Form,
+  PageSection,
+  // Title,
+} from "@patternfly/react-core";
+// import { useTranslation } from "react-i18next";
 import React from "react";
 import { KerberosSettingsRequired } from "./kerberos/KerberosSettingsRequired";
 import { KerberosSettingsCache } from "./kerberos/KerberosSettingsCache";
+// import { useHistory } from "react-router-dom";
+// import { useRealm } from "../context/realm-context/RealmContext";
 
 export const UserFederationKerberosSettings = () => {
+  // const { t } = useTranslation("user-federation");
+  // const history = useHistory();
+  // const { realm } = useRealm();
+
   return (
     <>
       <PageSection variant="light">
@@ -11,6 +24,24 @@ export const UserFederationKerberosSettings = () => {
       </PageSection>
       <PageSection variant="light" isFilled>
         <KerberosSettingsCache showSectionHeading />
+        {/* Cache settings
+        <Title size={"xl"} headingLevel={"h2"} className="pf-u-mb-lg">
+          {t("cacheSettings")}
+        </Title>
+        <KerberosSettingsCache />
+        <Form>
+          <ActionGroup>
+            <Button variant="primary" type="submit">
+              {t("common:save")}
+            </Button>
+            <Button
+              variant="link"
+              onClick={() => history.push(`/${realm}/user-federation`)}
+            >
+              {t("common:cancel")}
+            </Button>
+          </ActionGroup>
+        </Form> */}
       </PageSection>
     </>
   );

--- a/src/user-federation/UserFederationKerberosSettings.tsx
+++ b/src/user-federation/UserFederationKerberosSettings.tsx
@@ -65,10 +65,10 @@ export const UserFederationKerberosSettings = () => {
   return (
     <>
       <PageSection variant="light">
-        <KerberosSettingsRequired form={form} save={save} showSectionHeading />
+        <KerberosSettingsRequired form={form} showSectionHeading />
       </PageSection>
       <PageSection variant="light" isFilled>
-        <KerberosSettingsCache form={form} save={save} showSectionHeading />
+        <KerberosSettingsCache form={form} showSectionHeading />
         <Form onSubmit={form.handleSubmit(save)}>
           <ActionGroup>
             <Button variant="primary" type="submit">

--- a/src/user-federation/UserFederationKerberosSettings.tsx
+++ b/src/user-federation/UserFederationKerberosSettings.tsx
@@ -1,21 +1,15 @@
-import {
-  // ActionGroup,
-  // Button,
-  // Form,
-  PageSection,
-  // Title,
-} from "@patternfly/react-core";
-// import { useTranslation } from "react-i18next";
+import { ActionGroup, Button, Form, PageSection } from "@patternfly/react-core";
+import { useTranslation } from "react-i18next";
 import React from "react";
 import { KerberosSettingsRequired } from "./kerberos/KerberosSettingsRequired";
 import { KerberosSettingsCache } from "./kerberos/KerberosSettingsCache";
-// import { useHistory } from "react-router-dom";
-// import { useRealm } from "../context/realm-context/RealmContext";
+import { useHistory } from "react-router-dom";
+import { useRealm } from "../context/realm-context/RealmContext";
 
 export const UserFederationKerberosSettings = () => {
-  // const { t } = useTranslation("user-federation");
-  // const history = useHistory();
-  // const { realm } = useRealm();
+  const { t } = useTranslation("user-federation");
+  const history = useHistory();
+  const { realm } = useRealm();
 
   return (
     <>
@@ -24,11 +18,6 @@ export const UserFederationKerberosSettings = () => {
       </PageSection>
       <PageSection variant="light" isFilled>
         <KerberosSettingsCache showSectionHeading />
-        {/* Cache settings
-        <Title size={"xl"} headingLevel={"h2"} className="pf-u-mb-lg">
-          {t("cacheSettings")}
-        </Title>
-        <KerberosSettingsCache />
         <Form>
           <ActionGroup>
             <Button variant="primary" type="submit">
@@ -41,7 +30,7 @@ export const UserFederationKerberosSettings = () => {
               {t("common:cancel")}
             </Button>
           </ActionGroup>
-        </Form> */}
+        </Form>
       </PageSection>
     </>
   );

--- a/src/user-federation/UserFederationKerberosSettings.tsx
+++ b/src/user-federation/UserFederationKerberosSettings.tsx
@@ -56,9 +56,9 @@ export const UserFederationKerberosSettings = () => {
     try {
       await adminClient.components.update({ id }, component);
       setupForm(component as ComponentRepresentation);
-      addAlert(t("roleSaveSuccess"), AlertVariant.success);
+      addAlert(t("saveSuccess"), AlertVariant.success);
     } catch (error) {
-      addAlert(`${t("roleSaveError")} '${error}'`, AlertVariant.danger);
+      addAlert(`${t("saveError")} '${error}'`, AlertVariant.danger);
     }
   };
 

--- a/src/user-federation/UserFederationKerberosSettings.tsx
+++ b/src/user-federation/UserFederationKerberosSettings.tsx
@@ -1,23 +1,74 @@
-import { ActionGroup, Button, Form, PageSection } from "@patternfly/react-core";
+import {
+  ActionGroup,
+  AlertVariant,
+  Button,
+  Form,
+  PageSection,
+} from "@patternfly/react-core";
 import { useTranslation } from "react-i18next";
-import React from "react";
+import React, { useEffect } from "react";
+
 import { KerberosSettingsRequired } from "./kerberos/KerberosSettingsRequired";
 import { KerberosSettingsCache } from "./kerberos/KerberosSettingsCache";
 import { useHistory } from "react-router-dom";
 import { useRealm } from "../context/realm-context/RealmContext";
+import { useParams } from "react-router-dom";
+import { convertToFormValues } from "../util";
+import { useAlerts } from "../components/alert/Alerts";
+import { useAdminClient } from "../context/auth/AdminClient";
+import ComponentRepresentation from "keycloak-admin/lib/defs/componentRepresentation";
+import { useForm } from "react-hook-form";
 
 export const UserFederationKerberosSettings = () => {
   const { t } = useTranslation("user-federation");
+  const form = useForm<ComponentRepresentation>({ mode: "onChange" });
   const history = useHistory();
+  const adminClient = useAdminClient();
   const { realm } = useRealm();
+
+  const { id } = useParams<{ id: string }>();
+
+  const { addAlert } = useAlerts();
+
+  useEffect(() => {
+    (async () => {
+      const fetchedComponent = await adminClient.components.findOne({ id });
+      if (fetchedComponent) {
+        setupForm(fetchedComponent);
+      }
+    })();
+  }, []);
+
+  const setupForm = (component: ComponentRepresentation) => {
+    Object.entries(component).map((entry) => {
+      form.setValue(
+        "config.allowPasswordAuthentication",
+        component.config?.allowPasswordAuthentication
+      );
+      if (entry[0] === "config") {
+        convertToFormValues(entry[1], "config", form.setValue);
+      }
+      form.setValue(entry[0], entry[1]);
+    });
+  };
+
+  const save = async (component: ComponentRepresentation) => {
+    try {
+      await adminClient.components.update({ id }, component);
+      setupForm(component as ComponentRepresentation);
+      addAlert(t("roleSaveSuccess"), AlertVariant.success);
+    } catch (error) {
+      addAlert(`${t("roleSaveError")} '${error}'`, AlertVariant.danger);
+    }
+  };
 
   return (
     <>
       <PageSection variant="light">
-        <KerberosSettingsRequired showSectionHeading />
+        <KerberosSettingsRequired form={form} save={save} showSectionHeading />
       </PageSection>
       <PageSection variant="light" isFilled>
-        <KerberosSettingsCache showSectionHeading />
+        <KerberosSettingsCache form={form} save={save} showSectionHeading />
         <Form>
           <ActionGroup>
             <Button variant="primary" type="submit">

--- a/src/user-federation/UserFederationKerberosSettings.tsx
+++ b/src/user-federation/UserFederationKerberosSettings.tsx
@@ -69,7 +69,7 @@ export const UserFederationKerberosSettings = () => {
       </PageSection>
       <PageSection variant="light" isFilled>
         <KerberosSettingsCache form={form} save={save} showSectionHeading />
-        <Form>
+        <Form onSubmit={form.handleSubmit(save)}>
           <ActionGroup>
             <Button variant="primary" type="submit">
               {t("common:save")}

--- a/src/user-federation/UserFederationKerberosWizard.tsx
+++ b/src/user-federation/UserFederationKerberosWizard.tsx
@@ -14,13 +14,21 @@ export const UserFederationKerberosWizard = () => {
     {
       name: t("requiredSettings"),
       component: (
-        <KerberosSettingsRequired form={form} showSectionHeading showSectionDescription />
+        <KerberosSettingsRequired
+          form={form}
+          showSectionHeading
+          showSectionDescription
+        />
       ),
     },
     {
       name: t("cacheSettings"),
       component: (
-        <KerberosSettingsCache form={form} showSectionHeading showSectionDescription />
+        <KerberosSettingsCache
+          form={form}
+          showSectionHeading
+          showSectionDescription
+        />
       ),
       nextButtonText: t("common:finish"), // TODO: needs to disable until cache policy is valid
     },

--- a/src/user-federation/UserFederationKerberosWizard.tsx
+++ b/src/user-federation/UserFederationKerberosWizard.tsx
@@ -3,21 +3,24 @@ import { useTranslation } from "react-i18next";
 import React from "react";
 import { KerberosSettingsRequired } from "./kerberos/KerberosSettingsRequired";
 import { KerberosSettingsCache } from "./kerberos/KerberosSettingsCache";
+import ComponentRepresentation from "keycloak-admin/lib/defs/componentRepresentation";
+import { useForm } from "react-hook-form";
 
 export const UserFederationKerberosWizard = () => {
   const { t } = useTranslation("user-federation");
+  const form = useForm<ComponentRepresentation>({ mode: "onChange" });
 
   const steps = [
     {
       name: t("requiredSettings"),
       component: (
-        <KerberosSettingsRequired showSectionHeading showSectionDescription />
+        <KerberosSettingsRequired form={form} showSectionHeading showSectionDescription />
       ),
     },
     {
       name: t("cacheSettings"),
       component: (
-        <KerberosSettingsCache showSectionHeading showSectionDescription />
+        <KerberosSettingsCache form={form} showSectionHeading showSectionDescription />
       ),
       nextButtonText: t("common:finish"), // TODO: needs to disable until cache policy is valid
     },

--- a/src/user-federation/kerberos/KerberosSettingsCache.tsx
+++ b/src/user-federation/kerberos/KerberosSettingsCache.tsx
@@ -25,7 +25,6 @@ import { WizardSectionHeader } from "../../components/wizard-section-header/Wiza
 export type KerberosSettingsCacheProps = {
   showSectionHeading?: boolean;
   showSectionDescription?: boolean;
-  // form: UseFormMethods;
 };
 
 export const KerberosSettingsCache = ({

--- a/src/user-federation/kerberos/KerberosSettingsCache.tsx
+++ b/src/user-federation/kerberos/KerberosSettingsCache.tsx
@@ -8,27 +8,19 @@ import {
 import { useTranslation } from "react-i18next";
 import { HelpItem } from "../../components/help-enabler/HelpItem";
 import React, { useState } from "react";
-import {
-  SubmitHandler,
-  UseFormMethods,
-  Controller,
-  useWatch,
-} from "react-hook-form";
-import ComponentRepresentation from "keycloak-admin/lib/defs/componentRepresentation";
+import { UseFormMethods, Controller, useWatch } from "react-hook-form";
 import { FormAccess } from "../../components/form-access/FormAccess";
 import _ from "lodash";
 import { WizardSectionHeader } from "../../components/wizard-section-header/WizardSectionHeader";
 
 export type KerberosSettingsCacheProps = {
   form: UseFormMethods;
-  save: SubmitHandler<ComponentRepresentation>;
   showSectionHeading?: boolean;
   showSectionDescription?: boolean;
 };
 
 export const KerberosSettingsCache = ({
   form,
-  save,
   showSectionHeading = false,
   showSectionDescription = false,
 }: KerberosSettingsCacheProps) => {
@@ -79,11 +71,7 @@ export const KerberosSettingsCache = ({
       )}
 
       {/* Cache settings */}
-      <FormAccess
-        role="manage-realm"
-        isHorizontal
-        onSubmit={form.handleSubmit(save)}
-      >
+      <FormAccess role="manage-realm" isHorizontal>
         <FormGroup
           label={t("cachePolicy")}
           labelIcon={

--- a/src/user-federation/kerberos/KerberosSettingsCache.tsx
+++ b/src/user-federation/kerberos/KerberosSettingsCache.tsx
@@ -288,7 +288,7 @@ export const KerberosSettingsCache = ({
               isRequired
               type="text"
               id="kc-max-lifespan"
-              name="config.maxLifespan"
+              name="config.maxLifespan[0]"
               ref={form.register}
             />
           </FormGroup>

--- a/src/user-federation/kerberos/KerberosSettingsCache.tsx
+++ b/src/user-federation/kerberos/KerberosSettingsCache.tsx
@@ -125,7 +125,7 @@ export const KerberosSettingsCache = ({
           >
             <Controller
               name="config.evictionDay"
-              defaultValue={["Sunday"]}
+              defaultValue={[t("common:Sunday")]}
               control={form.control}
               render={({ onChange, value }) => (
                 <Select

--- a/src/user-federation/kerberos/KerberosSettingsCache.tsx
+++ b/src/user-federation/kerberos/KerberosSettingsCache.tsx
@@ -46,18 +46,16 @@ export const KerberosSettingsCache = ({
     false
   );
 
-  const hourOptions = [
-    <SelectOption key={0} value={t("common:selectOne")} isPlaceholder />,
-  ];
-  for (let index = 1; index <= 24; index++) {
-    hourOptions.push(<SelectOption key={index + 1} value={[`${index}`]} />);
+  const hourOptions = [<SelectOption key={0} value={[`${1}`]} isPlaceholder />];
+  for (let index = 2; index <= 24; index++) {
+    hourOptions.push(<SelectOption key={index - 1} value={[`${index}`]} />);
   }
 
   const minuteOptions = [
-    <SelectOption key={0} value={t("common:selectOne")} isPlaceholder />,
+    <SelectOption key={0} value={[`${1}`]} isPlaceholder />,
   ];
-  for (let index = 1; index <= 60; index++) {
-    minuteOptions.push(<SelectOption key={index + 1} value={[`${index}`]} />);
+  for (let index = 2; index <= 60; index++) {
+    minuteOptions.push(<SelectOption key={index - 1} value={[`${index}`]} />);
   }
 
   return (
@@ -102,16 +100,11 @@ export const KerberosSettingsCache = ({
                 selections={value}
                 variant={SelectVariant.single}
               >
-                <SelectOption
-                  key={0}
-                  value={t("common:selectOne")}
-                  isPlaceholder
-                />
-                <SelectOption key={1} value={["DEFAULT"]} />
-                <SelectOption key={2} value={["EVICT_DAILY"]} />
-                <SelectOption key={3} value={["EVICT_WEEKLY"]} />
-                <SelectOption key={4} value={["MAX_LIFESPAN"]} />
-                <SelectOption key={5} value={["NO_CACHE"]} />
+                <SelectOption key={0} value={["DEFAULT"]} isPlaceholder />
+                <SelectOption key={1} value={["EVICT_DAILY"]} />
+                <SelectOption key={2} value={["EVICT_WEEKLY"]} />
+                <SelectOption key={3} value={["MAX_LIFESPAN"]} />
+                <SelectOption key={4} value={["NO_CACHE"]} />
               </Select>
             )}
           ></Controller>
@@ -127,6 +120,7 @@ export const KerberosSettingsCache = ({
                 forID="kc-eviction-day"
               />
             }
+            isRequired
             fieldId="kc-eviction-day"
           >
             <Controller
@@ -148,30 +142,25 @@ export const KerberosSettingsCache = ({
                   selections={value}
                   variant={SelectVariant.single}
                 >
-                  <SelectOption
-                    key={0}
-                    value={t("common:selectOne")}
-                    isPlaceholder
-                  />
-                  <SelectOption key={1} value={["1"]}>
+                  <SelectOption key={0} value={["1"]} isPlaceholder>
                     {t("common:Sunday")}
                   </SelectOption>
-                  <SelectOption key={2} value={["2"]}>
+                  <SelectOption key={1} value={["2"]}>
                     {t("common:Monday")}
                   </SelectOption>
-                  <SelectOption key={3} value={["3"]}>
+                  <SelectOption key={2} value={["3"]}>
                     {t("common:Tuesday")}
                   </SelectOption>
-                  <SelectOption key={4} value={["4"]}>
+                  <SelectOption key={3} value={["4"]}>
                     {t("common:Wednesday")}
                   </SelectOption>
-                  <SelectOption key={5} value={["5"]}>
+                  <SelectOption key={4} value={["5"]}>
                     {t("common:Thursday")}
                   </SelectOption>
-                  <SelectOption key={6} value={["6"]}>
+                  <SelectOption key={5} value={["6"]}>
                     {t("common:Friday")}
                   </SelectOption>
-                  <SelectOption key={7} value={["7"]}>
+                  <SelectOption key={6} value={["7"]}>
                     {t("common:Saturday")}
                   </SelectOption>
                 </Select>
@@ -194,6 +183,7 @@ export const KerberosSettingsCache = ({
                   forID="kc-eviction-hour"
                 />
               }
+              isRequired
               fieldId="kc-eviction-hour"
             >
               <Controller
@@ -229,6 +219,7 @@ export const KerberosSettingsCache = ({
                   forID="kc-eviction-minute"
                 />
               }
+              isRequired
               fieldId="kc-eviction-minute"
             >
               <Controller
@@ -270,6 +261,7 @@ export const KerberosSettingsCache = ({
                 forID="kc-max-lifespan"
               />
             }
+            isRequired
             fieldId="kc-max-lifespan"
           >
             <TextInput

--- a/src/user-federation/kerberos/KerberosSettingsCache.tsx
+++ b/src/user-federation/kerberos/KerberosSettingsCache.tsx
@@ -83,7 +83,7 @@ export const KerberosSettingsCache = ({
         >
           <Controller
             name="config.cachePolicy"
-            defaultValue=""
+            defaultValue={["DEFAULT"]}
             control={form.control}
             render={({ onChange, value }) => (
               <Select
@@ -125,7 +125,7 @@ export const KerberosSettingsCache = ({
           >
             <Controller
               name="config.evictionDay"
-              defaultValue=""
+              defaultValue={["Sunday"]}
               control={form.control}
               render={({ onChange, value }) => (
                 <Select
@@ -188,7 +188,7 @@ export const KerberosSettingsCache = ({
             >
               <Controller
                 name="config.evictionHour"
-                defaultValue=""
+                defaultValue={["1"]}
                 control={form.control}
                 render={({ onChange, value }) => (
                   <Select
@@ -224,7 +224,7 @@ export const KerberosSettingsCache = ({
             >
               <Controller
                 name="config.evictionMinute"
-                defaultValue=""
+                defaultValue={["1"]}
                 control={form.control}
                 render={({ onChange, value }) => (
                   <Select

--- a/src/user-federation/kerberos/KerberosSettingsCache.tsx
+++ b/src/user-federation/kerberos/KerberosSettingsCache.tsx
@@ -1,5 +1,4 @@
 import {
-  AlertVariant,
   FormGroup,
   Select,
   SelectOption,
@@ -8,72 +7,38 @@ import {
 } from "@patternfly/react-core";
 import { useTranslation } from "react-i18next";
 import { HelpItem } from "../../components/help-enabler/HelpItem";
-import React, { useEffect, useState } from "react";
-import { convertToFormValues } from "../../util";
-import { useForm, Controller, useWatch } from "react-hook-form";
+import React, { useState } from "react";
+import {
+  SubmitHandler,
+  UseFormMethods,
+  Controller,
+  useWatch,
+} from "react-hook-form";
 import ComponentRepresentation from "keycloak-admin/lib/defs/componentRepresentation";
 import { FormAccess } from "../../components/form-access/FormAccess";
-import {
-  useAdminClient,
-  asyncStateFetch,
-} from "../../context/auth/AdminClient";
-import { useParams } from "react-router-dom";
-import { useAlerts } from "../../components/alert/Alerts";
 import _ from "lodash";
 import { WizardSectionHeader } from "../../components/wizard-section-header/WizardSectionHeader";
 
 export type KerberosSettingsCacheProps = {
+  form: UseFormMethods;
+  save: SubmitHandler<ComponentRepresentation>;
   showSectionHeading?: boolean;
   showSectionDescription?: boolean;
 };
 
 export const KerberosSettingsCache = ({
+  form,
+  save,
   showSectionHeading = false,
   showSectionDescription = false,
 }: KerberosSettingsCacheProps) => {
   const { t } = useTranslation("user-federation");
   const helpText = useTranslation("user-federation-help").t;
 
-  const adminClient = useAdminClient();
-  const { register, control, setValue } = useForm<ComponentRepresentation>();
-  const { id } = useParams<{ id: string }>();
-
   const cachePolicyType = useWatch({
-    control: control,
+    control: form.control,
     name: "config.cachePolicy",
   });
-
-  const { addAlert } = useAlerts();
-
-  useEffect(() => {
-    return asyncStateFetch(
-      () => adminClient.components.findOne({ id }),
-      (component) => setupForm(component)
-    );
-  }, []);
-
-  const setupForm = (component: ComponentRepresentation) => {
-    Object.entries(component).map((entry) => {
-      setValue("config.cachePolicy", component.config?.cachePolicy);
-      if (entry[0] === "config") {
-        convertToFormValues(entry[1], "config", setValue);
-      } else {
-        setValue(entry[0], entry[1]);
-      }
-    });
-  };
-
-  const save = async (component: ComponentRepresentation) => {
-    try {
-      await adminClient.components.update({ id }, component);
-      setupForm(component as ComponentRepresentation);
-      addAlert(t("roleSaveSuccess"), AlertVariant.success);
-    } catch (error) {
-      addAlert(`${t("roleSaveError")} '${error}'`, AlertVariant.danger);
-    }
-  };
-
-  const form = useForm<ComponentRepresentation>();
 
   const [isCachePolicyDropdownOpen, setIsCachePolicyDropdownOpen] = useState(
     false
@@ -133,7 +98,7 @@ export const KerberosSettingsCache = ({
           <Controller
             name="config.cachePolicy"
             defaultValue=""
-            control={control}
+            control={form.control}
             render={({ onChange, value }) => (
               <Select
                 toggleId="kc-cache-policy"
@@ -179,7 +144,7 @@ export const KerberosSettingsCache = ({
             <Controller
               name="config.evictionDay"
               defaultValue=""
-              control={control}
+              control={form.control}
               render={({ onChange, value }) => (
                 <Select
                   toggleId="kc-eviction-day"
@@ -246,7 +211,7 @@ export const KerberosSettingsCache = ({
               <Controller
                 name="config.evictionHour"
                 defaultValue=""
-                control={control}
+                control={form.control}
                 render={({ onChange, value }) => (
                   <Select
                     toggleId="kc-eviction-hour"
@@ -281,7 +246,7 @@ export const KerberosSettingsCache = ({
               <Controller
                 name="config.evictionMinute"
                 defaultValue=""
-                control={control}
+                control={form.control}
                 render={({ onChange, value }) => (
                   <Select
                     toggleId="kc-eviction-minute"
@@ -324,7 +289,7 @@ export const KerberosSettingsCache = ({
               type="text"
               id="kc-max-lifespan"
               name="config.maxLifespan"
-              ref={register}
+              ref={form.register}
             />
           </FormGroup>
         ) : (

--- a/src/user-federation/kerberos/KerberosSettingsRequired.tsx
+++ b/src/user-federation/kerberos/KerberosSettingsRequired.tsx
@@ -73,6 +73,36 @@ export const KerberosSettingsRequired = ({
           fieldId="kc-console-display-name"
           isRequired
         >
+          {/* These hidden fields are required so data object written back matches data retrieved */}
+          <TextInput
+            hidden
+            type="text"
+            id="kc-console-display-name"
+            name="id"
+            ref={form.register}
+          />
+          <TextInput
+            hidden
+            type="text"
+            id="kc-console-display-name"
+            name="providerId"
+            ref={form.register}
+          />
+          <TextInput
+            hidden
+            type="text"
+            id="kc-console-display-name"
+            name="providerType"
+            ref={form.register}
+          />
+          <TextInput
+            hidden
+            type="text"
+            id="kc-console-display-name"
+            name="parentId"
+            ref={form.register}
+          />
+
           <TextInput
             isRequired
             type="text"
@@ -98,7 +128,7 @@ export const KerberosSettingsRequired = ({
             isRequired
             type="text"
             id="kc-kerberos-realm"
-            name="config.kerberosRealm"
+            name="config.kerberosRealm[0]"
             ref={form.register}
           />
         </FormGroup>
@@ -119,7 +149,7 @@ export const KerberosSettingsRequired = ({
             isRequired
             type="text"
             id="kc-server-principal"
-            name="config.serverPrincipal"
+            name="config.serverPrincipal[0]"
             ref={form.register}
           />
         </FormGroup>
@@ -140,7 +170,7 @@ export const KerberosSettingsRequired = ({
             isRequired
             type="text"
             id="kc-key-tab"
-            name="config.keyTab"
+            name="config.keyTab[0]"
             ref={form.register}
           />
         </FormGroup>

--- a/src/user-federation/kerberos/KerberosSettingsRequired.tsx
+++ b/src/user-federation/kerberos/KerberosSettingsRequired.tsx
@@ -8,14 +8,8 @@ import {
   TextInput,
 } from "@patternfly/react-core";
 import { useTranslation } from "react-i18next";
-import {
-  SubmitHandler,
-  UseFormMethods,
-  Controller,
-  useWatch,
-} from "react-hook-form";
+import { UseFormMethods, Controller, useWatch } from "react-hook-form";
 
-import ComponentRepresentation from "keycloak-admin/lib/defs/componentRepresentation";
 import { FormAccess } from "../../components/form-access/FormAccess";
 
 import { HelpItem } from "../../components/help-enabler/HelpItem";
@@ -24,14 +18,12 @@ import { WizardSectionHeader } from "../../components/wizard-section-header/Wiza
 
 export type KerberosSettingsRequiredProps = {
   form: UseFormMethods;
-  save: SubmitHandler<ComponentRepresentation>;
   showSectionHeading?: boolean;
   showSectionDescription?: boolean;
 };
 
 export const KerberosSettingsRequired = ({
   form,
-  save,
   showSectionHeading = false,
   showSectionDescription = false,
 }: KerberosSettingsRequiredProps) => {
@@ -56,11 +48,7 @@ export const KerberosSettingsRequired = ({
       )}
 
       {/* Required settings */}
-      <FormAccess
-        role="manage-realm"
-        isHorizontal
-        onSubmit={form.handleSubmit(save)}
-      >
+      <FormAccess role="manage-realm" isHorizontal>
         <FormGroup
           label={t("consoleDisplayName")}
           labelIcon={

--- a/src/user-federation/kerberos/KerberosSettingsRequired.tsx
+++ b/src/user-federation/kerberos/KerberosSettingsRequired.tsx
@@ -96,8 +96,16 @@ export const KerberosSettingsRequired = ({
             type="text"
             id="kc-console-display-name"
             name="name"
-            ref={form.register}
+            ref={form.register({
+              required: {
+                value: true,
+                message: "You must enter a name",
+              },
+            })}
           />
+          {form.errors.name && (
+            <div className="error">{form.errors.name.message}</div>
+          )}
         </FormGroup>
 
         <FormGroup
@@ -117,8 +125,20 @@ export const KerberosSettingsRequired = ({
             type="text"
             id="kc-kerberos-realm"
             name="config.kerberosRealm[0]"
-            ref={form.register}
+            ref={form.register({
+              required: {
+                value: true,
+                message: "You must enter a realm",
+              },
+            })}
           />
+          {form.errors.config &&
+            form.errors.config.kerberosRealm &&
+            form.errors.config.kerberosRealm[0] && (
+              <div className="error">
+                {form.errors.config.kerberosRealm[0].message}
+              </div>
+            )}
         </FormGroup>
 
         <FormGroup
@@ -138,8 +158,20 @@ export const KerberosSettingsRequired = ({
             type="text"
             id="kc-server-principal"
             name="config.serverPrincipal[0]"
-            ref={form.register}
+            ref={form.register({
+              required: {
+                value: true,
+                message: "You must enter a server principal",
+              },
+            })}
           />
+          {form.errors.config &&
+            form.errors.config.serverPrincipal &&
+            form.errors.config.serverPrincipal[0] && (
+              <div className="error">
+                {form.errors.config.serverPrincipal[0].message}
+              </div>
+            )}
         </FormGroup>
 
         <FormGroup
@@ -159,8 +191,20 @@ export const KerberosSettingsRequired = ({
             type="text"
             id="kc-key-tab"
             name="config.keyTab[0]"
-            ref={form.register}
+            ref={form.register({
+              required: {
+                value: true,
+                message: "You must enter a key tab",
+              },
+            })}
           />
+          {form.errors.config &&
+            form.errors.config.keyTab &&
+            form.errors.config.keyTab[0] && (
+              <div className="error">
+                {form.errors.config.keyTab[0].message}
+              </div>
+            )}
         </FormGroup>
 
         <FormGroup
@@ -232,13 +276,15 @@ export const KerberosSettingsRequired = ({
                 forID="kc-edit-mode"
               />
             }
+            isRequired
             fieldId="kc-edit-mode"
           >
             {" "}
             <Controller
-              name="config.editMode"
-              defaultValue={t("common:selectOne")}
+              name="config.editMode[0]"
+              defaultValue="READ_ONLY"
               control={form.control}
+              rules={{ required: true }}
               render={({ onChange, value }) => (
                 <Select
                   toggleId="kc-edit-mode"
@@ -254,13 +300,8 @@ export const KerberosSettingsRequired = ({
                   selections={value}
                   variant={SelectVariant.single}
                 >
-                  <SelectOption
-                    key={0}
-                    value={t("common:selectOne")}
-                    isPlaceholder
-                  />
-                  <SelectOption key={1} value="READ_ONLY" />
-                  <SelectOption key={2} value="UNSYNCED" />
+                  <SelectOption key={0} value="READ_ONLY" isPlaceholder />
+                  <SelectOption key={1} value="UNSYNCED" />
                 </Select>
               )}
             ></Controller>

--- a/src/user-federation/kerberos/KerberosSettingsRequired.tsx
+++ b/src/user-federation/kerberos/KerberosSettingsRequired.tsx
@@ -1,6 +1,5 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import {
-  AlertVariant,
   FormGroup,
   Select,
   SelectOption,
@@ -9,74 +8,42 @@ import {
   TextInput,
 } from "@patternfly/react-core";
 import { useTranslation } from "react-i18next";
-import { HelpItem } from "../../components/help-enabler/HelpItem";
-import { useForm, Controller, useWatch } from "react-hook-form";
+import {
+  SubmitHandler,
+  UseFormMethods,
+  Controller,
+  useWatch,
+} from "react-hook-form";
+
 import ComponentRepresentation from "keycloak-admin/lib/defs/componentRepresentation";
 import { FormAccess } from "../../components/form-access/FormAccess";
-import { useAdminClient } from "../../context/auth/AdminClient";
-import { useParams } from "react-router-dom";
-import { convertToFormValues } from "../../util";
-import { useAlerts } from "../../components/alert/Alerts";
+
+import { HelpItem } from "../../components/help-enabler/HelpItem";
 import _ from "lodash";
 import { WizardSectionHeader } from "../../components/wizard-section-header/WizardSectionHeader";
 
 export type KerberosSettingsRequiredProps = {
+  form: UseFormMethods;
+  save: SubmitHandler<ComponentRepresentation>;
   showSectionHeading?: boolean;
   showSectionDescription?: boolean;
 };
 
 export const KerberosSettingsRequired = ({
+  form,
+  save,
   showSectionHeading = false,
   showSectionDescription = false,
 }: KerberosSettingsRequiredProps) => {
   const { t } = useTranslation("user-federation");
   const helpText = useTranslation("user-federation-help").t;
 
-  const adminClient = useAdminClient();
   const [isEditModeDropdownOpen, setIsEditModeDropdownOpen] = useState(false);
-  const { register, control, setValue } = useForm<ComponentRepresentation>();
-  const { id } = useParams<{ id: string }>();
 
   const allowPassAuth = useWatch({
-    control: control,
+    control: form.control,
     name: "config.allowPasswordAuthentication",
   });
-
-  const { addAlert } = useAlerts();
-
-  useEffect(() => {
-    (async () => {
-      const fetchedComponent = await adminClient.components.findOne({ id });
-      if (fetchedComponent) {
-        setupForm(fetchedComponent);
-      }
-    })();
-  }, []);
-
-  const setupForm = (component: ComponentRepresentation) => {
-    Object.entries(component).map((entry) => {
-      setValue(
-        "config.allowPasswordAuthentication",
-        component.config?.allowPasswordAuthentication
-      );
-      if (entry[0] === "config") {
-        convertToFormValues(entry[1], "config", setValue);
-      }
-      setValue(entry[0], entry[1]);
-    });
-  };
-
-  const save = async (component: ComponentRepresentation) => {
-    try {
-      await adminClient.components.update({ id }, component);
-      setupForm(component as ComponentRepresentation);
-      addAlert(t("roleSaveSuccess"), AlertVariant.success);
-    } catch (error) {
-      addAlert(`${t("roleSaveError")} '${error}'`, AlertVariant.danger);
-    }
-  };
-
-  const form = useForm<ComponentRepresentation>();
 
   return (
     <>
@@ -111,7 +78,7 @@ export const KerberosSettingsRequired = ({
             type="text"
             id="kc-console-display-name"
             name="name"
-            ref={register}
+            ref={form.register}
           />
         </FormGroup>
 
@@ -132,7 +99,7 @@ export const KerberosSettingsRequired = ({
             type="text"
             id="kc-kerberos-realm"
             name="config.kerberosRealm"
-            ref={register}
+            ref={form.register}
           />
         </FormGroup>
 
@@ -153,7 +120,7 @@ export const KerberosSettingsRequired = ({
             type="text"
             id="kc-server-principal"
             name="config.serverPrincipal"
-            ref={register}
+            ref={form.register}
           />
         </FormGroup>
 
@@ -174,7 +141,7 @@ export const KerberosSettingsRequired = ({
             type="text"
             id="kc-key-tab"
             name="config.keyTab"
-            ref={register}
+            ref={form.register}
           />
         </FormGroup>
 
@@ -194,7 +161,7 @@ export const KerberosSettingsRequired = ({
           <Controller
             name="config.debug"
             defaultValue={false}
-            control={control}
+            control={form.control}
             render={({ onChange, value }) => (
               <Switch
                 id={"kc-debug"}
@@ -223,7 +190,7 @@ export const KerberosSettingsRequired = ({
           <Controller
             name="config.allowPasswordAuthentication"
             defaultValue={false}
-            control={control}
+            control={form.control}
             render={({ onChange, value }) => (
               <Switch
                 id={"kc-allow-password-authentication"}
@@ -253,7 +220,7 @@ export const KerberosSettingsRequired = ({
             <Controller
               name="config.editMode"
               defaultValue={t("common:selectOne")}
-              control={control}
+              control={form.control}
               render={({ onChange, value }) => (
                 <Select
                   toggleId="kc-edit-mode"
@@ -299,7 +266,7 @@ export const KerberosSettingsRequired = ({
           <Controller
             name="config.updateProfileFirstLogin"
             defaultValue={false}
-            control={control}
+            control={form.control}
             render={({ onChange, value }) => (
               <Switch
                 id={"kc-update-first-login"}

--- a/src/user-federation/kerberos/KerberosSettingsRequired.tsx
+++ b/src/user-federation/kerberos/KerberosSettingsRequired.tsx
@@ -65,28 +65,28 @@ export const KerberosSettingsRequired = ({
           <TextInput
             hidden
             type="text"
-            id="kc-console-display-name"
+            id="kc-console-id"
             name="id"
             ref={form.register}
           />
           <TextInput
             hidden
             type="text"
-            id="kc-console-display-name"
+            id="kc-console-providerId"
             name="providerId"
             ref={form.register}
           />
           <TextInput
             hidden
             type="text"
-            id="kc-console-display-name"
+            id="kc-console-providerType"
             name="providerType"
             ref={form.register}
           />
           <TextInput
             hidden
             type="text"
-            id="kc-console-display-name"
+            id="kc-console-parentId"
             name="parentId"
             ref={form.register}
           />
@@ -94,7 +94,7 @@ export const KerberosSettingsRequired = ({
           <TextInput
             isRequired
             type="text"
-            id="kc-console-display-name"
+            id="kc-console-name"
             name="name"
             ref={form.register({
               required: {

--- a/src/user-federation/kerberos/KerberosSettingsRequired.tsx
+++ b/src/user-federation/kerberos/KerberosSettingsRequired.tsx
@@ -99,7 +99,7 @@ export const KerberosSettingsRequired = ({
             ref={form.register({
               required: {
                 value: true,
-                message: "You must enter a name",
+                message: `${t("validateName")}`,
               },
             })}
           />
@@ -128,7 +128,7 @@ export const KerberosSettingsRequired = ({
             ref={form.register({
               required: {
                 value: true,
-                message: "You must enter a realm",
+                message: `${t("validateRealm")}`,
               },
             })}
           />
@@ -161,7 +161,7 @@ export const KerberosSettingsRequired = ({
             ref={form.register({
               required: {
                 value: true,
-                message: "You must enter a server principal",
+                message: `${t("validateServerPrincipal")}`,
               },
             })}
           />
@@ -194,7 +194,7 @@ export const KerberosSettingsRequired = ({
             ref={form.register({
               required: {
                 value: true,
-                message: "You must enter a key tab",
+                message: `${t("validateKeyTab")}`,
               },
             })}
           />

--- a/src/user-federation/kerberos/KerberosSettingsRequired.tsx
+++ b/src/user-federation/kerberos/KerberosSettingsRequired.tsx
@@ -7,7 +7,6 @@ import {
   SelectVariant,
   Switch,
   TextInput,
-  // Title,
 } from "@patternfly/react-core";
 import { useTranslation } from "react-i18next";
 import { HelpItem } from "../../components/help-enabler/HelpItem";
@@ -24,14 +23,12 @@ import { WizardSectionHeader } from "../../components/wizard-section-header/Wiza
 export type KerberosSettingsRequiredProps = {
   showSectionHeading?: boolean;
   showSectionDescription?: boolean;
-  // form: UseFormMethods;
 };
 
 export const KerberosSettingsRequired = ({
   showSectionHeading = false,
   showSectionDescription = false,
 }: KerberosSettingsRequiredProps) => {
-
   const { t } = useTranslation("user-federation");
   const helpText = useTranslation("user-federation-help").t;
 

--- a/src/user-federation/messages.json
+++ b/src/user-federation/messages.json
@@ -78,6 +78,9 @@
     "oneLevel": "One Level",
     "subtree": "Subtree",
 
+    "saveSuccess": "User federation successfully saved",
+    "saveError": "User federation could not be saved: {error}",
+
     "learnMore": "Learn more",
     "addNewProvider": "Add new provider",
     "userFedDeletedSuccess": "The user federation provider has been deleted.",

--- a/src/user-federation/messages.json
+++ b/src/user-federation/messages.json
@@ -88,8 +88,12 @@
     "userFedDeleteConfirmTitle": "Delete user federation provider?",
     "userFedDeleteConfirm": "If you delete this user federation provider, all associated data will be removed.",
 
-    "id": "ID",
+    "validateName": "You must enter a name",
+    "validateRealm":"You must enter a realm",
+    "validateServerPrincipal":"You must enter a server principal",
+    "validateKeyTab": "You must enter a key tab",
 
+    "id": "ID",
     "mapperType": "Mapper type",
     "mapperTypeMsadUserAccountControlManager": "msad-user-account-control-mapper",
     "mapperTypeMsadLdsUserAccountControlMapper": "msad-user-account-control-mapper",

--- a/src/user-federation/user-federation.css
+++ b/src/user-federation/user-federation.css
@@ -5,3 +5,7 @@
 .keycloak-admin--user-federation__gallery-item {
   display: contents;
 }
+
+.error {
+  color: red;
+}


### PR DESCRIPTION
## Motivation
https://issues.redhat.com/browse/APPDUX-721

## Brief Description
Adds the ability to save (or cancel) changes made to the User Federation Kerberos settings page.

## Verification Steps
1. Go to User federation and select a Kerberos card.
2. Change any of the values in the Required Settings or Cache Settings sections.
3. Click Save. You should see a success alert.
4. Verify that the changes have been saved by traversing anywhere else in the UI and then re-clicking the card to make sure the values that were changed are displayed correctly.

## Checklist:
- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [x] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated
- [x] Formatting has been performed via prettier/eslint
- [ ] Type checking has been performed via 'yarn check-types'

## Additional Notes
Screen cap of successful save:
![kerberos-save-success](https://user-images.githubusercontent.com/39063664/104776853-b91ed700-5748-11eb-8f2d-f7f62da96e41.png)
