### PR TITLE
Add enable switch and action menu to kerberos settings

### DIFF
--- a/src/components/bread-crumb/__tests__/__snapshots__/PageBreadCrumbs.test.tsx.snap
+++ b/src/components/bread-crumb/__tests__/__snapshots__/PageBreadCrumbs.test.tsx.snap
@@ -22,6 +22,63 @@ exports[`BreadCrumbs tests couple of crumbs 1`] = `
             className="pf-c-breadcrumb__item"
           >
             <Link
+              to="/master"
+            >
+              <LinkAnchor
+                href="/master"
+                navigate={[Function]}
+              >
+                <a
+                  href="/master"
+                  onClick={[Function]}
+                >
+                  <span
+                    key="/master"
+                  >
+                    Home
+                  </span>
+                </a>
+              </LinkAnchor>
+            </Link>
+          </li>
+        </BreadcrumbItem>
+        <BreadcrumbItem
+          isActive={false}
+          key=".$1"
+          showDivider={true}
+        >
+          <li
+            className="pf-c-breadcrumb__item"
+          >
+            <span
+              className="pf-c-breadcrumb__item-divider"
+            >
+              <AngleRightIcon
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
+              >
+                <svg
+                  aria-hidden={true}
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 256 512"
+                  width="1em"
+                >
+                  <path
+                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                  />
+                </svg>
+              </AngleRightIcon>
+            </span>
+            <Link
               to="/master/clients"
             >
               <LinkAnchor
@@ -44,7 +101,7 @@ exports[`BreadCrumbs tests couple of crumbs 1`] = `
         </BreadcrumbItem>
         <BreadcrumbItem
           isActive={true}
-          key=".$1"
+          key=".$2"
           showDivider={true}
         >
           <li

--- a/src/route-config.ts
+++ b/src/route-config.ts
@@ -143,15 +143,6 @@ export const routes: RoutesFn = (t: TFunction) => [
     access: "query-users",
   },
   {
-    path: "/:realm/groups",
-    component: GroupsSection,
-    breadcrumb: null,
-    matchOptions: {
-      exact: false,
-    },
-    access: "query-groups",
-  },
-  {
     path: "/:realm/sessions",
     component: SessionsSection,
     breadcrumb: t("sessions:title"),
@@ -234,5 +225,14 @@ export const routes: RoutesFn = (t: TFunction) => [
     component: PageNotFoundSection,
     breadcrumb: null,
     access: "anyone",
+  },
+  {
+    path: "/:realm/groups",
+    component: GroupsSection,
+    breadcrumb: null,
+    matchOptions: {
+      exact: false,
+    },
+    access: "query-groups",
   },
 ];

--- a/src/user-federation/UserFederationKerberosSettings.tsx
+++ b/src/user-federation/UserFederationKerberosSettings.tsx
@@ -119,6 +119,7 @@ export const UserFederationKerberosSettings = () => {
       try {
         await adminClient.components.del({ id });
         addAlert(t("userFedDeletedSuccess"), AlertVariant.success);
+        history.replace(`/${realm}/user-federation`);
       } catch (error) {
         addAlert(`${t("userFedDeleteError")} ${error}`, AlertVariant.danger);
       }

--- a/src/user-federation/UserFederationKerberosSettings.tsx
+++ b/src/user-federation/UserFederationKerberosSettings.tsx
@@ -54,12 +54,12 @@ const KerberosSettingsHeader = ({
             {t("deleteProvider")}
           </DropdownItem>,
         ]}
-        isEnabled={value}
+        isEnabled={value === "true"}
         onToggle={(value) => {
           if (!value) {
             toggleDisableDialog();
           } else {
-            onChange(value);
+            onChange("" + value);
           }
         }}
       />
@@ -109,7 +109,6 @@ export const UserFederationKerberosSettings = () => {
       addAlert(`${t("saveError")} '${error}'`, AlertVariant.danger);
     }
   };
-  // const form = useForm();
 
   const [toggleDeleteDialog, DeleteConfirm] = useConfirmDialog({
     titleKey: "user-federation:userFedDeleteConfirmTitle",
@@ -118,7 +117,7 @@ export const UserFederationKerberosSettings = () => {
     continueButtonVariant: ButtonVariant.danger,
     onConfirm: async () => {
       try {
-        await adminClient.clients.del({ id });
+        await adminClient.components.del({ id });
         addAlert(t("userFedDeletedSuccess"), AlertVariant.success);
       } catch (error) {
         addAlert(`${t("userFedDeleteError")} ${error}`, AlertVariant.danger);
@@ -130,13 +129,13 @@ export const UserFederationKerberosSettings = () => {
     <>
       <DeleteConfirm />
       <Controller
-        name="enabled"
+        name="config.enabled[0]"
+        defaultValue={["true"]}
         control={form.control}
-        defaultValue={true}
         render={({ onChange, value }) => (
           <KerberosSettingsHeader
             value={value}
-            onChange={onChange}
+            onChange={(value) => onChange("" + value)}
             toggleDeleteDialog={toggleDeleteDialog}
           />
         )}

--- a/src/user-federation/messages.json
+++ b/src/user-federation/messages.json
@@ -89,6 +89,8 @@
     "userFedDeleteError": "Could not delete user federation provider: '{{error}}'",
     "userFedDeleteConfirmTitle": "Delete user federation provider?",
     "userFedDeleteConfirm": "If you delete this user federation provider, all associated data will be removed.",
+    "userFedDisableConfirmTitle": "Disable user federation provider?",
+    "userFedDisableConfirm": "If you disable this user federation provider, you cannot make changes to the provider.",
 
     "validateName": "You must enter a name",
     "validateRealm":"You must enter a realm",


### PR DESCRIPTION
## Motivation
https://issues.redhat.com/browse/APPDUX-722

## Brief Description
Adds an Enable switch and Actions menu to the Kerberos settings page.

Design spec:
https://marvelapp.com/prototype/ecjc94b/screen/72098368

## Verification Steps

1. Go to User federation and select a Kerberos card.
2. Enable (if disabled) or disable (if enabled) the switch and click Save.
3. Verify that the Kerberos card you enabled/disabled now appears on the User Fed card view with the correct tag of enabled or disabled.
4. Click the card and verify that the Enabled/Disabled switch is correct.
5. Select Action > Delete provider to delete the user fed provider. 
6. Go back to the User federation card view and verify that the card is now gone and the provider has been deleted.


## Checklist:

- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [x] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated
- [x] Formatting has been performed via prettier/eslint
- [ ] Type checking has been performed via 'yarn check-types'

## Additional Notes
Screen caps:
![kerb-enable-and-actions](https://user-images.githubusercontent.com/39063664/105738194-c421f600-5f04-11eb-9af7-b3993a4a2d0f.png)
![delete-confirm](https://user-images.githubusercontent.com/39063664/105738208-c71ce680-5f04-11eb-894b-c4a18caebd04.png)
![disable-confirm](https://user-images.githubusercontent.com/39063664/105738218-ca17d700-5f04-11eb-9ad9-5da0c654f641.png)

