### PR TITLE
Add Save/Cancel buttons and logic to LDAP settings

### DIFF
--- a/src/user-federation/UserFederationLdapSettings.tsx
+++ b/src/user-federation/UserFederationLdapSettings.tsx
@@ -41,8 +41,6 @@ export const UserFederationLdapSettings = () => {
       const fetchedComponent = await adminClient.components.findOne({ id });
       if (fetchedComponent) {
         setupForm(fetchedComponent);
-        console.log(`COMPONENT PULLED IN`);
-        console.log(fetchedComponent);
       }
     })();
   }, []);
@@ -58,9 +56,6 @@ export const UserFederationLdapSettings = () => {
   };
 
   const save = async (component: ComponentRepresentation) => {
-    console.log(`COMPONENT SAVED OUT`);
-    console.log(component);
-
     try {
       await adminClient.components.update({ id }, component);
       setupForm(component as ComponentRepresentation);

--- a/src/user-federation/UserFederationLdapSettings.tsx
+++ b/src/user-federation/UserFederationLdapSettings.tsx
@@ -1,7 +1,13 @@
-import { PageSection } from "@patternfly/react-core";
+import {
+  ActionGroup,
+  AlertVariant,
+  Button,
+  Form,
+  PageSection,
+} from "@patternfly/react-core";
 import { useTranslation } from "react-i18next";
-import React from "react";
-import { ScrollForm } from "../components/scroll-form/ScrollForm";
+import React, { useEffect } from "react";
+
 import { LdapSettingsAdvanced } from "./ldap/LdapSettingsAdvanced";
 import { LdapSettingsKerberosIntegration } from "./ldap/LdapSettingsKerberosIntegration";
 import { LdapSettingsCache } from "./ldap/LdapSettingsCache";
@@ -9,9 +15,142 @@ import { LdapSettingsSynchronization } from "./ldap/LdapSettingsSynchronization"
 import { LdapSettingsGeneral } from "./ldap/LdapSettingsGeneral";
 import { LdapSettingsConnection } from "./ldap/LdapSettingsConnection";
 import { LdapSettingsSearching } from "./ldap/LdapSettingsSearching";
+import { ScrollForm } from "../components/scroll-form/ScrollForm";
+
+import { useHistory, useParams } from "react-router-dom";
+import { useRealm } from "../context/realm-context/RealmContext";
+import { convertToFormValues } from "../util";
+import { useAlerts } from "../components/alert/Alerts";
+import { useAdminClient } from "../context/auth/AdminClient";
+import ComponentRepresentation from "keycloak-admin/lib/defs/componentRepresentation";
+
+import { useForm } from "react-hook-form";
 
 export const UserFederationLdapSettings = () => {
   const { t } = useTranslation("user-federation");
+  const form = useForm<ComponentRepresentation>();
+  const history = useHistory();
+  const adminClient = useAdminClient();
+  const { realm } = useRealm();
+
+  const { id } = useParams<{ id: string }>();
+
+  const { addAlert } = useAlerts();
+
+  // const { control, setValue } = useForm<ComponentRepresentation>();
+
+  const convertToDays = (num: string) => {
+    switch (num) {
+      case "1":
+        return t("common:Sunday");
+      case "2":
+        return t("common:Monday");
+      case "3":
+        return t("common:Tuesday");
+      case "4":
+        return t("common:Wednesday");
+      case "5":
+        return t("common:Thursday");
+      case "6":
+        return t("common:Friday");
+      case "7":
+        return t("common:Saturday");
+      default:
+        return t("common:selectOne");
+    }
+  };
+
+  const convertVendorNames = (vendorName: string) => {
+    switch (vendorName) {
+      case "ad":
+        return "Active Directory";
+      case "rhds":
+        return "Red Hat Directory Server";
+      case "tivoli":
+        return "Tivoli";
+      case "edirectory":
+        return "Novell eDirectory";
+      case "other":
+        return "Other";
+      default:
+        return t("common:choose");
+    }
+  };
+
+  const convertSearchScopes = (scope: string) => {
+    switch (scope) {
+      case "1":
+      default:
+        return `${t("oneLevel")}`;
+      case "2":
+        return `${t("subtree")}`;
+    }
+  };
+
+  const convertTruststoreSpiValues = (truststoreValue: string) => {
+    switch (truststoreValue) {
+      case "always":
+        return `${t("always")}`;
+      case "never":
+        return `${t("never")}`;
+      case "ldapsOnly":
+      default:
+        return `${t("onlyLdaps")}`;
+    }
+  };
+
+  useEffect(() => {
+    (async () => {
+      const fetchedComponent = await adminClient.components.findOne({ id });
+      if (fetchedComponent) {
+        setupForm(fetchedComponent);
+      }
+    })();
+  }, []);
+
+  const setupForm = (component: ComponentRepresentation) => {
+    Object.entries(component).map((entry) => {
+      if (entry[0] === "config") {
+        convertToFormValues(entry[1], "config", form.setValue);
+        if (entry[1].evictionDay) {
+          form.setValue(
+            "config.evictionDay",
+            convertToDays(entry[1].evictionDay[0])
+          );
+        }
+        if (entry[1].vendor) {
+          form.setValue(
+            "config.vendor",
+            convertVendorNames(entry[1].vendor[0])
+          );
+        }
+        if (entry[1].searchScope) {
+          form.setValue(
+            "config.searchScope",
+            convertSearchScopes(entry[1].searchScope[0])
+          );
+        }
+        if (entry[1].useTruststoreSpi) {
+          form.setValue(
+            "config.useTruststoreSpi",
+            convertTruststoreSpiValues(entry[1].useTruststoreSpi[0])
+          );
+        }
+      } else {
+        form.setValue(entry[0], entry[1]);
+      }
+    });
+  };
+
+  const save = async (component: ComponentRepresentation) => {
+    try {
+      await adminClient.components.update({ id }, component);
+      setupForm(component as ComponentRepresentation);
+      addAlert(t("saveSuccess"), AlertVariant.success);
+    } catch (error) {
+      addAlert(`${t("saveError")} '${error}'`, AlertVariant.danger);
+    }
+  };
 
   return (
     <>
@@ -27,27 +166,27 @@ export const UserFederationLdapSettings = () => {
             t("advancedSettings"),
           ]}
         >
-          {/* General settings */}
-          <LdapSettingsGeneral />
-
-          {/* Connection settings */}
-          <LdapSettingsConnection />
-
-          {/* Searching and updating settings */}
-          <LdapSettingsSearching />
-
-          {/* Synchronization settings */}
-          <LdapSettingsSynchronization />
-
-          {/* Kerberos integration */}
-          <LdapSettingsKerberosIntegration />
-
-          {/* Cache settings */}
-          <LdapSettingsCache />
-
-          {/* Advanced settings */}
-          <LdapSettingsAdvanced />
+          <LdapSettingsGeneral form={form} />
+          <LdapSettingsConnection form={form} />
+          <LdapSettingsSearching form={form} />
+          <LdapSettingsSynchronization form={form} />
+          <LdapSettingsKerberosIntegration form={form} />
+          <LdapSettingsCache form={form} />
+          <LdapSettingsAdvanced form={form} />
         </ScrollForm>
+        <Form onSubmit={form.handleSubmit(save)}>
+          <ActionGroup>
+            <Button variant="primary" type="submit">
+              {t("common:save")}
+            </Button>
+            <Button
+              variant="link"
+              onClick={() => history.push(`/${realm}/user-federation`)}
+            >
+              {t("common:cancel")}
+            </Button>
+          </ActionGroup>
+        </Form>
       </PageSection>
     </>
   );

--- a/src/user-federation/UserFederationLdapSettings.tsx
+++ b/src/user-federation/UserFederationLdapSettings.tsx
@@ -36,50 +36,13 @@ export const UserFederationLdapSettings = () => {
   const { id } = useParams<{ id: string }>();
   const { addAlert } = useAlerts();
 
-  const convertVendorNames = (vendorName: string) => {
-    switch (vendorName) {
-      case "ad":
-        return "Active Directory";
-      case "rhds":
-        return "Red Hat Directory Server";
-      case "tivoli":
-        return "Tivoli";
-      case "edirectory":
-        return "Novell eDirectory";
-      case "other":
-        return "Other";
-      default:
-        return t("common:choose");
-    }
-  };
-
-  const convertSearchScopes = (scope: string) => {
-    switch (scope) {
-      case "1":
-      default:
-        return `${t("oneLevel")}`;
-      case "2":
-        return `${t("subtree")}`;
-    }
-  };
-
-  const convertTruststoreSpiValues = (truststoreValue: string) => {
-    switch (truststoreValue) {
-      case "always":
-        return `${t("always")}`;
-      case "never":
-        return `${t("never")}`;
-      case "ldapsOnly":
-      default:
-        return `${t("onlyLdaps")}`;
-    }
-  };
-
   useEffect(() => {
     (async () => {
       const fetchedComponent = await adminClient.components.findOne({ id });
       if (fetchedComponent) {
         setupForm(fetchedComponent);
+        console.log(`COMPONENT PULLED IN`);
+        console.log(fetchedComponent);
       }
     })();
   }, []);
@@ -88,24 +51,6 @@ export const UserFederationLdapSettings = () => {
     Object.entries(component).map((entry) => {
       if (entry[0] === "config") {
         convertToFormValues(entry[1], "config", form.setValue);
-        if (entry[1].vendor) {
-          form.setValue(
-            "config.vendor",
-            convertVendorNames(entry[1].vendor[0])
-          );
-        }
-        if (entry[1].searchScope) {
-          form.setValue(
-            "config.searchScope",
-            convertSearchScopes(entry[1].searchScope[0])
-          );
-        }
-        if (entry[1].useTruststoreSpi) {
-          form.setValue(
-            "config.useTruststoreSpi",
-            convertTruststoreSpiValues(entry[1].useTruststoreSpi[0])
-          );
-        }
       } else {
         form.setValue(entry[0], entry[1]);
       }
@@ -113,6 +58,9 @@ export const UserFederationLdapSettings = () => {
   };
 
   const save = async (component: ComponentRepresentation) => {
+    console.log(`COMPONENT SAVED OUT`);
+    console.log(component);
+
     try {
       await adminClient.components.update({ id }, component);
       setupForm(component as ComponentRepresentation);

--- a/src/user-federation/UserFederationLdapSettings.tsx
+++ b/src/user-federation/UserFederationLdapSettings.tsx
@@ -34,31 +34,7 @@ export const UserFederationLdapSettings = () => {
   const { realm } = useRealm();
 
   const { id } = useParams<{ id: string }>();
-
   const { addAlert } = useAlerts();
-
-  // const { control, setValue } = useForm<ComponentRepresentation>();
-
-  const convertToDays = (num: string) => {
-    switch (num) {
-      case "1":
-        return t("common:Sunday");
-      case "2":
-        return t("common:Monday");
-      case "3":
-        return t("common:Tuesday");
-      case "4":
-        return t("common:Wednesday");
-      case "5":
-        return t("common:Thursday");
-      case "6":
-        return t("common:Friday");
-      case "7":
-        return t("common:Saturday");
-      default:
-        return t("common:selectOne");
-    }
-  };
 
   const convertVendorNames = (vendorName: string) => {
     switch (vendorName) {
@@ -112,12 +88,6 @@ export const UserFederationLdapSettings = () => {
     Object.entries(component).map((entry) => {
       if (entry[0] === "config") {
         convertToFormValues(entry[1], "config", form.setValue);
-        if (entry[1].evictionDay) {
-          form.setValue(
-            "config.evictionDay",
-            convertToDays(entry[1].evictionDay[0])
-          );
-        }
         if (entry[1].vendor) {
           form.setValue(
             "config.vendor",

--- a/src/user-federation/UserFederationLdapWizard.tsx
+++ b/src/user-federation/UserFederationLdapWizard.tsx
@@ -13,8 +13,12 @@ import { LdapSettingsKerberosIntegration } from "./ldap/LdapSettingsKerberosInte
 import { LdapSettingsCache } from "./ldap/LdapSettingsCache";
 import { LdapSettingsAdvanced } from "./ldap/LdapSettingsAdvanced";
 import { useTranslation } from "react-i18next";
+import ComponentRepresentation from "keycloak-admin/lib/defs/componentRepresentation";
+
+import { useForm } from "react-hook-form";
 
 export const UserFederationLdapWizard = () => {
+  const form = useForm<ComponentRepresentation>();
   const { t } = useTranslation("user-federation");
 
   const steps = [
@@ -22,21 +26,33 @@ export const UserFederationLdapWizard = () => {
       name: t("requiredSettings"),
       id: "ldapRequiredSettingsStep",
       component: (
-        <LdapSettingsGeneral showSectionHeading showSectionDescription />
+        <LdapSettingsGeneral
+          form={form}
+          showSectionHeading
+          showSectionDescription
+        />
       ),
     },
     {
       name: t("connectionAndAuthenticationSettings"),
       id: "ldapConnectionSettingsStep",
       component: (
-        <LdapSettingsConnection showSectionHeading showSectionDescription />
+        <LdapSettingsConnection
+          form={form}
+          showSectionHeading
+          showSectionDescription
+        />
       ),
     },
     {
       name: t("ldapSearchingAndUpdatingSettings"),
       id: "ldapSearchingSettingsStep",
       component: (
-        <LdapSettingsSearching showSectionHeading showSectionDescription />
+        <LdapSettingsSearching
+          form={form}
+          showSectionHeading
+          showSectionDescription
+        />
       ),
     },
     {
@@ -44,6 +60,7 @@ export const UserFederationLdapWizard = () => {
       id: "ldapSynchronizationSettingsStep",
       component: (
         <LdapSettingsSynchronization
+          form={form}
           showSectionHeading
           showSectionDescription
         />
@@ -54,6 +71,7 @@ export const UserFederationLdapWizard = () => {
       id: "ldapKerberosIntegrationSettingsStep",
       component: (
         <LdapSettingsKerberosIntegration
+          form={form}
           showSectionHeading
           showSectionDescription
         />
@@ -63,14 +81,22 @@ export const UserFederationLdapWizard = () => {
       name: t("cacheSettings"),
       id: "ldapCacheSettingsStep",
       component: (
-        <LdapSettingsCache showSectionHeading showSectionDescription />
+        <LdapSettingsCache
+          form={form}
+          showSectionHeading
+          showSectionDescription
+        />
       ),
     },
     {
       name: t("advancedSettings"),
       id: "ldapAdvancedSettingsStep",
       component: (
-        <LdapSettingsAdvanced showSectionHeading showSectionDescription />
+        <LdapSettingsAdvanced
+          form={form}
+          showSectionHeading
+          showSectionDescription
+        />
       ),
     },
   ];

--- a/src/user-federation/help.json
+++ b/src/user-federation/help.json
@@ -9,7 +9,7 @@
 
     "ldapConnectionAndAuthorizationSettingsDescription": "This section contains options related to the configuration of the connection to the LDAP server. It also contains options related to authentication of the LDAP connection to the LDAP server.",
     "consoleDisplayConnectionUrlHelp": "Connection URL to your LDAP server",
-    "enableStarttlsHelp": "Encrypts the connection to LDAP using STARTTLS, which will disable connection pooling",
+    "enableStartTlsHelp": "Encrypts the connection to LDAP using STARTTLS, which will disable connection pooling",
     "useTruststoreSpiHelp": "Specifies whether LDAP connection will use the Truststore SPI with the truststore configured in standalone.xml/domain.sml. 'Always' means that it will always use it. 'Never' means that it will not use it. 'Only for ldaps' means that it will use it if your connection URL use ldaps. Note that even if standalone.xml/domain.xml is not configured, the default java cacerts or certificate specified by 'javax.net.ssl.trustStore' property will be used.",
     "connectionPoolingHelp": "Determines if Keycloak should use connection pooling for accessing LDAP server.",
     "connectionTimeoutHelp": "LDAP connection timeout in milliseconds",
@@ -30,7 +30,7 @@
     "paginationHelp": "Whether the LDAP server supports pagination",
 
     "ldapSynchronizationSettingsDescription": "This section contains options related to synchronization of users from LDAP to the Keycloak database.",
-    "importUsersHelp": "Import users",
+    "importUsersHelp": "If true, LDAP users will be imported into the Keycloak DB and synced by the configured sync policies.",
     "batchSizeHelp": "Count of LDAP users to be imported from LDAP to Keycloak within a single transaction",
     "periodicFullSyncHelp": "Whether periodic full synchronization of LDAP users to Keycloak should be enabled or not",
     "fullSyncPeriodHelp": "Period for full synchronization in seconds",

--- a/src/user-federation/help.json
+++ b/src/user-federation/help.json
@@ -33,7 +33,9 @@
     "importUsersHelp": "Import users",
     "batchSizeHelp": "Count of LDAP users to be imported from LDAP to Keycloak within a single transaction",
     "periodicFullSyncHelp": "Whether periodic full synchronization of LDAP users to Keycloak should be enabled or not",
+    "fullSyncPeriodHelp": "Period for full synchronization in seconds",
     "periodicChangedUsersSyncHelp": "Whether periodic synchronization of changed or newly created LDAP users to Keycloak should be enabled or not",
+    "changedUsersSyncHelp": "Period for synchronization of changed or newly created LDAP users in seconds",
 
     "ldapKerberosSettingsDescription": "This section contains options useful for the Kerberos integration. This is used only when the LDAP server is used together with Kerberos/SPNEGO for user authentication.",
     "allowKerberosAuthenticationHelp": "Enable/disable HTTP authentication of users with SPNEGO/Kerberos tokens. The data about authenticated users will be provisioned from this LDAP server.",

--- a/src/user-federation/ldap/LdapSettingsAdvanced.tsx
+++ b/src/user-federation/ldap/LdapSettingsAdvanced.tsx
@@ -45,7 +45,7 @@ export const LdapSettingsAdvanced = ({
         >
           <Controller
             name="config.usePasswordModifyExtendedOp"
-            defaultValue={"false"}
+            defaultValue={["false"]}
             control={form.control}
             render={({ onChange, value }) => (
               <Switch

--- a/src/user-federation/ldap/LdapSettingsAdvanced.tsx
+++ b/src/user-federation/ldap/LdapSettingsAdvanced.tsx
@@ -44,7 +44,7 @@ export const LdapSettingsAdvanced = ({
           hasNoPaddingTop
         >
           <Controller
-            name="config.usePasswordModifyExtendedOp[0]"
+            name="config.usePasswordModifyExtendedOp"
             defaultValue={"false"}
             control={form.control}
             render={({ onChange, value }) => (

--- a/src/user-federation/ldap/LdapSettingsAdvanced.tsx
+++ b/src/user-federation/ldap/LdapSettingsAdvanced.tsx
@@ -44,8 +44,8 @@ export const LdapSettingsAdvanced = ({
           hasNoPaddingTop
         >
           <Controller
-            name="config.usePasswordModifyExtendedOp"
-            defaultValue={false}
+            name="config.usePasswordModifyExtendedOp[0]"
+            defaultValue={"false"}
             control={form.control}
             render={({ onChange, value }) => (
               <Switch
@@ -74,7 +74,7 @@ export const LdapSettingsAdvanced = ({
         >
           <Controller
             name="config.validatePasswordPolicy"
-            defaultValue={false}
+            defaultValue={"false"}
             control={form.control}
             render={({ onChange, value }) => (
               <Switch
@@ -103,7 +103,7 @@ export const LdapSettingsAdvanced = ({
         >
           <Controller
             name="config.trustEmail"
-            defaultValue={false}
+            defaultValue={"false"}
             control={form.control}
             render={({ onChange, value }) => (
               <Switch

--- a/src/user-federation/ldap/LdapSettingsAdvanced.tsx
+++ b/src/user-federation/ldap/LdapSettingsAdvanced.tsx
@@ -1,49 +1,24 @@
 import { FormGroup, Switch } from "@patternfly/react-core";
 import { useTranslation } from "react-i18next";
-import React, { useEffect } from "react";
+import React from "react";
 import { HelpItem } from "../../components/help-enabler/HelpItem";
-import { useForm, Controller } from "react-hook-form";
-import { convertToFormValues } from "../../util";
-import ComponentRepresentation from "keycloak-admin/lib/defs/componentRepresentation";
+import { UseFormMethods, Controller } from "react-hook-form";
 import { FormAccess } from "../../components/form-access/FormAccess";
-import {
-  useAdminClient,
-  asyncStateFetch,
-} from "../../context/auth/AdminClient";
-import { useParams } from "react-router-dom";
 import { WizardSectionHeader } from "../../components/wizard-section-header/WizardSectionHeader";
 
 export type LdapSettingsAdvancedProps = {
+  form: UseFormMethods;
   showSectionHeading?: boolean;
   showSectionDescription?: boolean;
 };
 
 export const LdapSettingsAdvanced = ({
+  form,
   showSectionHeading = false,
   showSectionDescription = false,
 }: LdapSettingsAdvancedProps) => {
   const { t } = useTranslation("user-federation");
   const helpText = useTranslation("user-federation-help").t;
-  const adminClient = useAdminClient();
-  const { control, setValue } = useForm<ComponentRepresentation>();
-  const { id } = useParams<{ id: string }>();
-
-  const setupForm = (component: ComponentRepresentation) => {
-    Object.entries(component).map((entry) => {
-      if (entry[0] === "config") {
-        convertToFormValues(entry[1], "config", setValue);
-      } else {
-        setValue(entry[0], entry[1]);
-      }
-    });
-  };
-
-  useEffect(() => {
-    return asyncStateFetch(
-      () => adminClient.components.findOne({ id }),
-      (fetchedComponent) => setupForm(fetchedComponent)
-    );
-  }, []);
 
   return (
     <>
@@ -71,13 +46,13 @@ export const LdapSettingsAdvanced = ({
           <Controller
             name="config.usePasswordModifyExtendedOp"
             defaultValue={false}
-            control={control}
+            control={form.control}
             render={({ onChange, value }) => (
               <Switch
                 id={"kc-enable-ldapv3-password"}
-                isChecked={value[0] === "true"}
                 isDisabled={false}
-                onChange={onChange}
+                onChange={(value) => onChange([`${value}`])}
+                isChecked={value[0] === "true"}
                 label={t("common:on")}
                 labelOff={t("common:off")}
               />
@@ -100,13 +75,13 @@ export const LdapSettingsAdvanced = ({
           <Controller
             name="config.validatePasswordPolicy"
             defaultValue={false}
-            control={control}
+            control={form.control}
             render={({ onChange, value }) => (
               <Switch
                 id={"kc-validate-password-policy"}
-                isChecked={value[0] === "true"}
                 isDisabled={false}
-                onChange={onChange}
+                onChange={(value) => onChange([`${value}`])}
+                isChecked={value[0] === "true"}
                 label={t("common:on")}
                 labelOff={t("common:off")}
               />
@@ -129,13 +104,13 @@ export const LdapSettingsAdvanced = ({
           <Controller
             name="config.trustEmail"
             defaultValue={false}
-            control={control}
+            control={form.control}
             render={({ onChange, value }) => (
               <Switch
                 id={"kc-trust-email"}
-                isChecked={value[0] === "true"}
                 isDisabled={false}
-                onChange={onChange}
+                onChange={(value) => onChange([`${value}`])}
+                isChecked={value[0] === "true"}
                 label={t("common:on")}
                 labelOff={t("common:off")}
               />

--- a/src/user-federation/ldap/LdapSettingsCache.tsx
+++ b/src/user-federation/ldap/LdapSettingsCache.tsx
@@ -49,20 +49,16 @@ export const LdapSettingsCache = ({
     false
   );
 
-  const hourOptions = [
-    <SelectOption key={0} value={t("common:selectOne")} isPlaceholder />,
-  ];
-  for (let index = 1; index <= 24; index++) {
-    hourOptions.push(<SelectOption key={index + 1} value={index.toString()} />);
+  const hourOptions = [<SelectOption key={0} value={[`${1}`]} isPlaceholder />];
+  for (let index = 2; index <= 24; index++) {
+    hourOptions.push(<SelectOption key={index - 1} value={[`${index}`]} />);
   }
 
   const minuteOptions = [
-    <SelectOption key={0} value={t("common:selectOne")} isPlaceholder />,
+    <SelectOption key={0} value={[`${1}`]} isPlaceholder />,
   ];
-  for (let index = 1; index <= 60; index++) {
-    minuteOptions.push(
-      <SelectOption key={index + 1} value={index.toString()} />
-    );
+  for (let index = 2; index <= 60; index++) {
+    minuteOptions.push(<SelectOption key={index - 1} value={[`${index}`]} />);
   }
 
   return (
@@ -105,16 +101,11 @@ export const LdapSettingsCache = ({
                 selections={value}
                 variant={SelectVariant.single}
               >
-                <SelectOption
-                  key={0}
-                  value={t("common:selectOne")}
-                  isPlaceholder
-                />
-                <SelectOption key={1} value={["DEFAULT"]} />
-                <SelectOption key={2} value={["EVICT_DAILY"]} />
-                <SelectOption key={3} value={["EVICT_WEEKLY"]} />
-                <SelectOption key={4} value={["MAX_LIFESPAN"]} />
-                <SelectOption key={5} value={["NO_CACHE"]} />
+                <SelectOption key={0} value={["DEFAULT"]} isPlaceholder />
+                <SelectOption key={1} value={["EVICT_DAILY"]} />
+                <SelectOption key={2} value={["EVICT_WEEKLY"]} />
+                <SelectOption key={3} value={["MAX_LIFESPAN"]} />
+                <SelectOption key={4} value={["NO_CACHE"]} />
               </Select>
             )}
           ></Controller>
@@ -129,6 +120,7 @@ export const LdapSettingsCache = ({
                 forID="kc-eviction-day"
               />
             }
+            isRequired
             fieldId="kc-eviction-day"
           >
             <Controller
@@ -150,30 +142,25 @@ export const LdapSettingsCache = ({
                   selections={value}
                   variant={SelectVariant.single}
                 >
-                  <SelectOption
-                    key={0}
-                    value={t("common:selectOne")}
-                    isPlaceholder
-                  />
-                  <SelectOption key={1} value={["1"]}>
+                  <SelectOption key={0} value={["1"]} isPlaceholder>
                     {t("common:Sunday")}
                   </SelectOption>
-                  <SelectOption key={2} value={["2"]}>
+                  <SelectOption key={1} value={["2"]}>
                     {t("common:Monday")}
                   </SelectOption>
-                  <SelectOption key={3} value={["3"]}>
+                  <SelectOption key={2} value={["3"]}>
                     {t("common:Tuesday")}
                   </SelectOption>
-                  <SelectOption key={4} value={["4"]}>
+                  <SelectOption key={3} value={["4"]}>
                     {t("common:Wednesday")}
                   </SelectOption>
-                  <SelectOption key={5} value={["5"]}>
+                  <SelectOption key={4} value={["5"]}>
                     {t("common:Thursday")}
                   </SelectOption>
-                  <SelectOption key={6} value={["6"]}>
+                  <SelectOption key={5} value={["6"]}>
                     {t("common:Friday")}
                   </SelectOption>
-                  <SelectOption key={7} value={["7"]}>
+                  <SelectOption key={6} value={["7"]}>
                     {t("common:Saturday")}
                   </SelectOption>
                 </Select>
@@ -195,10 +182,11 @@ export const LdapSettingsCache = ({
                   forID="kc-eviction-hour"
                 />
               }
+              isRequired
               fieldId="kc-eviction-hour"
             >
               <Controller
-                name="config.evictionHour[0]"
+                name="config.evictionHour"
                 defaultValue=""
                 control={form.control}
                 render={({ onChange, value }) => (
@@ -229,10 +217,11 @@ export const LdapSettingsCache = ({
                   forID="kc-eviction-minute"
                 />
               }
+              isRequired
               fieldId="kc-eviction-minute"
             >
               <Controller
-                name="config.evictionMinute[0]"
+                name="config.evictionMinute"
                 defaultValue=""
                 control={form.control}
                 render={({ onChange, value }) => (

--- a/src/user-federation/ldap/LdapSettingsCache.tsx
+++ b/src/user-federation/ldap/LdapSettingsCache.tsx
@@ -3,83 +3,29 @@ import {
   Select,
   SelectOption,
   SelectVariant,
-  Text,
-  TextContent,
   TextInput,
-  Title,
 } from "@patternfly/react-core";
 import { useTranslation } from "react-i18next";
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { HelpItem } from "../../components/help-enabler/HelpItem";
-import { useForm, Controller } from "react-hook-form";
-import { convertToFormValues } from "../../util";
-import ComponentRepresentation from "keycloak-admin/lib/defs/componentRepresentation";
+import { UseFormMethods, useWatch, Controller } from "react-hook-form";
 import { FormAccess } from "../../components/form-access/FormAccess";
-import { useAdminClient } from "../../context/auth/AdminClient";
-import { useParams } from "react-router-dom";
+import _ from "lodash";
 import { WizardSectionHeader } from "../../components/wizard-section-header/WizardSectionHeader";
 
 export type LdapSettingsCacheProps = {
+  form: UseFormMethods;
   showSectionHeading?: boolean;
   showSectionDescription?: boolean;
 };
 
 export const LdapSettingsCache = ({
+  form,
   showSectionHeading = false,
   showSectionDescription = false,
 }: LdapSettingsCacheProps) => {
   const { t } = useTranslation("user-federation");
   const helpText = useTranslation("user-federation-help").t;
-
-  const adminClient = useAdminClient();
-  const { control, setValue, register } = useForm<ComponentRepresentation>();
-  const { id } = useParams<{ id: string }>();
-
-  const convertToDays = (num: string) => {
-    switch (num) {
-      case "1":
-        return t("common:Sunday");
-      case "2":
-        return t("common:Monday");
-      case "3":
-        return t("common:Tuesday");
-      case "4":
-        return t("common:Wednesday");
-      case "5":
-        return t("common:Thursday");
-      case "6":
-        return t("common:Friday");
-      case "7":
-        return t("common:Saturday");
-      default:
-        return t("common:selectOne");
-    }
-  };
-
-  const setupForm = (component: ComponentRepresentation) => {
-    Object.entries(component).map((entry) => {
-      if (entry[0] === "config") {
-        convertToFormValues(entry[1], "config", setValue);
-        if (entry[1].evictionDay) {
-          setValue(
-            "config.evictionDay",
-            convertToDays(entry[1].evictionDay[0])
-          );
-        }
-      } else {
-        setValue(entry[0], entry[1]);
-      }
-    });
-  };
-
-  useEffect(() => {
-    (async () => {
-      const fetchedComponent = await adminClient.components.findOne({ id });
-      if (fetchedComponent) {
-        setupForm(fetchedComponent);
-      }
-    })();
-  }, []);
 
   const [isCachePolicyDropdownOpen, setIsCachePolicyDropdownOpen] = useState(
     false
@@ -88,6 +34,11 @@ export const LdapSettingsCache = ({
   const [isEvictionHourDropdownOpen, setIsEvictionHourDropdownOpen] = useState(
     false
   );
+
+  const cachePolicyType = useWatch({
+    control: form.control,
+    name: "config.cachePolicy",
+  });
 
   const [
     isEvictionMinuteDropdownOpen,
@@ -121,8 +72,6 @@ export const LdapSettingsCache = ({
           showDescription={showSectionDescription}
         />
       )}
-
-      {/* Cache settings */}
       <FormAccess role="manage-realm" isHorizontal>
         <FormGroup
           label={t("cachePolicy")}
@@ -138,7 +87,7 @@ export const LdapSettingsCache = ({
           <Controller
             name="config.cachePolicy"
             defaultValue=""
-            control={control}
+            control={form.control}
             render={({ onChange, value }) => (
               <Select
                 toggleId="kc-cache-policy"
@@ -154,159 +103,185 @@ export const LdapSettingsCache = ({
                 selections={value}
                 variant={SelectVariant.single}
               >
-                <SelectOption key={0} value="Choose..." isPlaceholder />
-                <SelectOption key={1} value="DEFAULT" />
-                <SelectOption key={2} value="EVICT_DAILY" />
-                <SelectOption key={3} value="EVICT_WEEKLY" />
-                <SelectOption key={4} value="MAX_LIFESPAN" />
-                <SelectOption key={5} value="NO_CACHE" />
-              </Select>
-            )}
-          ></Controller>
-        </FormGroup>
-
-        {/* TODO: Field shows only if cache policy is EVICT_WEEKLY */}
-        <FormGroup
-          label={t("evictionDay")}
-          labelIcon={
-            <HelpItem
-              helpText={helpText("evictionDayHelp")}
-              forLabel={t("evictionDay")}
-              forID="kc-eviction-day"
-            />
-          }
-          fieldId="kc-eviction-day"
-        >
-          <Controller
-            name="config.evictionDay"
-            defaultValue=""
-            control={control}
-            render={({ onChange, value }) => (
-              <Select
-                toggleId="kc-eviction-day"
-                required
-                onToggle={() =>
-                  setIsEvictionDayDropdownOpen(!isEvictionDayDropdownOpen)
-                }
-                isOpen={isEvictionDayDropdownOpen}
-                onSelect={(_, value) => {
-                  onChange(value as string);
-                  setIsEvictionDayDropdownOpen(false);
-                }}
-                selections={value}
-                variant={SelectVariant.single}
-              >
+                {/* <SelectOption key={0} value="Choose..." isPlaceholder /> */}
                 <SelectOption
                   key={0}
                   value={t("common:selectOne")}
                   isPlaceholder
                 />
-                <SelectOption key={1} value={t("common:Sunday")} />
-                <SelectOption key={2} value={t("common:Monday")} />
-                <SelectOption key={3} value={t("common:Tuesday")} />
-                <SelectOption key={4} value={t("common:Wednesday")} />
-                <SelectOption key={5} value={t("common:Thursday")} />
-                <SelectOption key={6} value={t("common:Friday")} />
-                <SelectOption key={7} value={t("common:Saturday")} />
+                <SelectOption key={1} value={["DEFAULT"]} />
+                <SelectOption key={2} value={["EVICT_DAILY"]} />
+                <SelectOption key={3} value={["EVICT_WEEKLY"]} />
+                <SelectOption key={4} value={["MAX_LIFESPAN"]} />
+                <SelectOption key={5} value={["NO_CACHE"]} />
               </Select>
             )}
           ></Controller>
         </FormGroup>
-
-        {/* TODO: Field shows only if cache policy is EVICT_WEEKLY or EVICT_DAILY */}
-        {/* TODO: Investigate whether this should be a number field instead of a dropdown/text field */}
-        <FormGroup
-          label={t("evictionHour")}
-          labelIcon={
-            <HelpItem
-              helpText={helpText("evictionHourHelp")}
-              forLabel={t("evictionHour")}
-              forID="kc-eviction-hour"
+        {_.isEqual(cachePolicyType, ["EVICT_WEEKLY"]) ? (
+          <FormGroup
+            label={t("evictionDay")}
+            labelIcon={
+              <HelpItem
+                helpText={helpText("evictionDayHelp")}
+                forLabel={t("evictionDay")}
+                forID="kc-eviction-day"
+              />
+            }
+            fieldId="kc-eviction-day"
+          >
+            <Controller
+              name="config.evictionDay"
+              defaultValue=""
+              control={form.control}
+              render={({ onChange, value }) => (
+                <Select
+                  toggleId="kc-eviction-day"
+                  required
+                  onToggle={() =>
+                    setIsEvictionDayDropdownOpen(!isEvictionDayDropdownOpen)
+                  }
+                  isOpen={isEvictionDayDropdownOpen}
+                  onSelect={(_, value) => {
+                    onChange(value as string);
+                    setIsEvictionDayDropdownOpen(false);
+                  }}
+                  selections={value}
+                  variant={SelectVariant.single}
+                >
+                  <SelectOption
+                    key={0}
+                    value={t("common:selectOne")}
+                    isPlaceholder
+                  />
+                  <SelectOption key={1} value={["1"]}>
+                    {t("common:Sunday")}
+                  </SelectOption>
+                  <SelectOption key={2} value={["2"]}>
+                    {t("common:Monday")}
+                  </SelectOption>
+                  <SelectOption key={3} value={["3"]}>
+                    {t("common:Tuesday")}
+                  </SelectOption>
+                  <SelectOption key={4} value={["4"]}>
+                    {t("common:Wednesday")}
+                  </SelectOption>
+                  <SelectOption key={5} value={["5"]}>
+                    {t("common:Thursday")}
+                  </SelectOption>
+                  <SelectOption key={6} value={["6"]}>
+                    {t("common:Friday")}
+                  </SelectOption>
+                  <SelectOption key={7} value={["7"]}>
+                    {t("common:Saturday")}
+                  </SelectOption>
+                </Select>
+              )}
+            ></Controller>
+          </FormGroup>
+        ) : (
+          <></>
+        )}
+        {_.isEqual(cachePolicyType, ["EVICT_DAILY"]) ||
+        _.isEqual(cachePolicyType, ["EVICT_WEEKLY"]) ? (
+          <>
+            <FormGroup
+              label={t("evictionHour")}
+              labelIcon={
+                <HelpItem
+                  helpText={helpText("evictionHourHelp")}
+                  forLabel={t("evictionHour")}
+                  forID="kc-eviction-hour"
+                />
+              }
+              fieldId="kc-eviction-hour"
+            >
+              <Controller
+                name="config.evictionHour"
+                defaultValue=""
+                control={form.control}
+                render={({ onChange, value }) => (
+                  <Select
+                    toggleId="kc-eviction-hour"
+                    onToggle={() =>
+                      setIsEvictionHourDropdownOpen(!isEvictionHourDropdownOpen)
+                    }
+                    isOpen={isEvictionHourDropdownOpen}
+                    onSelect={(_, value) => {
+                      onChange(value as string);
+                      setIsEvictionHourDropdownOpen(false);
+                    }}
+                    selections={value}
+                    variant={SelectVariant.single}
+                  >
+                    {hourOptions}
+                  </Select>
+                )}
+              ></Controller>
+            </FormGroup>
+            <FormGroup
+              label={t("evictionMinute")}
+              labelIcon={
+                <HelpItem
+                  helpText={helpText("evictionMinuteHelp")}
+                  forLabel={t("evictionMinute")}
+                  forID="kc-eviction-minute"
+                />
+              }
+              fieldId="kc-eviction-minute"
+            >
+              <Controller
+                name="config.evictionMinute"
+                defaultValue=""
+                control={form.control}
+                render={({ onChange, value }) => (
+                  <Select
+                    toggleId="kc-eviction-minute"
+                    onToggle={() =>
+                      setIsEvictionMinuteDropdownOpen(
+                        !isEvictionMinuteDropdownOpen
+                      )
+                    }
+                    isOpen={isEvictionMinuteDropdownOpen}
+                    onSelect={(_, value) => {
+                      onChange(value as string);
+                      setIsEvictionMinuteDropdownOpen(false);
+                    }}
+                    selections={value}
+                    variant={SelectVariant.single}
+                  >
+                    {minuteOptions}
+                  </Select>
+                )}
+              ></Controller>
+            </FormGroup>
+          </>
+        ) : (
+          <></>
+        )}
+        {_.isEqual(cachePolicyType, ["MAX_LIFESPAN"]) ? (
+          <FormGroup
+            label={t("maxLifespan")}
+            labelIcon={
+              <HelpItem
+                helpText={helpText("maxLifespanHelp")}
+                forLabel={t("maxLifespan")}
+                forID="kc-max-lifespan"
+              />
+            }
+            fieldId="kc-max-lifespan"
+          >
+            <TextInput
+              isRequired
+              type="text"
+              id="kc-max-lifespan"
+              name="config.maxLifespan"
+              ref={form.register}
             />
-          }
-          fieldId="kc-eviction-hour"
-        >
-          <Controller
-            name="config.evictionHour"
-            defaultValue=""
-            control={control}
-            render={({ onChange, value }) => (
-              <Select
-                toggleId="kc-eviction-hour"
-                onToggle={() =>
-                  setIsEvictionHourDropdownOpen(!isEvictionHourDropdownOpen)
-                }
-                isOpen={isEvictionHourDropdownOpen}
-                onSelect={(_, value) => {
-                  onChange(value as string);
-                  setIsEvictionHourDropdownOpen(false);
-                }}
-                selections={value}
-                variant={SelectVariant.single}
-              >
-                {hourOptions}
-              </Select>
-            )}
-          ></Controller>
-        </FormGroup>
-
-        {/* TODO: Field shows only if cache policy is EVICT_WEEKLY or EVICT_DAILY */}
-        {/* TODO: Investigate whether this should be a number field instead of a dropdown/text field */}
-        <FormGroup
-          label={t("evictionMinute")}
-          labelIcon={
-            <HelpItem
-              helpText={helpText("evictionMinuteHelp")}
-              forLabel={t("evictionMinute")}
-              forID="kc-eviction-minute"
-            />
-          }
-          fieldId="kc-eviction-minute"
-        >
-          <Controller
-            name="config.evictionMinute"
-            defaultValue=""
-            control={control}
-            render={({ onChange, value }) => (
-              <Select
-                toggleId="kc-eviction-minute"
-                onToggle={() =>
-                  setIsEvictionMinuteDropdownOpen(!isEvictionMinuteDropdownOpen)
-                }
-                isOpen={isEvictionMinuteDropdownOpen}
-                onSelect={(_, value) => {
-                  onChange(value as string);
-                  setIsEvictionMinuteDropdownOpen(false);
-                }}
-                selections={value}
-                variant={SelectVariant.single}
-              >
-                {minuteOptions}
-              </Select>
-            )}
-          ></Controller>
-        </FormGroup>
-
-        {/* TODO: Field shows only if cache policy is MAX_LIFESPAN */}
-        <FormGroup
-          label={t("maxLifespan")}
-          labelIcon={
-            <HelpItem
-              helpText={helpText("maxLifespanHelp")}
-              forLabel={t("maxLifespan")}
-              forID="kc-max-lifespan"
-            />
-          }
-          fieldId="kc-max-lifespan"
-        >
-          <TextInput
-            isRequired
-            type="text"
-            id="kc-max-lifespan"
-            name="config.maxLifespan"
-            ref={register}
-          />
-        </FormGroup>
+          </FormGroup>
+        ) : (
+          <></>
+        )}
       </FormAccess>
     </>
   );

--- a/src/user-federation/ldap/LdapSettingsCache.tsx
+++ b/src/user-federation/ldap/LdapSettingsCache.tsx
@@ -84,7 +84,7 @@ export const LdapSettingsCache = ({
         >
           <Controller
             name="config.cachePolicy"
-            defaultValue=""
+            defaultValue={["DEFAULT"]}
             control={form.control}
             render={({ onChange, value }) => (
               <Select
@@ -125,7 +125,7 @@ export const LdapSettingsCache = ({
           >
             <Controller
               name="config.evictionDay"
-              defaultValue=""
+              defaultValue={[t("common:Sunday")]}
               control={form.control}
               render={({ onChange, value }) => (
                 <Select
@@ -187,7 +187,7 @@ export const LdapSettingsCache = ({
             >
               <Controller
                 name="config.evictionHour"
-                defaultValue=""
+                defaultValue={["1"]}
                 control={form.control}
                 render={({ onChange, value }) => (
                   <Select
@@ -222,7 +222,7 @@ export const LdapSettingsCache = ({
             >
               <Controller
                 name="config.evictionMinute"
-                defaultValue=""
+                defaultValue={["1"]}
                 control={form.control}
                 render={({ onChange, value }) => (
                   <Select

--- a/src/user-federation/ldap/LdapSettingsCache.tsx
+++ b/src/user-federation/ldap/LdapSettingsCache.tsx
@@ -53,14 +53,16 @@ export const LdapSettingsCache = ({
     <SelectOption key={0} value={t("common:selectOne")} isPlaceholder />,
   ];
   for (let index = 1; index <= 24; index++) {
-    hourOptions.push(<SelectOption key={index + 1} value={index} />);
+    hourOptions.push(<SelectOption key={index + 1} value={index.toString()} />);
   }
 
   const minuteOptions = [
     <SelectOption key={0} value={t("common:selectOne")} isPlaceholder />,
   ];
   for (let index = 1; index <= 60; index++) {
-    minuteOptions.push(<SelectOption key={index + 1} value={index} />);
+    minuteOptions.push(
+      <SelectOption key={index + 1} value={index.toString()} />
+    );
   }
 
   return (
@@ -103,7 +105,6 @@ export const LdapSettingsCache = ({
                 selections={value}
                 variant={SelectVariant.single}
               >
-                {/* <SelectOption key={0} value="Choose..." isPlaceholder /> */}
                 <SelectOption
                   key={0}
                   value={t("common:selectOne")}
@@ -197,7 +198,7 @@ export const LdapSettingsCache = ({
               fieldId="kc-eviction-hour"
             >
               <Controller
-                name="config.evictionHour"
+                name="config.evictionHour[0]"
                 defaultValue=""
                 control={form.control}
                 render={({ onChange, value }) => (
@@ -231,7 +232,7 @@ export const LdapSettingsCache = ({
               fieldId="kc-eviction-minute"
             >
               <Controller
-                name="config.evictionMinute"
+                name="config.evictionMinute[0]"
                 defaultValue=""
                 control={form.control}
                 render={({ onChange, value }) => (
@@ -275,7 +276,7 @@ export const LdapSettingsCache = ({
               isRequired
               type="text"
               id="kc-max-lifespan"
-              name="config.maxLifespan"
+              name="config.maxLifespan[0]"
               ref={form.register}
             />
           </FormGroup>

--- a/src/user-federation/ldap/LdapSettingsConnection.tsx
+++ b/src/user-federation/ldap/LdapSettingsConnection.tsx
@@ -65,7 +65,7 @@ export const LdapSettingsConnection = ({
             isRequired
             type="text"
             id="kc-console-connection-url"
-            name="config.connectionUrl"
+            name="config.connectionUrl[0]"
             ref={form.register}
           />
         </FormGroup>
@@ -82,8 +82,8 @@ export const LdapSettingsConnection = ({
           hasNoPaddingTop
         >
           <Controller
-            name="config.startTls"
-            defaultValue={false}
+            name="config.startTls[0]"
+            defaultValue={"false"}
             control={form.control}
             render={({ onChange, value }) => (
               <Switch
@@ -97,6 +97,7 @@ export const LdapSettingsConnection = ({
             )}
           ></Controller>
         </FormGroup>
+
         <FormGroup
           label={t("useTruststoreSpi")}
           labelIcon={
@@ -109,7 +110,7 @@ export const LdapSettingsConnection = ({
           fieldId="kc-use-truststore-spi"
         >
           <Controller
-            name="config.useTruststoreSpi"
+            name="config.useTruststoreSpi[0]"
             defaultValue=""
             control={form.control}
             render={({ onChange, value }) => (
@@ -126,9 +127,15 @@ export const LdapSettingsConnection = ({
                 selections={value}
                 variant={SelectVariant.single}
               >
-                <SelectOption key={0} value={t("always")} />
-                <SelectOption key={1} value={t("onlyLdaps")} />
-                <SelectOption key={2} value={t("never")} />
+                <SelectOption key={0} value="always">
+                  {t("always")}
+                </SelectOption>
+                <SelectOption key={1} value="ldapsOnly">
+                  {t("onlyLdaps")}
+                </SelectOption>
+                <SelectOption key={2} value="never">
+                  {t("never")}
+                </SelectOption>
               </Select>
             )}
           ></Controller>
@@ -175,7 +182,7 @@ export const LdapSettingsConnection = ({
           <TextInput
             type="text"
             id="kc-console-connection-timeout"
-            name="config.connectionTimeout"
+            name="config.connectionTimeout[0]"
             ref={form.register}
           />
         </FormGroup>
@@ -192,7 +199,7 @@ export const LdapSettingsConnection = ({
           isRequired
         >
           <Controller
-            name="config.authType"
+            name="config.authType[0]"
             defaultValue=""
             control={form.control}
             render={({ onChange, value }) => (
@@ -230,7 +237,7 @@ export const LdapSettingsConnection = ({
           <TextInput
             type="text"
             id="kc-console-bind-dn"
-            name="config.bindDn"
+            name="config.bindDn[0]"
             ref={form.register}
           />
         </FormGroup>
@@ -251,7 +258,7 @@ export const LdapSettingsConnection = ({
               isRequired
               type="password"
               id="kc-console-bind-credentials"
-              name="config.bindCredential"
+              name="config.bindCredential[0]"
               ref={form.register}
             />
             <Button

--- a/src/user-federation/ldap/LdapSettingsConnection.tsx
+++ b/src/user-federation/ldap/LdapSettingsConnection.tsx
@@ -82,7 +82,7 @@ export const LdapSettingsConnection = ({
           hasNoPaddingTop
         >
           <Controller
-            name="config.startTls[0]"
+            name="config.startTls"
             defaultValue={"false"}
             control={form.control}
             render={({ onChange, value }) => (

--- a/src/user-federation/ldap/LdapSettingsConnection.tsx
+++ b/src/user-federation/ldap/LdapSettingsConnection.tsx
@@ -66,8 +66,20 @@ export const LdapSettingsConnection = ({
             type="text"
             id="kc-console-connection-url"
             name="config.connectionUrl[0]"
-            ref={form.register}
+            ref={form.register({
+              required: {
+                value: true,
+                message: `${t("validateConnectionUrl")}`,
+              },
+            })}
           />
+          {form.errors.config &&
+            form.errors.config.connectionUrl &&
+            form.errors.config.connectionUrl[0] && (
+              <div className="error">
+                {form.errors.config.connectionUrl[0].message}
+              </div>
+            )}
         </FormGroup>
         <FormGroup
           label={t("enableStartTls")}
@@ -259,7 +271,12 @@ export const LdapSettingsConnection = ({
               type="password"
               id="kc-console-bind-credentials"
               name="config.bindCredential[0]"
-              ref={form.register}
+              ref={form.register({
+                required: {
+                  value: true,
+                  message: `${t("validateBindCredentials")}`,
+                },
+              })}
             />
             <Button
               variant="control"
@@ -268,6 +285,13 @@ export const LdapSettingsConnection = ({
               <EyeIcon />
             </Button>
           </InputGroup>
+          {form.errors.config &&
+            form.errors.config.bindCredential &&
+            form.errors.config.bindCredential[0] && (
+              <div className="error">
+                {form.errors.config.bindCredential[0].message}
+              </div>
+            )}
         </FormGroup>
         <FormGroup fieldId="kc-test-button">
           {" "}

--- a/src/user-federation/ldap/LdapSettingsConnection.tsx
+++ b/src/user-federation/ldap/LdapSettingsConnection.tsx
@@ -95,7 +95,7 @@ export const LdapSettingsConnection = ({
         >
           <Controller
             name="config.startTls"
-            defaultValue={"false"}
+            defaultValue={["false"]}
             control={form.control}
             render={({ onChange, value }) => (
               <Switch

--- a/src/user-federation/ldap/LdapSettingsGeneral.tsx
+++ b/src/user-federation/ldap/LdapSettingsGeneral.tsx
@@ -3,77 +3,30 @@ import {
   Select,
   SelectOption,
   SelectVariant,
-  Text,
-  TextContent,
   TextInput,
-  Title,
 } from "@patternfly/react-core";
 import { useTranslation } from "react-i18next";
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { HelpItem } from "../../components/help-enabler/HelpItem";
-import { useForm, Controller } from "react-hook-form";
-import { convertToFormValues } from "../../util";
-import ComponentRepresentation from "keycloak-admin/lib/defs/componentRepresentation";
+import { UseFormMethods, Controller } from "react-hook-form";
 import { FormAccess } from "../../components/form-access/FormAccess";
-import {
-  useAdminClient,
-  asyncStateFetch,
-} from "../../context/auth/AdminClient";
-import { useParams } from "react-router-dom";
 import { WizardSectionHeader } from "../../components/wizard-section-header/WizardSectionHeader";
 
 export type LdapSettingsGeneralProps = {
+  form: UseFormMethods;
   showSectionHeading?: boolean;
   showSectionDescription?: boolean;
 };
 
 export const LdapSettingsGeneral = ({
+  form,
   showSectionHeading = false,
   showSectionDescription = false,
 }: LdapSettingsGeneralProps) => {
   const { t } = useTranslation("user-federation");
   const helpText = useTranslation("user-federation-help").t;
-  const adminClient = useAdminClient();
-  const { register, control, setValue } = useForm<ComponentRepresentation>();
-  const { id } = useParams<{ id: string }>();
+
   const [isVendorDropdownOpen, setIsVendorDropdownOpen] = useState(false);
-
-  const setupForm = (component: ComponentRepresentation) => {
-    Object.entries(component).map((entry) => {
-      if (entry[0] === "config") {
-        convertToFormValues(entry[1], "config", setValue);
-        if (entry[1].vendor) {
-          setValue("config.vendor", convertVendorNames(entry[1].vendor[0]));
-        }
-      } else {
-        setValue(entry[0], entry[1]);
-      }
-    });
-  };
-
-  useEffect(() => {
-    return asyncStateFetch(
-      () => adminClient.components.findOne({ id }),
-      (fetchedComponent) => setupForm(fetchedComponent)
-    );
-  }, []);
-
-  const convertVendorNames = (vendorName: string) => {
-    switch (vendorName) {
-      case "ad":
-        return "Active Directory";
-      case "rhds":
-        return "Red Hat Directory Server";
-      case "tivoli":
-        return "Tivoli";
-      case "edirectory":
-        return "Novell eDirectory";
-      case "other":
-        return "Other";
-      default:
-        return t("common:choose");
-    }
-  };
 
   return (
     <>
@@ -84,7 +37,6 @@ export const LdapSettingsGeneral = ({
           showDescription={showSectionDescription}
         />
       )}
-
       <FormAccess role="manage-realm" isHorizontal>
         <FormGroup
           label={t("consoleDisplayName")}
@@ -103,7 +55,7 @@ export const LdapSettingsGeneral = ({
             type="text"
             id="kc-console-display-name"
             name="name"
-            ref={register}
+            ref={form.register}
           />
         </FormGroup>
         <FormGroup
@@ -121,7 +73,7 @@ export const LdapSettingsGeneral = ({
           <Controller
             name="config.vendor"
             defaultValue=""
-            control={control}
+            control={form.control}
             render={({ onChange, value }) => (
               <Select
                 toggleId="kc-vendor"

--- a/src/user-federation/ldap/LdapSettingsGeneral.tsx
+++ b/src/user-federation/ldap/LdapSettingsGeneral.tsx
@@ -50,11 +50,40 @@ export const LdapSettingsGeneral = ({
           fieldId="kc-console-display-name"
           isRequired
         >
+          {/* These hidden fields are required so data object written back matches data retrieved */}
+          <TextInput
+            hidden
+            type="text"
+            id="kc-console-id"
+            name="id"
+            ref={form.register}
+          />
           <TextInput
             isRequired
             type="text"
             id="kc-console-display-name"
             name="name"
+            ref={form.register}
+          />
+          <TextInput
+            hidden
+            type="text"
+            id="kc-console-provider-id"
+            name="providerId"
+            ref={form.register}
+          />
+          <TextInput
+            hidden
+            type="text"
+            id="kc-console-provider-type"
+            name="providerType"
+            ref={form.register}
+          />
+          <TextInput
+            hidden
+            type="text"
+            id="kc-console-parentId"
+            name="parentId"
             ref={form.register}
           />
         </FormGroup>
@@ -71,7 +100,7 @@ export const LdapSettingsGeneral = ({
           isRequired
         >
           <Controller
-            name="config.vendor"
+            name="config.vendor[0]"
             defaultValue=""
             control={form.control}
             render={({ onChange, value }) => (
@@ -92,11 +121,21 @@ export const LdapSettingsGeneral = ({
                   value={t("common:choose")}
                   isPlaceholder
                 />
-                <SelectOption key={1} value="Active Directory" />
-                <SelectOption key={2} value="Red Hat Directory Server" />
-                <SelectOption key={3} value="Tivoli" />
-                <SelectOption key={4} value="Novell eDirectory" />
-                <SelectOption key={5} value="Other" />
+                <SelectOption key={1} value="ad">
+                  Active Directory
+                </SelectOption>
+                <SelectOption key={2} value="rhds">
+                  Red Hat Directory Server
+                </SelectOption>
+                <SelectOption key={3} value="tivoli">
+                  Tivoli
+                </SelectOption>
+                <SelectOption key={4} value="edirectory">
+                  Novell eDirectory
+                </SelectOption>
+                <SelectOption key={5} value="other">
+                  Other
+                </SelectOption>
               </Select>
             )}
           ></Controller>

--- a/src/user-federation/ldap/LdapSettingsGeneral.tsx
+++ b/src/user-federation/ldap/LdapSettingsGeneral.tsx
@@ -63,7 +63,12 @@ export const LdapSettingsGeneral = ({
             type="text"
             id="kc-console-display-name"
             name="name"
-            ref={form.register}
+            ref={form.register({
+              required: {
+                value: true,
+                message: `${t("validateName")}`,
+              },
+            })}
           />
           <TextInput
             hidden
@@ -86,6 +91,9 @@ export const LdapSettingsGeneral = ({
             name="parentId"
             ref={form.register}
           />
+          {form.errors.name && (
+            <div className="error">{form.errors.name.message}</div>
+          )}
         </FormGroup>
         <FormGroup
           label={t("vendor")}
@@ -116,24 +124,19 @@ export const LdapSettingsGeneral = ({
                 selections={value}
                 variant={SelectVariant.single}
               >
-                <SelectOption
-                  key={0}
-                  value={t("common:choose")}
-                  isPlaceholder
-                />
-                <SelectOption key={1} value="ad">
+                <SelectOption key={0} value="ad" isPlaceholder>
                   Active Directory
                 </SelectOption>
-                <SelectOption key={2} value="rhds">
+                <SelectOption key={1} value="rhds">
                   Red Hat Directory Server
                 </SelectOption>
-                <SelectOption key={3} value="tivoli">
+                <SelectOption key={2} value="tivoli">
                   Tivoli
                 </SelectOption>
-                <SelectOption key={4} value="edirectory">
+                <SelectOption key={3} value="edirectory">
                   Novell eDirectory
                 </SelectOption>
-                <SelectOption key={5} value="other">
+                <SelectOption key={4} value="other">
                   Other
                 </SelectOption>
               </Select>

--- a/src/user-federation/ldap/LdapSettingsKerberosIntegration.tsx
+++ b/src/user-federation/ldap/LdapSettingsKerberosIntegration.tsx
@@ -1,50 +1,24 @@
 import { FormGroup, Switch } from "@patternfly/react-core";
 import { useTranslation } from "react-i18next";
-import React, { useEffect } from "react";
+import React from "react";
 import { HelpItem } from "../../components/help-enabler/HelpItem";
-import { useForm, Controller } from "react-hook-form";
-import { convertToFormValues } from "../../util";
-import ComponentRepresentation from "keycloak-admin/lib/defs/componentRepresentation";
+import { UseFormMethods, Controller } from "react-hook-form";
 import { FormAccess } from "../../components/form-access/FormAccess";
-import {
-  useAdminClient,
-  asyncStateFetch,
-} from "../../context/auth/AdminClient";
-import { useParams } from "react-router-dom";
 import { WizardSectionHeader } from "../../components/wizard-section-header/WizardSectionHeader";
 
 export type LdapSettingsKerberosIntegrationProps = {
+  form: UseFormMethods;
   showSectionHeading?: boolean;
   showSectionDescription?: boolean;
 };
 
 export const LdapSettingsKerberosIntegration = ({
+  form,
   showSectionHeading = false,
   showSectionDescription = false,
 }: LdapSettingsKerberosIntegrationProps) => {
   const { t } = useTranslation("user-federation");
   const helpText = useTranslation("user-federation-help").t;
-
-  const adminClient = useAdminClient();
-  const { control, setValue } = useForm<ComponentRepresentation>();
-  const { id } = useParams<{ id: string }>();
-
-  const setupForm = (component: ComponentRepresentation) => {
-    Object.entries(component).map((entry) => {
-      if (entry[0] === "config") {
-        convertToFormValues(entry[1], "config", setValue);
-      } else {
-        setValue(entry[0], entry[1]);
-      }
-    });
-  };
-
-  useEffect(() => {
-    return asyncStateFetch(
-      () => adminClient.components.findOne({ id }),
-      (fetchedComponent) => setupForm(fetchedComponent)
-    );
-  }, []);
 
   return (
     <>
@@ -72,12 +46,12 @@ export const LdapSettingsKerberosIntegration = ({
           <Controller
             name="config.allowKerberosAuthentication"
             defaultValue={false}
-            control={control}
+            control={form.control}
             render={({ onChange, value }) => (
               <Switch
                 id={"kc-allow-kerberos-authentication"}
                 isDisabled={false}
-                onChange={onChange}
+                onChange={(value) => onChange([`${value}`])}
                 isChecked={value[0] === "true"}
                 label={t("common:on")}
                 labelOff={t("common:off")}
@@ -100,12 +74,12 @@ export const LdapSettingsKerberosIntegration = ({
           <Controller
             name="config.useKerberosForPasswordAuthentication"
             defaultValue={false}
-            control={control}
+            control={form.control}
             render={({ onChange, value }) => (
               <Switch
                 id={"kc-use-kerberos-password-authentication"}
                 isDisabled={false}
-                onChange={onChange}
+                onChange={(value) => onChange([`${value}`])}
                 isChecked={value[0] === "true"}
                 label={t("common:on")}
                 labelOff={t("common:off")}

--- a/src/user-federation/ldap/LdapSettingsSearching.tsx
+++ b/src/user-federation/ldap/LdapSettingsSearching.tsx
@@ -73,7 +73,7 @@ export const LdapSettingsSearching = ({
                 selections={value}
                 variant={SelectVariant.single}
               >
-                <SelectOption key={0} value="RACT_ONLY" isPlaceholder />
+                <SelectOption key={0} value="READ_ONLY" isPlaceholder />
                 <SelectOption key={1} value="WRITABLE" />
                 <SelectOption key={2} value="UNSYNCED" />
               </Select>

--- a/src/user-federation/ldap/LdapSettingsSearching.tsx
+++ b/src/user-federation/ldap/LdapSettingsSearching.tsx
@@ -73,14 +73,9 @@ export const LdapSettingsSearching = ({
                 selections={value}
                 variant={SelectVariant.single}
               >
-                <SelectOption
-                  key={0}
-                  value={t("common:choose")}
-                  isPlaceholder
-                />
-                <SelectOption key={1} value="RACT_ONLY" />
-                <SelectOption key={2} value="WRITABLE" />
-                <SelectOption key={3} value="UNSYNCED" />
+                <SelectOption key={0} value="RACT_ONLY" isPlaceholder />
+                <SelectOption key={1} value="WRITABLE" />
+                <SelectOption key={2} value="UNSYNCED" />
               </Select>
             )}
           ></Controller>
@@ -102,8 +97,20 @@ export const LdapSettingsSearching = ({
             type="text"
             id="kc-console-users-dn"
             name="config.usersDn[0]"
-            ref={form.register}
+            ref={form.register({
+              required: {
+                value: true,
+                message: `${t("validateUsersDn")}`,
+              },
+            })}
           />
+          {form.errors.config &&
+            form.errors.config.usersDn &&
+            form.errors.config.usersDn[0] && (
+              <div className="error">
+                {form.errors.config.usersDn[0].message}
+              </div>
+            )}
         </FormGroup>
         <FormGroup
           label={t("usernameLdapAttribute")}
@@ -122,8 +129,20 @@ export const LdapSettingsSearching = ({
             type="text"
             id="kc-username-ldap-attribute"
             name="config.usernameLDAPAttribute[0]"
-            ref={form.register}
+            ref={form.register({
+              required: {
+                value: true,
+                message: `${t("validateUsernameLDAPAttribute")}`,
+              },
+            })}
           />
+          {form.errors.config &&
+            form.errors.config.usernameLDAPAttribute &&
+            form.errors.config.usernameLDAPAttribute[0] && (
+              <div className="error">
+                {form.errors.config.usernameLDAPAttribute[0].message}
+              </div>
+            )}
         </FormGroup>
         <FormGroup
           label={t("rdnLdapAttribute")}
@@ -142,8 +161,20 @@ export const LdapSettingsSearching = ({
             type="text"
             id="kc-rdn-ldap-attribute"
             name="config.rdnLDAPAttribute[0]"
-            ref={form.register}
+            ref={form.register({
+              required: {
+                value: true,
+                message: `${t("validateRdnLdapAttribute")}`,
+              },
+            })}
           />
+          {form.errors.config &&
+            form.errors.config.rdnLDAPAttribute &&
+            form.errors.config.rdnLDAPAttribute[0] && (
+              <div className="error">
+                {form.errors.config.rdnLDAPAttribute[0].message}
+              </div>
+            )}
         </FormGroup>
         <FormGroup
           label={t("uuidLdapAttribute")}
@@ -162,8 +193,20 @@ export const LdapSettingsSearching = ({
             type="text"
             id="kc-uuid-ldap-attribute"
             name="config.uuidLDAPAttribute[0]"
-            ref={form.register}
+            ref={form.register({
+              required: {
+                value: true,
+                message: `${t("validateUuidLDAPAttribute")}`,
+              },
+            })}
           />
+          {form.errors.config &&
+            form.errors.config.uuidLDAPAttribute &&
+            form.errors.config.uuidLDAPAttribute[0] && (
+              <div className="error">
+                {form.errors.config.uuidLDAPAttribute[0].message}
+              </div>
+            )}
         </FormGroup>
         <FormGroup
           label={t("userObjectClasses")}
@@ -182,8 +225,20 @@ export const LdapSettingsSearching = ({
             type="text"
             id="kc-user-object-classes"
             name="config.userObjectClasses[0]"
-            ref={form.register}
+            ref={form.register({
+              required: {
+                value: true,
+                message: `${t("validateUserObjectClasses")}`,
+              },
+            })}
           />
+          {form.errors.config &&
+            form.errors.config.userObjectClasses &&
+            form.errors.config.userObjectClasses[0] && (
+              <div className="error">
+                {form.errors.config.userObjectClasses[0].message}
+              </div>
+            )}
         </FormGroup>
         <FormGroup
           label={t("userLdapFilter")}
@@ -234,15 +289,10 @@ export const LdapSettingsSearching = ({
                 selections={value}
                 variant={SelectVariant.single}
               >
-                <SelectOption
-                  key={0}
-                  value={t("common:choose")}
-                  isPlaceholder
-                />
-                <SelectOption key={1} value="1">
+                <SelectOption key={0} value="1" isPlaceholder>
                   {t("oneLevel")}
                 </SelectOption>
-                <SelectOption key={2} value="2">
+                <SelectOption key={1} value="2">
                   {t("subtree")}
                 </SelectOption>
               </Select>

--- a/src/user-federation/ldap/LdapSettingsSearching.tsx
+++ b/src/user-federation/ldap/LdapSettingsSearching.tsx
@@ -7,70 +7,30 @@ import {
   TextInput,
 } from "@patternfly/react-core";
 import { useTranslation } from "react-i18next";
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { HelpItem } from "../../components/help-enabler/HelpItem";
-import { useForm, Controller } from "react-hook-form";
-import ComponentRepresentation from "keycloak-admin/lib/defs/componentRepresentation";
+import { UseFormMethods, Controller } from "react-hook-form";
 import { FormAccess } from "../../components/form-access/FormAccess";
-import {
-  useAdminClient,
-  asyncStateFetch,
-} from "../../context/auth/AdminClient";
-import { useParams } from "react-router-dom";
-import { convertToFormValues } from "../../util";
 import { WizardSectionHeader } from "../../components/wizard-section-header/WizardSectionHeader";
 
 export type LdapSettingsSearchingProps = {
+  form: UseFormMethods;
   showSectionHeading?: boolean;
   showSectionDescription?: boolean;
 };
 
 export const LdapSettingsSearching = ({
+  form,
   showSectionHeading = false,
   showSectionDescription = false,
 }: LdapSettingsSearchingProps) => {
   const { t } = useTranslation("user-federation");
-  const adminClient = useAdminClient();
   const helpText = useTranslation("user-federation-help").t;
-  const [isEditModeDropdownOpen, setIsEditModeDropdownOpen] = useState(false);
-  const { id } = useParams<{ id: string }>();
+
   const [isSearchScopeDropdownOpen, setIsSearchScopeDropdownOpen] = useState(
     false
   );
-  const { register, control, setValue } = useForm<ComponentRepresentation>();
-
-  const convertSearchScopes = (scope: string) => {
-    switch (scope) {
-      case "1":
-      default:
-        return `${t("oneLevel")}`;
-      case "2":
-        return `${t("subtree")}`;
-    }
-  };
-
-  const setupForm = (component: ComponentRepresentation) => {
-    Object.entries(component).map((entry) => {
-      if (entry[0] === "config") {
-        convertToFormValues(entry[1], "config", setValue);
-        if (entry[1].searchScope) {
-          setValue(
-            "config.searchScope",
-            convertSearchScopes(entry[1].searchScope[0])
-          );
-        }
-      } else {
-        setValue(entry[0], entry[1]);
-      }
-    });
-  };
-
-  useEffect(() => {
-    return asyncStateFetch(
-      () => adminClient.components.findOne({ id }),
-      (fetchedComponent) => setupForm(fetchedComponent)
-    );
-  }, []);
+  const [isEditModeDropdownOpen, setIsEditModeDropdownOpen] = useState(false);
 
   return (
     <>
@@ -97,7 +57,7 @@ export const LdapSettingsSearching = ({
           <Controller
             name="config.editMode"
             defaultValue=""
-            control={control}
+            control={form.control}
             render={({ onChange, value }) => (
               <Select
                 toggleId="kc-edit-mode"
@@ -142,7 +102,7 @@ export const LdapSettingsSearching = ({
             type="text"
             id="kc-console-users-dn"
             name="config.usersDn"
-            ref={register}
+            ref={form.register}
           />
         </FormGroup>
         <FormGroup
@@ -162,7 +122,7 @@ export const LdapSettingsSearching = ({
             type="text"
             id="kc-username-ldap-attribute"
             name="config.usernameLDAPAttribute"
-            ref={register}
+            ref={form.register}
           />
         </FormGroup>
         <FormGroup
@@ -182,7 +142,7 @@ export const LdapSettingsSearching = ({
             type="text"
             id="kc-rdn-ldap-attribute"
             name="config.rdnLDAPAttribute"
-            ref={register}
+            ref={form.register}
           />
         </FormGroup>
         <FormGroup
@@ -202,7 +162,7 @@ export const LdapSettingsSearching = ({
             type="text"
             id="kc-uuid-ldap-attribute"
             name="config.uuidLDAPAttribute"
-            ref={register}
+            ref={form.register}
           />
         </FormGroup>
         <FormGroup
@@ -222,7 +182,7 @@ export const LdapSettingsSearching = ({
             type="text"
             id="kc-user-object-classes"
             name="config.userObjectClasses"
-            ref={register}
+            ref={form.register}
           />
         </FormGroup>
         <FormGroup
@@ -240,7 +200,7 @@ export const LdapSettingsSearching = ({
             type="text"
             id="kc-user-ldap-filter"
             name="config.customUserSearchFilter"
-            ref={register}
+            ref={form.register}
           />
         </FormGroup>
         <FormGroup
@@ -257,7 +217,7 @@ export const LdapSettingsSearching = ({
           <Controller
             name="config.searchScope"
             defaultValue=""
-            control={control}
+            control={form.control}
             render={({ onChange, value }) => (
               <Select
                 toggleId="kc-search-scope"
@@ -299,7 +259,7 @@ export const LdapSettingsSearching = ({
             type="text"
             id="kc-read-timeout"
             name="config.readTimeout"
-            ref={register}
+            ref={form.register}
           />
         </FormGroup>
         <FormGroup
@@ -317,13 +277,13 @@ export const LdapSettingsSearching = ({
           <Controller
             name="config.pagination"
             defaultValue={false}
-            control={control}
+            control={form.control}
             render={({ onChange, value }) => (
               <Switch
                 id={"kc-console-pagination"}
-                isChecked={value[0] === "true"}
                 isDisabled={false}
-                onChange={onChange}
+                onChange={(value) => onChange([`${value}`])}
+                isChecked={value[0] === "true"}
                 label={t("common:on")}
                 labelOff={t("common:off")}
               />

--- a/src/user-federation/ldap/LdapSettingsSearching.tsx
+++ b/src/user-federation/ldap/LdapSettingsSearching.tsx
@@ -55,7 +55,7 @@ export const LdapSettingsSearching = ({
           fieldId="kc-edit-mode"
         >
           <Controller
-            name="config.editMode"
+            name="config.editMode[0]"
             defaultValue=""
             control={form.control}
             render={({ onChange, value }) => (
@@ -101,7 +101,7 @@ export const LdapSettingsSearching = ({
             isRequired
             type="text"
             id="kc-console-users-dn"
-            name="config.usersDn"
+            name="config.usersDn[0]"
             ref={form.register}
           />
         </FormGroup>
@@ -121,7 +121,7 @@ export const LdapSettingsSearching = ({
             isRequired
             type="text"
             id="kc-username-ldap-attribute"
-            name="config.usernameLDAPAttribute"
+            name="config.usernameLDAPAttribute[0]"
             ref={form.register}
           />
         </FormGroup>
@@ -141,7 +141,7 @@ export const LdapSettingsSearching = ({
             isRequired
             type="text"
             id="kc-rdn-ldap-attribute"
-            name="config.rdnLDAPAttribute"
+            name="config.rdnLDAPAttribute[0]"
             ref={form.register}
           />
         </FormGroup>
@@ -161,7 +161,7 @@ export const LdapSettingsSearching = ({
             isRequired
             type="text"
             id="kc-uuid-ldap-attribute"
-            name="config.uuidLDAPAttribute"
+            name="config.uuidLDAPAttribute[0]"
             ref={form.register}
           />
         </FormGroup>
@@ -181,7 +181,7 @@ export const LdapSettingsSearching = ({
             isRequired
             type="text"
             id="kc-user-object-classes"
-            name="config.userObjectClasses"
+            name="config.userObjectClasses[0]"
             ref={form.register}
           />
         </FormGroup>
@@ -199,10 +199,11 @@ export const LdapSettingsSearching = ({
           <TextInput
             type="text"
             id="kc-user-ldap-filter"
-            name="config.customUserSearchFilter"
+            name="config.customUserSearchFilter[0]"
             ref={form.register}
           />
         </FormGroup>
+
         <FormGroup
           label={t("searchScope")}
           labelIcon={
@@ -215,7 +216,7 @@ export const LdapSettingsSearching = ({
           fieldId="kc-search-scope"
         >
           <Controller
-            name="config.searchScope"
+            name="config.searchScope[0]"
             defaultValue=""
             control={form.control}
             render={({ onChange, value }) => (
@@ -238,8 +239,12 @@ export const LdapSettingsSearching = ({
                   value={t("common:choose")}
                   isPlaceholder
                 />
-                <SelectOption key={1} value={t("oneLevel")} />
-                <SelectOption key={2} value={t("subtree")} />
+                <SelectOption key={1} value="1">
+                  {t("oneLevel")}
+                </SelectOption>
+                <SelectOption key={2} value="2">
+                  {t("subtree")}
+                </SelectOption>
               </Select>
             )}
           ></Controller>
@@ -258,7 +263,7 @@ export const LdapSettingsSearching = ({
           <TextInput
             type="text"
             id="kc-read-timeout"
-            name="config.readTimeout"
+            name="config.readTimeout[0]"
             ref={form.register}
           />
         </FormGroup>

--- a/src/user-federation/ldap/LdapSettingsSearching.tsx
+++ b/src/user-federation/ldap/LdapSettingsSearching.tsx
@@ -73,9 +73,10 @@ export const LdapSettingsSearching = ({
                 selections={value}
                 variant={SelectVariant.single}
               >
-                <SelectOption key={0} value="READ_ONLY" isPlaceholder />
-                <SelectOption key={1} value="WRITABLE" />
-                <SelectOption key={2} value="UNSYNCED" />
+                <SelectOption key={0} value="" isPlaceholder />
+                <SelectOption key={1} value="READ_ONLY" />
+                <SelectOption key={2} value="WRITABLE" />
+                <SelectOption key={3} value="UNSYNCED" />
               </Select>
             )}
           ></Controller>

--- a/src/user-federation/ldap/LdapSettingsSynchronization.tsx
+++ b/src/user-federation/ldap/LdapSettingsSynchronization.tsx
@@ -73,45 +73,49 @@ export const LdapSettingsSynchronization = ({
           <TextInput
             type="text"
             id="kc-batch-size"
-            name="config.batchSizeForSync"
+            name="config.batchSizeForSync[0]"
             ref={form.register}
           />
         </FormGroup>
+
+        {/* Enter -1 to switch off, otherwise enter value */}
         <FormGroup
           hasNoPaddingTop
-          label={t("periodicFullSync")}
+          label={t("fullSyncPeriod")}
           labelIcon={
             <HelpItem
-              helpText={helpText("periodicFullSyncHelp")}
-              forLabel={t("periodicFullSync")}
-              forID="kc-periodic-full-sync"
+              helpText={helpText("fullSyncPeriodHelp")}
+              forLabel={t("fullSyncPeriod")}
+              forID="kc-full-sync-period"
             />
           }
-          fieldId="kc-periodic-full-sync"
+          fieldId="kc-full-sync-period"
         >
           <TextInput
             type="text"
-            id="kc-batch-size"
-            name="config.fullSyncPeriod"
+            id="kc-full-sync-period"
+            name="config.fullSyncPeriod[0]"
             ref={form.register}
           />
         </FormGroup>
+
+        {/* Enter -1 to switch off, otherwise enter value */}
         <FormGroup
-          label={t("periodicChangedUsersSync")}
+          label={t("changedUsersSyncPeriod")}
           labelIcon={
             <HelpItem
-              helpText={helpText("periodicChangedUsersSyncHelp")}
-              forLabel={t("periodicChangedUsersSync")}
-              forID="kc-periodic-changed-users-sync"
+              helpText={helpText("changedUsersSyncHelp")}
+              forLabel={t("changedUsersSyncPeriod")}
+              forID="kc-changed-users-sync-period"
             />
           }
-          fieldId="kc-periodic-changed-users-sync"
+          fieldId="kc-changed-users-sync-period"
           hasNoPaddingTop
         >
           <TextInput
             type="text"
-            id="kc-batch-size"
-            name="config.changedSyncPeriod"
+            id="kc-changed-users-sync-period"
+            name="config.changedSyncPeriod[0]"
             ref={form.register}
           />
         </FormGroup>

--- a/src/user-federation/ldap/LdapSettingsSynchronization.tsx
+++ b/src/user-federation/ldap/LdapSettingsSynchronization.tsx
@@ -1,49 +1,24 @@
 import { FormGroup, Switch, TextInput } from "@patternfly/react-core";
 import { useTranslation } from "react-i18next";
-import React, { useEffect } from "react";
+import React from "react";
 import { HelpItem } from "../../components/help-enabler/HelpItem";
-import { useForm, Controller } from "react-hook-form";
-import { convertToFormValues } from "../../util";
-import ComponentRepresentation from "keycloak-admin/lib/defs/componentRepresentation";
+import { UseFormMethods, Controller } from "react-hook-form";
 import { FormAccess } from "../../components/form-access/FormAccess";
-import {
-  useAdminClient,
-  asyncStateFetch,
-} from "../../context/auth/AdminClient";
-import { useParams } from "react-router-dom";
 import { WizardSectionHeader } from "../../components/wizard-section-header/WizardSectionHeader";
 
 export type LdapSettingsSynchronizationProps = {
+  form: UseFormMethods;
   showSectionHeading?: boolean;
   showSectionDescription?: boolean;
 };
 
 export const LdapSettingsSynchronization = ({
+  form,
   showSectionHeading = false,
   showSectionDescription = false,
 }: LdapSettingsSynchronizationProps) => {
   const { t } = useTranslation("user-federation");
   const helpText = useTranslation("user-federation-help").t;
-  const adminClient = useAdminClient();
-  const { register, control, setValue } = useForm<ComponentRepresentation>();
-  const { id } = useParams<{ id: string }>();
-
-  const setupForm = (component: ComponentRepresentation) => {
-    Object.entries(component).map((entry) => {
-      if (entry[0] === "config") {
-        convertToFormValues(entry[1], "config", setValue);
-      } else {
-        setValue(entry[0], entry[1]);
-      }
-    });
-  };
-
-  useEffect(() => {
-    return asyncStateFetch(
-      () => adminClient.components.findOne({ id }),
-      (fetchedComponent) => setupForm(fetchedComponent)
-    );
-  }, []);
 
   return (
     <>
@@ -54,7 +29,6 @@ export const LdapSettingsSynchronization = ({
           showDescription={showSectionDescription}
         />
       )}
-
       <FormAccess role="manage-realm" isHorizontal>
         <FormGroup
           hasNoPaddingTop
@@ -71,16 +45,16 @@ export const LdapSettingsSynchronization = ({
           <Controller
             name="config.importEnabled"
             defaultValue={false}
-            control={control}
+            control={form.control}
             render={({ onChange, value }) => (
               <Switch
                 id={"kc-import-users"}
                 name="importEnabled"
                 label={t("common:on")}
                 labelOff={t("common:off")}
+                onChange={(value) => onChange([`${value}`])}
                 isChecked={value[0] === "true"}
                 isDisabled={false}
-                onChange={onChange}
               />
             )}
           ></Controller>
@@ -100,7 +74,7 @@ export const LdapSettingsSynchronization = ({
             type="text"
             id="kc-batch-size"
             name="config.batchSizeForSync"
-            ref={register}
+            ref={form.register}
           />
         </FormGroup>
         <FormGroup
@@ -119,7 +93,7 @@ export const LdapSettingsSynchronization = ({
             type="text"
             id="kc-batch-size"
             name="config.fullSyncPeriod"
-            ref={register}
+            ref={form.register}
           />
         </FormGroup>
         <FormGroup
@@ -138,7 +112,7 @@ export const LdapSettingsSynchronization = ({
             type="text"
             id="kc-batch-size"
             name="config.changedSyncPeriod"
-            ref={register}
+            ref={form.register}
           />
         </FormGroup>
       </FormAccess>

--- a/src/user-federation/messages.json
+++ b/src/user-federation/messages.json
@@ -94,6 +94,13 @@
     "validateRealm":"You must enter a realm",
     "validateServerPrincipal":"You must enter a server principal",
     "validateKeyTab": "You must enter a key tab",
+    "validateConnectionUrl": "You must enter a connection URL",
+    "validateBindCredentials": "You must enter bind credentials",
+    "validateUuidLDAPAttribute": "You must enter a UUID LDAP attribute",
+    "validateUserObjectClasses": "You must enter one or more user object classes",
+    "validateUsersDn": "You must enter users DN",
+    "validateUsernameLDAPAttribute": "You must enter a username LDAP attribute",
+    "validateRdnLdapAttribute": "You must enter an RDN LDAP attribute",
 
     "id": "ID",
     "mapperType": "Mapper type",

--- a/src/user-federation/messages.json
+++ b/src/user-federation/messages.json
@@ -46,7 +46,9 @@
     "importUsers": "Import users",
     "batchSize": "Batch size",
     "periodicFullSync": "Periodic full sync",
+    "fullSyncPeriod": "Full sync period",
     "periodicChangedUsersSync": "Periodic changed users sync",
+    "changedUsersSyncPeriod": "Changed users sync period",
 
     "kerberosIntegration": "Kerberos integration",
     "allowKerberosAuthentication": "Allow Kerberos authentication",


### PR DESCRIPTION
## Motivation
https://issues.redhat.com/browse/APPDUX-720

## Brief Description
Adds the ability to save (or cancel) changes made to the User Federation Kerberos settings page.

## Verification Steps
1. Go to User federation and select an LDAP card.
2. Change any of the values in any of the subsections.
3. Click Save. You should see a success alert.
4. Verify that the changes have been saved by traversing anywhere else in the UI and then re-clicking the card to make sure the values that were changed are displayed correctly.

## Checklist:
- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [x] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated
- [x] Formatting has been performed via prettier/eslint
- [ ] Type checking has been performed via 'yarn check-types'

## Additional Notes


