### PR TITLE
Modify CRUD tests

### DIFF
--- a/tests/cypress/integration/client_scopes_test.spec.js
+++ b/tests/cypress/integration/client_scopes_test.spec.js
@@ -5,7 +5,7 @@ import SidebarPage from "../support/pages/admin_console/SidebarPage.js";
 import CreateClientScopePage from "../support/pages/admin_console/manage/client_scopes/CreateClientScopePage.js";
 
 describe("Client Scopes test", function () {
-  const itemId = "client_scope_1";
+  let itemId = "client_scope_crud";
   const loginPage = new LoginPage();
   const masthead = new Masthead();
   const sidebarPage = new SidebarPage();
@@ -14,14 +14,13 @@ describe("Client Scopes test", function () {
 
   describe("Client Scope creation", function () {
     beforeEach(function () {
+      cy.clearCookies();
       cy.visit("");
+      loginPage.logIn();
+      sidebarPage.goToClientScopes();
     });
 
     it("should fail creating client scope", function () {
-      loginPage.logIn();
-
-      sidebarPage.goToClientScopes();
-
       listingPage.goToCreateItem();
 
       createClientScopePage.save().checkClientNameRequiredMessage();
@@ -37,38 +36,31 @@ describe("Client Scopes test", function () {
       );
     });
 
-    it("should create client scope", function () {
-      loginPage.logIn();
+    it('Client scope CRUD test',async function () {
+      itemId += "_" + (Math.random() + 1).toString(36).substring(7);
+
+      // Create
+      listingPage
+        .itemExist(itemId, false)
+        .goToCreateItem();
+
+      createClientScopePage
+        .fillClientScopeData(itemId)
+        .save();
+
+        masthead.checkNotificationMessage('Client scope created');
 
       sidebarPage.goToClientScopes();
 
-      listingPage.itemExist(itemId, false).goToCreateItem();
+      // Delete
+      listingPage
+        .itemExist(itemId)
+        .deleteItem(itemId); // There should be a confirmation pop-up
 
-      createClientScopePage.fillClientScopeData(itemId).save();
+        masthead.checkNotificationMessage('The client scope has been deleted');
 
-      masthead.checkNotificationMessage("Client scope created");
-
-      sidebarPage.goToClientScopes();
-
-      listingPage.itemExist(itemId).searchItem(itemId).itemExist(itemId);
+      listingPage // It is not refreshing after delete
+        .itemExist(itemId, false);
     });
   });
-
-  describe("Client scope elimination", function () {
-    beforeEach(function () {
-      cy.visit("");
-    });
-
-    it("should delete client scope", function () {
-      loginPage.logIn();
-
-      sidebarPage.goToClientScopes();
-
-      listingPage.itemExist(itemId).deleteItem(itemId); // There should be a confirmation pop-up
-
-      masthead.checkNotificationMessage("The client scope has been deleted");
-
-      listingPage.itemExist(itemId, false);
-    });
-  });
-});
+})

--- a/tests/cypress/integration/clients_test.spec.js
+++ b/tests/cypress/integration/clients_test.spec.js
@@ -5,7 +5,7 @@ import SidebarPage from "../support/pages/admin_console/SidebarPage.js";
 import CreateClientPage from "../support/pages/admin_console/manage/clients/CreateClientPage.js";
 
 describe("Clients test", function () {
-  const itemId = "client_1";
+  let itemId = "client_crud";
   const loginPage = new LoginPage();
   const masthead = new Masthead();
   const sidebarPage = new SidebarPage();
@@ -14,14 +14,13 @@ describe("Clients test", function () {
 
   describe("Client creation", function () {
     beforeEach(function () {
+      cy.clearCookies();
       cy.visit("");
+      loginPage.logIn();
+      sidebarPage.goToClients();
     });
 
     it("should fail creating client", function () {
-      loginPage.logIn();
-
-      sidebarPage.goToClients();
-
       listingPage.goToCreateItem();
 
       createClientPage
@@ -50,11 +49,10 @@ describe("Clients test", function () {
       );
     });
 
-    it("should create client", function () {
-      loginPage.logIn();
-
-      sidebarPage.goToClients();
-
+    it("Client CRUD test", function () {
+      itemId += "_" + (Math.random() + 1).toString(36).substring(7);
+      
+      // Create
       listingPage.itemExist(itemId, false).goToCreateItem();
 
       createClientPage
@@ -67,21 +65,13 @@ describe("Clients test", function () {
 
       sidebarPage.goToClients();
 
-      listingPage.itemExist(itemId).searchItem(itemId).itemExist(itemId);
-    });
-  });
+      listingPage
+        .searchItem(itemId)
+        .itemExist(itemId);
 
-  describe("Client elimination", function () {
-    beforeEach(function () {
-      cy.visit("");
-    });
-
-    it("should delete client", function () {
-      loginPage.logIn();
-
-      sidebarPage.goToClients();
-
-      listingPage.itemExist(itemId).deleteItem(itemId); // There should be a confirmation pop-up
+      // Delete
+      listingPage
+        .deleteItem(itemId); // There should be a confirmation pop-up
 
       masthead.checkNotificationMessage("The client has been deleted");
 

--- a/tests/cypress/integration/masthead_test.spec.js
+++ b/tests/cypress/integration/masthead_test.spec.js
@@ -24,6 +24,7 @@ const goToAcctMgtTest = () => {
 
 describe("Masthead tests in desktop mode", () => {
   beforeEach(() => {
+    cy.clearCookies();
     cy.visit("");
     loginPage.logIn();
   });
@@ -51,6 +52,7 @@ describe("Masthead tests in desktop mode", () => {
 
 describe("Masthead tests with kebab menu", () => {
   beforeEach(() => {
+    cy.clearCookies();
     cy.visit("");
     loginPage.logIn();
     masthead.setMobileMode(true);

--- a/tests/cypress/integration/realm_roles_test.spec.js
+++ b/tests/cypress/integration/realm_roles_test.spec.js
@@ -6,7 +6,7 @@ import SidebarPage from "../support/pages/admin_console/SidebarPage.js";
 import CreateRealmRolePage from "../support/pages/admin_console/manage/realm_roles/CreateRealmRolePage.js";
 
 describe("Realm roles test", function () {
-  const itemId = "realm_role_1";
+  let itemId = "realm_role_crud";
   const loginPage = new LoginPage();
   const masthead = new Masthead();
   const modalUtils = new ModalUtils();
@@ -16,14 +16,13 @@ describe("Realm roles test", function () {
 
   describe("Realm roles creation", function () {
     beforeEach(function () {
+      cy.clearCookies();
       cy.visit("");
+      loginPage.logIn();
+      sidebarPage.goToRealmRoles();
     });
 
     it("should fail creating realm role", function () {
-      loginPage.logIn();
-
-      sidebarPage.goToRealmRoles();
-
       listingPage.goToCreateItem();
 
       createRealmRolePage.save().checkRealmRoleNameRequiredMessage();
@@ -36,12 +35,13 @@ describe("Realm roles test", function () {
       );
     });
 
-    it("should create realm role", function () {
-      loginPage.logIn();
+    it("Realm role CRUD test", function () {
+      itemId += "_" + (Math.random() + 1).toString(36).substring(7);
 
-      sidebarPage.goToRealmRoles();
-
-      listingPage.itemExist(itemId, false).goToCreateItem();
+      // Create
+      listingPage
+        .itemExist(itemId, false)
+        .goToCreateItem();
 
       createRealmRolePage.fillRealmRoleData(itemId).save();
 
@@ -49,21 +49,15 @@ describe("Realm roles test", function () {
 
       sidebarPage.goToRealmRoles();
 
-      listingPage.itemExist(itemId).searchItem(itemId).itemExist(itemId);
-    });
-  });
+      listingPage
+        .searchItem(itemId)
+        .itemExist(itemId);
 
-  describe("Realm roles elimination", function () {
-    beforeEach(function () {
-      cy.visit("");
-    });
-
-    it("should delete realm role", function () {
-      loginPage.logIn();
-
-      sidebarPage.goToRealmRoles();
-
-      listingPage.itemExist(itemId).deleteItem(itemId);
+      // Update
+      
+      // Delete
+      listingPage
+        .deleteItem(itemId);
 
       modalUtils.checkModalTitle("Delete role?").confirmModal();
 

--- a/tests/cypress/integration/realm_test.spec.js
+++ b/tests/cypress/integration/realm_test.spec.js
@@ -11,12 +11,12 @@ describe("Realms test", function () {
 
   describe("Realm creation", function () {
     beforeEach(function () {
+      cy.clearCookies();
       cy.visit("");
+      loginPage.logIn();
     });
 
     it("should fail creating Master realm", function () {
-      loginPage.logIn();
-
       sidebarPage.goToCreateRealm();
       createRealmPage.fillRealmName("master").createRealm();
 
@@ -26,8 +26,6 @@ describe("Realms test", function () {
     });
 
     it("should create Test realm", function () {
-      loginPage.logIn();
-
       sidebarPage.goToCreateRealm();
       createRealmPage.fillRealmName("Test").createRealm();
 
@@ -35,8 +33,6 @@ describe("Realms test", function () {
     });
 
     it("should change to Test realm", function () {
-      loginPage.logIn();
-
       sidebarPage.getCurrentRealm().should("eq", "Master");
 
       sidebarPage.goToRealm("Test").getCurrentRealm().should("eq", "Test");

--- a/tests/cypress/support/pages/admin_console/ListingPage.js
+++ b/tests/cypress/support/pages/admin_console/ListingPage.js
@@ -2,7 +2,7 @@ export default class ListingPage {
 
     constructor() {
         this.searchInput = '.pf-c-toolbar__item [type="search"]';
-        this.itemsRows = '.pf-c-page__main-section tbody > tr';
+        this.itemsRows = '.pf-c-page__main-section table';
         this.itemRowDrpDwn = '.pf-c-dropdown > button';
         this.exportBtn = '[role="menuitem"]:nth-child(1)';
         this.deleteBtn = '[role="menuitem"]:nth-child(2)';


### PR DESCRIPTION
This PR modify the CRUD tests to join them and it adds a line to clear cookies before log in, it seems like after a retry Cypress doesn't clear cookies and when it launches the test the user is already logged in, causing an error when it waits for the login page. This should stabilize the test failures on retries.

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated
- [ ] Formatting has been performed via prettier/eslint
- [ ] Type checking has been performed via 'yarn check-types'

## Additional Notes
<!-- 
Add images and/or screen caps to illustrate what was changed if this pull request adds to or modifies existing user-visible appearance/output. 
-->
