### PR TITLE
added roles tab to clients

### DIFF
--- a/src/clients/ClientDetails.tsx
+++ b/src/clients/ClientDetails.tsx
@@ -31,7 +31,7 @@ import {
 } from "../components/multi-line-input/MultiLineInput";
 import { ClientScopes } from "./scopes/ClientScopes";
 import { EvaluateScopes } from "./scopes/EvaluateScopes";
-import { RealmRolesList } from "../realm-roles/RealmRolesList";
+import { RolesList } from "../realm-roles/RolesList";
 import { ServiceAccount } from "./service-account/ServiceAccount";
 import { KeycloakTabs } from "../components/keycloak-tabs/KeycloakTabs";
 
@@ -108,6 +108,10 @@ export const ClientDetails = () => {
   const { id } = useParams<{ id: string }>();
 
   const [client, setClient] = useState<ClientRepresentation>();
+
+  const loader = async () => {
+    return await adminClient.clients.listRoles({ id });
+  };
 
   const [toggleDeleteDialog, DeleteConfirm] = useConfirmDialog({
     titleKey: "clients:clientDeleteConfirmTitle",
@@ -221,7 +225,7 @@ export const ClientDetails = () => {
             eventKey="roles"
             title={<TabTitleText>{t("roles")}</TabTitleText>}
           >
-            <RealmRolesList />
+            <RolesList loader={loader} paginated={false} />
           </Tab>
           <Tab
             eventKey="clientScopes"

--- a/src/clients/ClientDetails.tsx
+++ b/src/clients/ClientDetails.tsx
@@ -31,6 +31,7 @@ import {
 } from "../components/multi-line-input/MultiLineInput";
 import { ClientScopes } from "./scopes/ClientScopes";
 import { EvaluateScopes } from "./scopes/EvaluateScopes";
+import { RealmRolesList } from "../realm-roles/RealmRolesList";
 import { ServiceAccount } from "./service-account/ServiceAccount";
 import { KeycloakTabs } from "../components/keycloak-tabs/KeycloakTabs";
 
@@ -216,6 +217,12 @@ export const ClientDetails = () => {
               <Credentials clientId={id} form={form} save={save} />
             </Tab>
           )}
+          <Tab
+            eventKey="roles"
+            title={<TabTitleText>{t("roles")}</TabTitleText>}
+          >
+            <RealmRolesList />
+          </Tab>
           <Tab
             eventKey="clientScopes"
             title={<TabTitleText>{t("clientScopes")}</TabTitleText>}

--- a/src/clients/messages.json
+++ b/src/clients/messages.json
@@ -9,6 +9,7 @@
     "formatOption": "Format option",
     "downloadAdaptorTitle": "Download adaptor configs",
     "credentials": "Credentials",
+    "roles": "Roles",
     "clientScopes": "Client scopes",
     "addClientScope": "Add client scope",
     "addClientScopesTo": "Add client scopes to {{clientId}}",

--- a/src/realm-roles/RealmRoleTabs.tsx
+++ b/src/realm-roles/RealmRoleTabs.tsx
@@ -95,13 +95,13 @@ export const RealmRoleTabs = () => {
         }
         if (!clientId) {
           await adminClient.roles.updateById({ id }, roleRepresentation);
-          setRole(role);
         } else {
           await adminClient.clients.updateRole(
             { id: clientId, roleName: role.name! },
-            role
+            roleRepresentation
           );
         }
+        setRole(role);
       } else {
         let createdRole;
         if (!clientId) {
@@ -117,7 +117,7 @@ export const RealmRoleTabs = () => {
           if (role.description) {
             await adminClient.clients.updateRole(
               { id: clientId, roleName: role.name! },
-              role
+              roleRepresentation
             );
           }
           createdRole = await adminClient.clients.findRole({
@@ -154,7 +154,7 @@ export const RealmRoleTabs = () => {
           await adminClient.clients.delRole({ id: clientId, roleName: name });
         }
         addAlert(t("roleDeletedSuccess"), AlertVariant.success);
-        const loc = url.replaceAll("/attributes", "");
+        const loc = url.replace(/\/attributes/g, "");
         history.replace(`${loc.substr(0, loc.lastIndexOf("/"))}`);
       } catch (error) {
         addAlert(`${t("roleDeleteError")} ${error}`, AlertVariant.danger);

--- a/src/realm-roles/RealmRoleTabs.tsx
+++ b/src/realm-roles/RealmRoleTabs.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { useHistory, useParams } from "react-router-dom";
+import { useHistory, useParams, useRouteMatch } from "react-router-dom";
 import {
   AlertVariant,
   ButtonVariant,
@@ -55,6 +55,7 @@ export const RealmRoleTabs = () => {
   const [role, setRole] = useState<RoleFormType>();
 
   const { id } = useParams<{ id: string }>();
+  const { url } = useRouteMatch();
   const { addAlert } = useAlerts();
 
   const [open, setOpen] = useState(false);
@@ -102,7 +103,7 @@ export const RealmRoleTabs = () => {
           name: role.name!,
         });
         setRole(convert(createdRole));
-        history.push(`/${realm}/roles/${createdRole.id}`);
+        history.push(url.substr(0, url.lastIndexOf("/") + 1) + createdRole.id);
       }
       addAlert(t(id ? "roleSaveSuccess" : "roleCreated"), AlertVariant.success);
     } catch (error) {

--- a/src/realm-roles/RealmRoleTabs.tsx
+++ b/src/realm-roles/RealmRoleTabs.tsx
@@ -114,6 +114,12 @@ export const RealmRoleTabs = () => {
             id: clientId,
             name: role.name,
           });
+          if (role.description) {
+            await adminClient.clients.updateRole(
+              { id: clientId, roleName: role.name! },
+              role
+            );
+          }
           createdRole = await adminClient.clients.findRole({
             id: clientId,
             roleName: role.name!,
@@ -148,7 +154,8 @@ export const RealmRoleTabs = () => {
           await adminClient.clients.delRole({ id: clientId, roleName: name });
         }
         addAlert(t("roleDeletedSuccess"), AlertVariant.success);
-        history.replace(`${url.substr(0, url.lastIndexOf("/"))}`);
+        const loc = url.replaceAll("/attributes", "");
+        history.replace(`${loc.substr(0, loc.lastIndexOf("/"))}`);
       } catch (error) {
         addAlert(`${t("roleDeleteError")} ${error}`, AlertVariant.danger);
       }

--- a/src/realm-roles/RealmRolesList.tsx
+++ b/src/realm-roles/RealmRolesList.tsx
@@ -1,0 +1,115 @@
+import React, { useState } from "react";
+import { Link, useHistory, useRouteMatch } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { AlertVariant, Button, ButtonVariant } from "@patternfly/react-core";
+
+import { useAdminClient } from "../context/auth/AdminClient";
+import RoleRepresentation from "keycloak-admin/lib/defs/roleRepresentation";
+import { ListEmptyState } from "../components/list-empty-state/ListEmptyState";
+import { KeycloakDataTable } from "../components/table-toolbar/KeycloakDataTable";
+import { formattedLinkTableCell } from "../components/external-link/FormattedLink";
+import { useAlerts } from "../components/alert/Alerts";
+import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
+import { emptyFormatter, boolFormatter } from "../util";
+
+export const RealmRolesList = () => {
+  const { t } = useTranslation("roles");
+  const history = useHistory();
+  const adminClient = useAdminClient();
+  const { addAlert } = useAlerts();
+  const { url } = useRouteMatch();
+
+  const [selectedRole, setSelectedRole] = useState<RoleRepresentation>();
+
+  const loader = async (to?: number, max?: number, search?: string) => {
+    const params: { [name: string]: string | number } = {
+      to: to!,
+      max: max!,
+      search: search!,
+    };
+    return await adminClient.roles.find(params);
+  };
+
+  const RoleDetailLink = (role: RoleRepresentation) => (
+    <>
+      <Link key={role.id} to={`${url}/${role.id}`}>
+        {role.name}
+      </Link>
+    </>
+  );
+
+  const [toggleDeleteDialog, DeleteConfirm] = useConfirmDialog({
+    titleKey: "roles:roleDeleteConfirm",
+    messageKey: t("roles:roleDeleteConfirmDialog", {
+      selectedRoleName: selectedRole ? selectedRole!.name : "",
+    }),
+    continueButtonLabel: "common:delete",
+    continueButtonVariant: ButtonVariant.danger,
+    onConfirm: async () => {
+      try {
+        await adminClient.roles.delById({
+          id: selectedRole!.id!,
+        });
+        setSelectedRole(undefined);
+        addAlert(t("roleDeletedSuccess"), AlertVariant.success);
+      } catch (error) {
+        addAlert(`${t("roleDeleteError")} ${error}`, AlertVariant.danger);
+      }
+    },
+  });
+
+  const goToCreate = () => history.push(`${url}/add-role`);
+  return (
+    <>
+      <DeleteConfirm />
+      <KeycloakDataTable
+        key={selectedRole ? selectedRole.id : "roleList"}
+        loader={loader}
+        ariaLabelKey="roles:roleList"
+        searchPlaceholderKey="roles:searchFor"
+        isPaginated
+        toolbarItem={
+          <>
+            <Button onClick={goToCreate}>{t("createRole")}</Button>
+          </>
+        }
+        actions={[
+          {
+            title: t("common:delete"),
+            onRowClick: (role) => {
+              setSelectedRole(role);
+              toggleDeleteDialog();
+            },
+          },
+        ]}
+        columns={[
+          {
+            name: "name",
+            displayKey: "roles:roleName",
+            cellRenderer: RoleDetailLink,
+            cellFormatters: [formattedLinkTableCell(), emptyFormatter()],
+          },
+          {
+            name: "composite",
+            displayKey: "roles:composite",
+            cellFormatters: [boolFormatter(), emptyFormatter()],
+          },
+          {
+            name: "description",
+            displayKey: "common:description",
+            cellFormatters: [emptyFormatter()],
+          },
+        ]}
+        emptyState={
+          <ListEmptyState
+            hasIcon={true}
+            message={t("noRolesInThisRealm")}
+            instructions={t("noRolesInThisRealmInstructions")}
+            primaryActionText={t("createRole")}
+            onPrimaryAction={goToCreate}
+          />
+        }
+      />
+    </>
+  );
+};

--- a/src/realm-roles/RealmRolesSection.tsx
+++ b/src/realm-roles/RealmRolesSection.tsx
@@ -1,123 +1,14 @@
-import React, { useState } from "react";
-import { Link, useHistory, useRouteMatch } from "react-router-dom";
-import { useTranslation } from "react-i18next";
-import {
-  AlertVariant,
-  Button,
-  ButtonVariant,
-  PageSection,
-} from "@patternfly/react-core";
-import { boolFormatter } from "../util";
-import { useAdminClient } from "../context/auth/AdminClient";
+import React from "react";
+import { PageSection } from "@patternfly/react-core";
 import { ViewHeader } from "../components/view-header/ViewHeader";
-import RoleRepresentation from "keycloak-admin/lib/defs/roleRepresentation";
-import { ListEmptyState } from "../components/list-empty-state/ListEmptyState";
-import { KeycloakDataTable } from "../components/table-toolbar/KeycloakDataTable";
-import { formattedLinkTableCell } from "../components/external-link/FormattedLink";
-import { useAlerts } from "../components/alert/Alerts";
-import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
-import { emptyFormatter } from "../util";
+import { RealmRolesList } from "./RealmRolesList";
 
 export const RealmRolesSection = () => {
-  const { t } = useTranslation("roles");
-  const history = useHistory();
-  const adminClient = useAdminClient();
-  const { addAlert } = useAlerts();
-  const { url } = useRouteMatch();
-
-  const [selectedRole, setSelectedRole] = useState<RoleRepresentation>();
-
-  const loader = async (to?: number, max?: number, search?: string) => {
-    const params: { [name: string]: string | number } = {
-      to: to!,
-      max: max!,
-      search: search!,
-    };
-    return await adminClient.roles.find(params);
-  };
-
-  const RoleDetailLink = (role: RoleRepresentation) => (
-    <>
-      <Link key={role.id} to={`${url}/${role.id}`}>
-        {role.name}
-      </Link>
-    </>
-  );
-
-  const [toggleDeleteDialog, DeleteConfirm] = useConfirmDialog({
-    titleKey: "roles:roleDeleteConfirm",
-    messageKey: t("roles:roleDeleteConfirmDialog", {
-      selectedRoleName: selectedRole ? selectedRole!.name : "",
-    }),
-    continueButtonLabel: "common:delete",
-    continueButtonVariant: ButtonVariant.danger,
-    onConfirm: async () => {
-      try {
-        await adminClient.roles.delById({
-          id: selectedRole!.id!,
-        });
-        setSelectedRole(undefined);
-        addAlert(t("roleDeletedSuccess"), AlertVariant.success);
-      } catch (error) {
-        addAlert(`${t("roleDeleteError")} ${error}`, AlertVariant.danger);
-      }
-    },
-  });
-
-  const goToCreate = () => history.push(`${url}/add-role`);
   return (
     <>
       <ViewHeader titleKey="roles:title" subKey="roles:roleExplain" />
       <PageSection variant="light">
-        <DeleteConfirm />
-        <KeycloakDataTable
-          key={selectedRole ? selectedRole.id : "roleList"}
-          loader={loader}
-          ariaLabelKey="roles:roleList"
-          searchPlaceholderKey="roles:searchFor"
-          isPaginated
-          toolbarItem={
-            <>
-              <Button onClick={goToCreate}>{t("createRole")}</Button>
-            </>
-          }
-          actions={[
-            {
-              title: t("common:delete"),
-              onRowClick: (role) => {
-                setSelectedRole(role);
-                toggleDeleteDialog();
-              },
-            },
-          ]}
-          columns={[
-            {
-              name: "name",
-              displayKey: "roles:roleName",
-              cellRenderer: RoleDetailLink,
-              cellFormatters: [formattedLinkTableCell(), emptyFormatter()],
-            },
-            {
-              name: "composite",
-              displayKey: "roles:composite",
-              cellFormatters: [boolFormatter(), emptyFormatter()],
-            },
-            {
-              name: "description",
-              displayKey: "common:description",
-              cellFormatters: [emptyFormatter()],
-            },
-          ]}
-          emptyState={
-            <ListEmptyState
-              hasIcon={true}
-              message={t("noRolesInThisRealm")}
-              instructions={t("noRolesInThisRealmInstructions")}
-              primaryActionText={t("createRole")}
-              onPrimaryAction={goToCreate}
-            />
-          }
-        />
+        <RealmRolesList />
       </PageSection>
     </>
   );

--- a/src/realm-roles/RealmRolesSection.tsx
+++ b/src/realm-roles/RealmRolesSection.tsx
@@ -1,14 +1,24 @@
 import React from "react";
 import { PageSection } from "@patternfly/react-core";
 import { ViewHeader } from "../components/view-header/ViewHeader";
-import { RealmRolesList } from "./RealmRolesList";
+import { useAdminClient } from "../context/auth/AdminClient";
+import { RolesList } from "./RolesList";
 
 export const RealmRolesSection = () => {
+  const adminClient = useAdminClient();
+  const loader = async (to?: number, max?: number, search?: string) => {
+    const params: { [name: string]: string | number } = {
+      to: to!,
+      max: max!,
+      search: search!,
+    };
+    return await adminClient.roles.find(params);
+  };
   return (
     <>
       <ViewHeader titleKey="roles:title" subKey="roles:roleExplain" />
       <PageSection variant="light">
-        <RealmRolesList />
+        <RolesList loader={loader} />
       </PageSection>
     </>
   );

--- a/src/realm-roles/RolesList.tsx
+++ b/src/realm-roles/RolesList.tsx
@@ -12,7 +12,12 @@ import { useAlerts } from "../components/alert/Alerts";
 import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
 import { emptyFormatter, boolFormatter } from "../util";
 
-export const RealmRolesList = () => {
+type RolesListProps = {
+  loader: (first?: number, max?: number, search?: string) => Promise<RoleRepresentation[]>;
+  paginated?: boolean;
+}
+
+export const RolesList = ({ loader, paginated = true }: RolesListProps) => {
   const { t } = useTranslation("roles");
   const history = useHistory();
   const adminClient = useAdminClient();
@@ -20,15 +25,6 @@ export const RealmRolesList = () => {
   const { url } = useRouteMatch();
 
   const [selectedRole, setSelectedRole] = useState<RoleRepresentation>();
-
-  const loader = async (to?: number, max?: number, search?: string) => {
-    const params: { [name: string]: string | number } = {
-      to: to!,
-      max: max!,
-      search: search!,
-    };
-    return await adminClient.roles.find(params);
-  };
 
   const RoleDetailLink = (role: RoleRepresentation) => (
     <>
@@ -67,7 +63,7 @@ export const RealmRolesList = () => {
         loader={loader}
         ariaLabelKey="roles:roleList"
         searchPlaceholderKey="roles:searchFor"
-        isPaginated
+        isPaginated={paginated}
         toolbarItem={
           <>
             <Button onClick={goToCreate}>{t("createRole")}</Button>

--- a/src/realm-roles/RolesList.tsx
+++ b/src/realm-roles/RolesList.tsx
@@ -13,9 +13,13 @@ import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
 import { emptyFormatter, boolFormatter } from "../util";
 
 type RolesListProps = {
-  loader: (first?: number, max?: number, search?: string) => Promise<RoleRepresentation[]>;
+  loader: (
+    first?: number,
+    max?: number,
+    search?: string
+  ) => Promise<RoleRepresentation[]>;
   paginated?: boolean;
-}
+};
 
 export const RolesList = ({ loader, paginated = true }: RolesListProps) => {
   const { t } = useTranslation("roles");

--- a/src/route-config.ts
+++ b/src/route-config.ts
@@ -71,13 +71,13 @@ export const routes: RoutesFn = (t: TFunction) => [
     access: "manage-realm",
   },
   {
-    path: "/:realm/clients/:id/roles/:id",
+    path: "/:realm/clients/:clientId/roles/:id",
     component: RealmRoleTabs,
     breadcrumb: t("roles:roleDetails"),
     access: "view-realm",
   },
   {
-    path: "/:realm/clients/:id/roles/:id/:tab",
+    path: "/:realm/clients/:clientId/roles/:id/:tab",
     component: RealmRoleTabs,
     breadcrumb: null,
     access: "view-realm",

--- a/src/route-config.ts
+++ b/src/route-config.ts
@@ -65,6 +65,24 @@ export const routes: RoutesFn = (t: TFunction) => [
     access: "view-clients",
   },
   {
+    path: "/:realm/clients/:clientId/roles/add-role",
+    component: RealmRoleTabs,
+    breadcrumb: t("roles:createRole"),
+    access: "manage-realm",
+  },
+  {
+    path: "/:realm/clients/:id/roles/:id",
+    component: RealmRoleTabs,
+    breadcrumb: t("roles:roleDetails"),
+    access: "view-realm",
+  },
+  {
+    path: "/:realm/clients/:id/roles/:id/:tab",
+    component: RealmRoleTabs,
+    breadcrumb: null,
+    access: "view-realm",
+  },
+  {
     path: "/:realm/clients/:id/:tab?/:subtab?",
     component: ClientDetails,
     breadcrumb: null,

--- a/src/user/SearchUser.tsx
+++ b/src/user/SearchUser.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import {
+  Button,
+  ButtonVariant,
+  EmptyState,
+  EmptyStateBody,
+  Form,
+  InputGroup,
+  TextInput,
+  Title,
+} from "@patternfly/react-core";
+import { SearchIcon } from "@patternfly/react-icons";
+import { useForm } from "react-hook-form";
+
+type SearchUserProps = {
+  onSearch: (search: string) => void;
+};
+
+export const SearchUser = ({ onSearch }: SearchUserProps) => {
+  const { t } = useTranslation("users");
+  const { register, handleSubmit } = useForm<{ search: string }>();
+  return (
+    <EmptyState>
+      <Title headingLevel="h4" size="lg">
+        {t("startBySearchingAUser")}
+      </Title>
+      <EmptyStateBody>
+        {t("startIntro")}
+        <Form onSubmit={handleSubmit((form) => onSearch(form.search))}>
+          <InputGroup>
+            <TextInput
+              type="text"
+              id="kc-user-search"
+              name="search"
+              ref={register()}
+            />
+            <Button
+              variant={ButtonVariant.control}
+              aria-label={t("common:search")}
+              type="submit"
+            >
+              <SearchIcon />
+            </Button>
+          </InputGroup>
+        </Form>
+      </EmptyStateBody>
+      <Button variant="link" onClick={() => {}}>
+        {t("createNewUser")}
+      </Button>
+    </EmptyState>
+  );
+};


### PR DESCRIPTION
## Motivation
Roles tab under clients is the same as the roles section this PR add it see [marvel](https://marvelapp.com/prototype/bi16ff1/screen/75842763)

## Brief Description
<!-- Add a short answer for: 
What was done in this PR? (e.g Fix to prevent users from accessing feature X.)
Why it was done? (e.g Feature X was deprecated.)
-->

## Verification Steps
<!--
Add the steps required to verify this change. Keep in mind that these steps should be written so groups unfamiliar with the 
new functionality can follow them, such as QE or documentation.

1. Go to `XX >> YY >> SS`.
2. Create a new item `N` with info `X`.
3. Right-click the item and select Delete.
4. Verify that the item is no longer present in the left navigation menu.
-->
See that there is a new tab under client details named roles that has the same functionality as the roles section

## Checklist:

- [x] Code has been tested locally by PR requester
- [x] Formatting has been performed via prettier/eslint
- [x] Type checking has been performed via 'yarn check-types'

## Additional Notes
<!-- 
Add images and/or screen caps to illustrate what was changed if this pull request adds to or modifies existing user-visible appearance/output. 
-->