### PR TITLE
Ignore login when user is already logged

### DIFF
--- a/tests/cypress.json
+++ b/tests/cypress.json
@@ -1,7 +1,6 @@
 {
     "screenshotsFolder": "assets/screenshots",
     "videosFolder": "assets/videos",
-    "video": false,
     "baseUrl": "http://localhost:8080",
     "chromeWebSecurity": false,
     "viewportWidth": 1360,

--- a/tests/cypress.json
+++ b/tests/cypress.json
@@ -1,6 +1,7 @@
 {
     "screenshotsFolder": "assets/screenshots",
     "videosFolder": "assets/videos",
+    "video": false,
     "baseUrl": "http://localhost:8080",
     "chromeWebSecurity": false,
     "viewportWidth": 1360,

--- a/tests/cypress/integration/00_set_new_admin_console.spec.js
+++ b/tests/cypress/integration/00_set_new_admin_console.spec.js
@@ -2,27 +2,24 @@ import LoginPage from '../support/pages/LoginPage.js'
 import WelcomePage from '../support/pages/WelcomePage.js'
 import OldClientPage from '../support/pages/admin_console/manage/clients/OldClientPage.js'
 
-describe('Set up test', function () {
+const loginPage = new LoginPage();
+const welcomePage = new WelcomePage();
+const oldClientPage = new OldClientPage();
 
-    const loginPage = new LoginPage();
-    const welcomePage = new WelcomePage();
-    const oldClientPage = new OldClientPage();
-  
-    describe('Set up test', function () {
-      beforeEach(function () {
-        cy.visit('http://localhost:8180/auth')
-      })
-
-      it('Create admin user and adds admin console client', function () {
-          welcomePage
-              .createAdminUser()
-              .goToAdminConsole();
-
-          loginPage.logIn();
-
-          oldClientPage
-              .goToClients()
-              .addNewAdminConsole();
-      });
-    })
+describe("Set up test", function () {
+  beforeEach(function () {
+    cy.visit("http://localhost:8180/auth")
   })
+
+  it("Create admin user and adds admin console client", function () {
+      welcomePage
+          .createAdminUser()
+          .goToAdminConsole();
+
+      loginPage.logIn();
+
+      oldClientPage
+          .goToClients()
+          .addNewAdminConsole();
+  });
+})

--- a/tests/cypress/integration/client_scopes_test.spec.js
+++ b/tests/cypress/integration/client_scopes_test.spec.js
@@ -4,13 +4,14 @@ import ListingPage from "../support/pages/admin_console/ListingPage.js";
 import SidebarPage from "../support/pages/admin_console/SidebarPage.js";
 import CreateClientScopePage from "../support/pages/admin_console/manage/client_scopes/CreateClientScopePage.js";
 
+let itemId = "client_scope_crud";
+const loginPage = new LoginPage();
+const masthead = new Masthead();
+const sidebarPage = new SidebarPage();
+const listingPage = new ListingPage();
+const createClientScopePage = new CreateClientScopePage();
+
 describe("Client Scopes test", function () {
-  let itemId = "client_scope_crud";
-  const loginPage = new LoginPage();
-  const masthead = new Masthead();
-  const sidebarPage = new SidebarPage();
-  const listingPage = new ListingPage();
-  const createClientScopePage = new CreateClientScopePage();
 
   describe("Client Scope creation", function () {
     beforeEach(function () {

--- a/tests/cypress/integration/client_scopes_test.spec.js
+++ b/tests/cypress/integration/client_scopes_test.spec.js
@@ -14,7 +14,6 @@ describe("Client Scopes test", function () {
 
   describe("Client Scope creation", function () {
     beforeEach(function () {
-      cy.clearCookies();
       cy.visit("");
       loginPage.logIn();
       sidebarPage.goToClientScopes();

--- a/tests/cypress/integration/client_scopes_test.spec.js
+++ b/tests/cypress/integration/client_scopes_test.spec.js
@@ -47,7 +47,7 @@ describe("Client Scopes test", function () {
         .fillClientScopeData(itemId)
         .save();
 
-        masthead.checkNotificationMessage('Client scope created');
+        masthead.checkNotificationMessage("Client scope created");
 
       sidebarPage.goToClientScopes();
 
@@ -56,7 +56,7 @@ describe("Client Scopes test", function () {
         .itemExist(itemId)
         .deleteItem(itemId); // There should be a confirmation pop-up
 
-        masthead.checkNotificationMessage('The client scope has been deleted');
+        masthead.checkNotificationMessage("The client scope has been deleted");
 
       listingPage // It is not refreshing after delete
         .itemExist(itemId, false);

--- a/tests/cypress/integration/clients_test.spec.js
+++ b/tests/cypress/integration/clients_test.spec.js
@@ -14,7 +14,6 @@ describe("Clients test", function () {
 
   describe("Client creation", function () {
     beforeEach(function () {
-      cy.clearCookies();
       cy.visit("");
       loginPage.logIn();
       sidebarPage.goToClients();

--- a/tests/cypress/integration/clients_test.spec.js
+++ b/tests/cypress/integration/clients_test.spec.js
@@ -4,13 +4,14 @@ import ListingPage from "../support/pages/admin_console/ListingPage.js";
 import SidebarPage from "../support/pages/admin_console/SidebarPage.js";
 import CreateClientPage from "../support/pages/admin_console/manage/clients/CreateClientPage.js";
 
+let itemId = "client_crud";
+const loginPage = new LoginPage();
+const masthead = new Masthead();
+const sidebarPage = new SidebarPage();
+const listingPage = new ListingPage();
+const createClientPage = new CreateClientPage();
+
 describe("Clients test", function () {
-  let itemId = "client_crud";
-  const loginPage = new LoginPage();
-  const masthead = new Masthead();
-  const sidebarPage = new SidebarPage();
-  const listingPage = new ListingPage();
-  const createClientPage = new CreateClientPage();
 
   describe("Client creation", function () {
     beforeEach(function () {

--- a/tests/cypress/integration/login_test.spec.js
+++ b/tests/cypress/integration/login_test.spec.js
@@ -15,8 +15,9 @@ describe("Logging In", function () {
 
     it("displays errors on login", function () {
       loginPage
-        .logIn("wrong", "user{enter}")
-        .checkErrorMessage("Invalid username or password.")
+        .logIn("wrong", "user{enter}");
+
+      loginPage.checkErrorMessage("Invalid username or password.")
         .isLogInPage();
     });
 

--- a/tests/cypress/integration/login_test.spec.js
+++ b/tests/cypress/integration/login_test.spec.js
@@ -1,12 +1,13 @@
 import LoginPage from "./../support/pages/LoginPage.js";
 import Masthead from "./../support/pages/admin_console/Masthead.js";
 
-describe("Logging In", function () {
-  const username = "admin";
-  const password = "admin";
+const username = "admin";
+const password = "admin";
 
-  const loginPage = new LoginPage();
-  const masthead = new Masthead();
+const loginPage = new LoginPage();
+const masthead = new Masthead();
+
+describe("Logging In", function () {
 
   beforeEach(function () {
     cy.visit("");
@@ -14,7 +15,9 @@ describe("Logging In", function () {
 
   it("displays errors on wrong credentials", function () {
     loginPage
-      .logIn("wrong", "user{enter}")
+      .logIn("wrong", "user{enter}");
+      
+    loginPage
       .checkErrorMessage("Invalid username or password.")
       .isLogInPage();
   });

--- a/tests/cypress/integration/login_test.spec.js
+++ b/tests/cypress/integration/login_test.spec.js
@@ -8,25 +8,22 @@ describe("Logging In", function () {
   const loginPage = new LoginPage();
   const masthead = new Masthead();
 
-  describe("Login form submission", function () {
-    beforeEach(function () {
-      cy.visit("");
-    });
+  beforeEach(function () {
+    cy.visit("");
+  });
 
-    it("displays errors on login", function () {
-      loginPage
-        .logIn("wrong", "user{enter}");
+  it("displays errors on wrong credentials", function () {
+    loginPage
+      .logIn("wrong", "user{enter}")
+      .checkErrorMessage("Invalid username or password.")
+      .isLogInPage();
+  });
 
-      loginPage.checkErrorMessage("Invalid username or password.")
-        .isLogInPage();
-    });
+  it("logs in", function () {
+    loginPage.logIn(username, password);
 
-    it("redirects to admin console on success", function () {
-      loginPage.logIn(username, password);
+    masthead.isAdminConsole();
 
-      masthead.isAdminConsole();
-
-      cy.getCookie("KEYCLOAK_SESSION_LEGACY").should("exist");
-    });
+    cy.getCookie("KEYCLOAK_SESSION_LEGACY").should("exist");
   });
 });

--- a/tests/cypress/integration/masthead_test.spec.js
+++ b/tests/cypress/integration/masthead_test.spec.js
@@ -24,7 +24,6 @@ const goToAcctMgtTest = () => {
 
 describe("Masthead tests in desktop mode", () => {
   beforeEach(() => {
-    cy.clearCookies();
     cy.visit("");
     loginPage.logIn();
   });
@@ -52,7 +51,6 @@ describe("Masthead tests in desktop mode", () => {
 
 describe("Masthead tests with kebab menu", () => {
   beforeEach(() => {
-    cy.clearCookies();
     cy.visit("");
     loginPage.logIn();
     masthead.setMobileMode(true);

--- a/tests/cypress/integration/realm_roles_test.spec.js
+++ b/tests/cypress/integration/realm_roles_test.spec.js
@@ -5,14 +5,15 @@ import ListingPage from "../support/pages/admin_console/ListingPage.js";
 import SidebarPage from "../support/pages/admin_console/SidebarPage.js";
 import CreateRealmRolePage from "../support/pages/admin_console/manage/realm_roles/CreateRealmRolePage.js";
 
+let itemId = "realm_role_crud";
+const loginPage = new LoginPage();
+const masthead = new Masthead();
+const modalUtils = new ModalUtils();
+const sidebarPage = new SidebarPage();
+const listingPage = new ListingPage();
+const createRealmRolePage = new CreateRealmRolePage();
+
 describe("Realm roles test", function () {
-  let itemId = "realm_role_crud";
-  const loginPage = new LoginPage();
-  const masthead = new Masthead();
-  const modalUtils = new ModalUtils();
-  const sidebarPage = new SidebarPage();
-  const listingPage = new ListingPage();
-  const createRealmRolePage = new CreateRealmRolePage();
 
   describe("Realm roles creation", function () {
     beforeEach(function () {

--- a/tests/cypress/integration/realm_roles_test.spec.js
+++ b/tests/cypress/integration/realm_roles_test.spec.js
@@ -16,7 +16,6 @@ describe("Realm roles test", function () {
 
   describe("Realm roles creation", function () {
     beforeEach(function () {
-      cy.clearCookies();
       cy.visit("");
       loginPage.logIn();
       sidebarPage.goToRealmRoles();

--- a/tests/cypress/integration/realm_test.spec.js
+++ b/tests/cypress/integration/realm_test.spec.js
@@ -3,11 +3,12 @@ import SidebarPage from "../support/pages/admin_console/SidebarPage.js";
 import CreateRealmPage from "../support/pages/admin_console/CreateRealmPage.js";
 import Masthead from "../support/pages/admin_console/Masthead.js";
 
+const masthead = new Masthead();
+const loginPage = new LoginPage();
+const sidebarPage = new SidebarPage();
+const createRealmPage = new CreateRealmPage();
+
 describe("Realms test", function () {
-  const loginPage = new LoginPage();
-  const sidebarPage = new SidebarPage();
-  const createRealmPage = new CreateRealmPage();
-  const masthead = new Masthead();
 
   describe("Realm creation", function () {
     beforeEach(function () {

--- a/tests/cypress/integration/realm_test.spec.js
+++ b/tests/cypress/integration/realm_test.spec.js
@@ -11,7 +11,6 @@ describe("Realms test", function () {
 
   describe("Realm creation", function () {
     beforeEach(function () {
-      cy.clearCookies();
       cy.visit("");
       loginPage.logIn();
     });

--- a/tests/cypress/support/pages/LoginPage.js
+++ b/tests/cypress/support/pages/LoginPage.js
@@ -11,8 +11,8 @@ export default class LoginPage {
   }
 
   isLogInPage() {
-    cy.get(this.userNameInput).should('exist');
-    cy.url().should('include', '/auth');
+    cy.get(this.userNameInput).should("exist");
+    cy.url().should("include", "/auth");
 
     return this;
   }
@@ -34,13 +34,13 @@ export default class LoginPage {
   }
 
   checkErrorIsDisplayed() {
-    cy.get(this.userDrpDwn).should('exist');
+    cy.get(this.userDrpDwn).should("exist");
 
     return this;
   }
 
   checkErrorMessage(message) {
-    cy.get(this.errorText).invoke('text').should('contain', message);
+    cy.get(this.errorText).invoke("text").should("contain", message);
 
     return this;
   }

--- a/tests/cypress/support/pages/LoginPage.js
+++ b/tests/cypress/support/pages/LoginPage.js
@@ -6,6 +6,7 @@ export default class LoginPage {
     this.submitBtn = "#kc-login";
 
     this.errorText = ".kc-feedback-text";
+    this.loadingContainer = "div.keycloak__loading-container";
   }
 
   isLogInPage() {
@@ -16,7 +17,7 @@ export default class LoginPage {
   }
 
   logIn(userName = "admin", password = "admin") {
-    cy.get("div.keycloak__loading-container").should("not.be.visible");
+    cy.get(this.loadingContainer).should("not.exist");
 
     cy.get("body").children().then((children) => {
       if(children.length == 1) {

--- a/tests/cypress/support/pages/LoginPage.js
+++ b/tests/cypress/support/pages/LoginPage.js
@@ -6,7 +6,8 @@ export default class LoginPage {
     this.submitBtn = "#kc-login";
 
     this.errorText = ".kc-feedback-text";
-    this.loadingContainer = "div.keycloak__loading-container";
+    this.oldLoadContainer = "#loading";
+    this.loadContainer = "div.keycloak__loading-container";
   }
 
   isLogInPage() {
@@ -17,7 +18,8 @@ export default class LoginPage {
   }
 
   logIn(userName = "admin", password = "admin") {
-    cy.get(this.loadingContainer).should("not.exist");
+    cy.get(this.oldLoadContainer).should("not.exist");
+    cy.get(this.loadContainer).should("not.exist");
 
     cy.get("body").children().then((children) => {
       if(children.length == 1) {

--- a/tests/cypress/support/pages/LoginPage.js
+++ b/tests/cypress/support/pages/LoginPage.js
@@ -29,8 +29,6 @@ export default class LoginPage {
         cy.get(this.submitBtn).click();
       }
     });
-
-    return this;
   }
 
   checkErrorIsDisplayed() {

--- a/tests/cypress/support/pages/LoginPage.js
+++ b/tests/cypress/support/pages/LoginPage.js
@@ -16,12 +16,14 @@ export default class LoginPage {
     }
 
     logIn(userName = "admin", password = "admin") {
-        cy.get(this.userNameInput).type(userName);
-        cy.get(this.passwordInput).type(password);
-
-        cy.get(this.submitBtn).click();
-
-        return this;
+        cy.getCookie("KEYCLOAK_SESSION_LEGACY").then((cookie) => {
+            if(!cookie) {
+                cy.get(this.userNameInput).type(userName);
+                cy.get(this.passwordInput).type(password);
+        
+                cy.get(this.submitBtn).click();
+            }
+        });
     }
 
     checkErrorIsDisplayed() {

--- a/tests/cypress/support/pages/LoginPage.js
+++ b/tests/cypress/support/pages/LoginPage.js
@@ -1,40 +1,44 @@
 export default class LoginPage {
 
-    constructor() {
-        this.userNameInput = "#username";
-        this.passwordInput = "#password";
-        this.submitBtn = "#kc-login";
+  constructor() {
+    this.userNameInput = "#username";
+    this.passwordInput = "#password";
+    this.submitBtn = "#kc-login";
 
-        this.errorText = ".kc-feedback-text";
-    }
+    this.errorText = ".kc-feedback-text";
+  }
 
-    isLogInPage() {
-        cy.get(this.userNameInput).should('exist');
-        cy.url().should('include', '/auth');
+  isLogInPage() {
+    cy.get(this.userNameInput).should('exist');
+    cy.url().should('include', '/auth');
 
-        return this;
-    }
+    return this;
+  }
 
-    logIn(userName = "admin", password = "admin") {
-        cy.getCookie("KEYCLOAK_SESSION_LEGACY").then((cookie) => {
-            if(!cookie) {
-                cy.get(this.userNameInput).type(userName);
-                cy.get(this.passwordInput).type(password);
-        
-                cy.get(this.submitBtn).click();
-            }
-        });
-    }
+  logIn(userName = "admin", password = "admin") {
+    cy.get("div.keycloak__loading-container").should("not.be.visible");
 
-    checkErrorIsDisplayed() {
-        cy.get(this.userDrpDwn).should('exist');
+    cy.get("body").children().then((children) => {
+      if(children.length == 1) {
+        cy.get(this.userNameInput).type(userName);
+        cy.get(this.passwordInput).type(password);
+    
+        cy.get(this.submitBtn).click();
+      }
+    });
 
-        return this;
-    }
+    return this;
+  }
 
-    checkErrorMessage(message) {
-        cy.get(this.errorText).invoke('text').should('contain', message);
+  checkErrorIsDisplayed() {
+    cy.get(this.userDrpDwn).should('exist');
 
-        return this;
-    }
+    return this;
+  }
+
+  checkErrorMessage(message) {
+    cy.get(this.errorText).invoke('text').should('contain', message);
+
+    return this;
+  }
 }

--- a/tests/package.json
+++ b/tests/package.json
@@ -9,6 +9,6 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "cypress": "^5.6.0"
+    "cypress": "6.2.1"
   }
 }


### PR DESCRIPTION
Due to the random Cypress load failures and a bug which doesn't clear cookies, when Cypress retries a test sometimes the user is already logged in, so it fails when expecting the login page.

This PR adds a code on the log in to only do the login when there is a login page.

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated
- [ ] Formatting has been performed via prettier/eslint
- [ ] Type checking has been performed via 'yarn check-types'
