### PR TITLE
Add enable switch and action menu to LDAP settings

### DIFF
--- a/src/clients/ClientDetails.tsx
+++ b/src/clients/ClientDetails.tsx
@@ -36,8 +36,8 @@ import { ServiceAccount } from "./service-account/ServiceAccount";
 import { KeycloakTabs } from "../components/keycloak-tabs/KeycloakTabs";
 
 type ClientDetailHeaderProps = {
-  onChange: (...event: any[]) => void;
-  value: any;
+  onChange: (value: boolean) => void;
+  value: boolean;
   save: () => void;
   client: ClientRepresentation;
   toggleDownloadDialog: () => void;

--- a/src/realm-settings/RealmSettingsSection.tsx
+++ b/src/realm-settings/RealmSettingsSection.tsx
@@ -36,7 +36,7 @@ import { HelpItem } from "../components/help-enabler/HelpItem";
 import { FormattedLink } from "../components/external-link/FormattedLink";
 
 type RealmSettingsHeaderProps = {
-  onChange: (...event: any[]) => void;
+  onChange: (value: boolean) => void;
   value: boolean;
   save: () => void;
   realmName: string;

--- a/src/user-federation/UserFederationKerberosSettings.tsx
+++ b/src/user-federation/UserFederationKerberosSettings.tsx
@@ -24,14 +24,16 @@ import { ViewHeader } from "../components/view-header/ViewHeader";
 import { useHistory, useParams } from "react-router-dom";
 
 type KerberosSettingsHeaderProps = {
-  onChange: (...event: any[]) => void;
-  value: any;
+  onChange: (value: string) => void;
+  value: string;
+  save: () => void;
   toggleDeleteDialog: () => void;
 };
 
 const KerberosSettingsHeader = ({
   onChange,
   value,
+  save,
   toggleDeleteDialog,
 }: KerberosSettingsHeaderProps) => {
   const { t } = useTranslation("user-federation");
@@ -40,7 +42,8 @@ const KerberosSettingsHeader = ({
     messageKey: "user-federation:userFedDisableConfirm",
     continueButtonLabel: "common:disable",
     onConfirm: () => {
-      onChange(!value);
+      onChange("false");
+      save();
     },
   });
   return (
@@ -60,6 +63,7 @@ const KerberosSettingsHeader = ({
             toggleDisableDialog();
           } else {
             onChange("" + value);
+            save();
           }
         }}
       />
@@ -136,7 +140,8 @@ export const UserFederationKerberosSettings = () => {
         render={({ onChange, value }) => (
           <KerberosSettingsHeader
             value={value}
-            onChange={(value) => onChange("" + value)}
+            onChange={onChange}
+            save={() => save(form.getValues())}
             toggleDeleteDialog={toggleDeleteDialog}
           />
         )}

--- a/src/user-federation/UserFederationLdapSettings.tsx
+++ b/src/user-federation/UserFederationLdapSettings.tsx
@@ -41,7 +41,7 @@ const LdapSettingsHeader = ({
   onChange,
   value,
   toggleDeleteDialog,
-  toggleRemoveUsersDialog
+  toggleRemoveUsersDialog,
 }: LdapSettingsHeaderProps) => {
   const { t } = useTranslation("user-federation");
   const [toggleDisableDialog, DisableConfirm] = useConfirmDialog({
@@ -59,22 +59,31 @@ const LdapSettingsHeader = ({
         titleKey="LDAP"
         subKey=""
         dropdownItems={[
-          <DropdownItem key="sync" onClick={() => console.log("Sync users TBD")}>
-          Sync changed users
-        </DropdownItem>,
-          <DropdownItem key="syncall" onClick={() => console.log("Sync all users TBD")}>
-          Sync all users
-        </DropdownItem>,
-          <DropdownItem key="unlink" onClick={() => console.log("Unlink users TBD")}>
-          Unlink users
-        </DropdownItem>,
+          <DropdownItem
+            key="sync"
+            onClick={() => console.log("Sync users TBD")}
+          >
+            {t("syncChangedUsers")}
+          </DropdownItem>,
+          <DropdownItem
+            key="syncall"
+            onClick={() => console.log("Sync all users TBD")}
+          >
+            {t("syncAllUsers")}
+          </DropdownItem>,
+          <DropdownItem
+            key="unlink"
+            onClick={() => console.log("Unlink users TBD")}
+          >
+            {t("unlinkUsers")}
+          </DropdownItem>,
           <DropdownItem key="remove" onClick={() => toggleRemoveUsersDialog()}>
-          Remove imported
-        </DropdownItem>,
+            {t("removeImported")}
+          </DropdownItem>,
           <DropdownItem key="delete" onClick={() => toggleDeleteDialog()}>
-          {t("deleteProvider")}
-        </DropdownItem>,
-    ]}
+            {t("deleteProvider")}
+          </DropdownItem>,
+        ]}
         isEnabled={value === "true"}
         onToggle={(value) => {
           if (!value) {
@@ -133,7 +142,7 @@ export const UserFederationLdapSettings = () => {
     continueButtonLabel: "common:remove",
     onConfirm: async () => {
       try {
-        console.log("Imported users removed.");
+        console.log("Remove imported TBD");
         // TODO await remove imported users command
         addAlert(t("removeImportedUsersSuccess"), AlertVariant.success);
       } catch (error) {

--- a/src/user-federation/UserFederationLdapSettings.tsx
+++ b/src/user-federation/UserFederationLdapSettings.tsx
@@ -5,6 +5,7 @@ import {
   Button,
   ButtonVariant,
   DropdownItem,
+  DropdownSeparator,
   Form,
   PageSection,
 } from "@patternfly/react-core";
@@ -80,6 +81,7 @@ const LdapSettingsHeader = ({
           <DropdownItem key="remove" onClick={() => toggleRemoveUsersDialog()}>
             {t("removeImported")}
           </DropdownItem>,
+          <DropdownSeparator key="separator" />,
           <DropdownItem key="delete" onClick={() => toggleDeleteDialog()}>
             {t("deleteProvider")}
           </DropdownItem>,

--- a/src/user-federation/UserFederationLdapSettings.tsx
+++ b/src/user-federation/UserFederationLdapSettings.tsx
@@ -1,12 +1,13 @@
+import React, { useEffect } from "react";
 import {
   ActionGroup,
   AlertVariant,
   Button,
+  ButtonVariant,
+  DropdownItem,
   Form,
   PageSection,
 } from "@patternfly/react-core";
-import { useTranslation } from "react-i18next";
-import React, { useEffect } from "react";
 
 import { LdapSettingsAdvanced } from "./ldap/LdapSettingsAdvanced";
 import { LdapSettingsKerberosIntegration } from "./ldap/LdapSettingsKerberosIntegration";
@@ -15,17 +16,77 @@ import { LdapSettingsSynchronization } from "./ldap/LdapSettingsSynchronization"
 import { LdapSettingsGeneral } from "./ldap/LdapSettingsGeneral";
 import { LdapSettingsConnection } from "./ldap/LdapSettingsConnection";
 import { LdapSettingsSearching } from "./ldap/LdapSettingsSearching";
-import { ScrollForm } from "../components/scroll-form/ScrollForm";
-import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
 
-import { useHistory, useParams } from "react-router-dom";
 import { useRealm } from "../context/realm-context/RealmContext";
 import { convertToFormValues } from "../util";
-import { useAlerts } from "../components/alert/Alerts";
-import { useAdminClient } from "../context/auth/AdminClient";
 import ComponentRepresentation from "keycloak-admin/lib/defs/componentRepresentation";
 
-import { useForm } from "react-hook-form";
+import { Controller, useForm } from "react-hook-form";
+import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
+import { useAdminClient } from "../context/auth/AdminClient";
+import { useAlerts } from "../components/alert/Alerts";
+import { useTranslation } from "react-i18next";
+import { ViewHeader } from "../components/view-header/ViewHeader";
+import { useHistory, useParams } from "react-router-dom";
+import { ScrollForm } from "../components/scroll-form/ScrollForm";
+
+type LdapSettingsHeaderProps = {
+  onChange: (...event: any[]) => void;
+  value: any;
+  toggleDeleteDialog: () => void;
+  toggleRemoveUsersDialog: () => void;
+};
+
+const LdapSettingsHeader = ({
+  onChange,
+  value,
+  toggleDeleteDialog,
+  toggleRemoveUsersDialog
+}: LdapSettingsHeaderProps) => {
+  const { t } = useTranslation("user-federation");
+  const [toggleDisableDialog, DisableConfirm] = useConfirmDialog({
+    titleKey: "user-federation:userFedDisableConfirmTitle",
+    messageKey: "user-federation:userFedDisableConfirm",
+    continueButtonLabel: "common:disable",
+    onConfirm: () => {
+      onChange(!value);
+    },
+  });
+  return (
+    <>
+      <DisableConfirm />
+      <ViewHeader
+        titleKey="LDAP"
+        subKey=""
+        dropdownItems={[
+          <DropdownItem key="sync" onClick={() => console.log("Sync users TBD")}>
+          Sync changed users
+        </DropdownItem>,
+          <DropdownItem key="syncall" onClick={() => console.log("Sync all users TBD")}>
+          Sync all users
+        </DropdownItem>,
+          <DropdownItem key="unlink" onClick={() => console.log("Unlink users TBD")}>
+          Unlink users
+        </DropdownItem>,
+          <DropdownItem key="remove" onClick={() => toggleRemoveUsersDialog()}>
+          Remove imported
+        </DropdownItem>,
+          <DropdownItem key="delete" onClick={() => toggleDeleteDialog()}>
+          {t("deleteProvider")}
+        </DropdownItem>,
+    ]}
+        isEnabled={value === "true"}
+        onToggle={(value) => {
+          if (!value) {
+            toggleDisableDialog();
+          } else {
+            onChange("" + value);
+          }
+        }}
+      />
+    </>
+  );
+};
 
 export const UserFederationLdapSettings = () => {
   const { t } = useTranslation("user-federation");
@@ -36,21 +97,6 @@ export const UserFederationLdapSettings = () => {
 
   const { id } = useParams<{ id: string }>();
   const { addAlert } = useAlerts();
-
-  const [toggleDeleteDialog, DeleteConfirm] = useConfirmDialog({
-    titleKey: t("removeImportedUsers"),
-    messageKey: t("removeImportedUsersMessage"),
-    continueButtonLabel: "common:remove",
-    onConfirm: async () => {
-      // try {
-      //   await something? :-)
-      //   refresh();
-      //   addAlert(t("removeImportedUsersSuccess"), AlertVariant.success);
-      // } catch (error) {
-      //   addAlert(t("removeImportedUsersError", { error }), AlertVariant.danger);
-      // }
-    },
-  });
 
   useEffect(() => {
     (async () => {
@@ -81,8 +127,54 @@ export const UserFederationLdapSettings = () => {
     }
   };
 
+  const [toggleRemoveUsersDialog, RemoveUsersConfirm] = useConfirmDialog({
+    titleKey: t("removeImportedUsers"),
+    messageKey: t("removeImportedUsersMessage"),
+    continueButtonLabel: "common:remove",
+    onConfirm: async () => {
+      try {
+        console.log("Imported users removed.");
+        // TODO await remove imported users command
+        addAlert(t("removeImportedUsersSuccess"), AlertVariant.success);
+      } catch (error) {
+        addAlert(t("removeImportedUsersError", { error }), AlertVariant.danger);
+      }
+    },
+  });
+
+  const [toggleDeleteDialog, DeleteConfirm] = useConfirmDialog({
+    titleKey: "user-federation:userFedDeleteConfirmTitle",
+    messageKey: "user-federation:userFedDeleteConfirm",
+    continueButtonLabel: "common:delete",
+    continueButtonVariant: ButtonVariant.danger,
+    onConfirm: async () => {
+      try {
+        await adminClient.components.del({ id });
+        addAlert(t("userFedDeletedSuccess"), AlertVariant.success);
+        history.replace(`/${realm}/user-federation`);
+      } catch (error) {
+        addAlert(`${t("userFedDeleteError")} ${error}`, AlertVariant.danger);
+      }
+    },
+  });
+
   return (
     <>
+      <DeleteConfirm />
+      <RemoveUsersConfirm />
+      <Controller
+        name="config.enabled[0]"
+        defaultValue={["true"]}
+        control={form.control}
+        render={({ onChange, value }) => (
+          <LdapSettingsHeader
+            value={value}
+            onChange={(value) => onChange("" + value)}
+            toggleDeleteDialog={toggleDeleteDialog}
+            toggleRemoveUsersDialog={toggleRemoveUsersDialog}
+          />
+        )}
+      />
       <PageSection variant="light" isFilled>
         <ScrollForm
           sections={[

--- a/src/user-federation/UserFederationLdapSettings.tsx
+++ b/src/user-federation/UserFederationLdapSettings.tsx
@@ -16,6 +16,7 @@ import { LdapSettingsGeneral } from "./ldap/LdapSettingsGeneral";
 import { LdapSettingsConnection } from "./ldap/LdapSettingsConnection";
 import { LdapSettingsSearching } from "./ldap/LdapSettingsSearching";
 import { ScrollForm } from "../components/scroll-form/ScrollForm";
+import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
 
 import { useHistory, useParams } from "react-router-dom";
 import { useRealm } from "../context/realm-context/RealmContext";
@@ -35,6 +36,21 @@ export const UserFederationLdapSettings = () => {
 
   const { id } = useParams<{ id: string }>();
   const { addAlert } = useAlerts();
+
+  const [toggleDeleteDialog, DeleteConfirm] = useConfirmDialog({
+    titleKey: t("removeImportedUsers"),
+    messageKey: t("removeImportedUsersMessage"),
+    continueButtonLabel: "common:remove",
+    onConfirm: async () => {
+      // try {
+      //   await something? :-)
+      //   refresh();
+      //   addAlert(t("removeImportedUsersSuccess"), AlertVariant.success);
+      // } catch (error) {
+      //   addAlert(t("removeImportedUsersError", { error }), AlertVariant.danger);
+      // }
+    },
+  });
 
   useEffect(() => {
     (async () => {

--- a/src/user-federation/UserFederationLdapSettings.tsx
+++ b/src/user-federation/UserFederationLdapSettings.tsx
@@ -32,8 +32,9 @@ import { useHistory, useParams } from "react-router-dom";
 import { ScrollForm } from "../components/scroll-form/ScrollForm";
 
 type LdapSettingsHeaderProps = {
-  onChange: (...event: any[]) => void;
-  value: any;
+  onChange: (value: string) => void;
+  value: string;
+  save: () => void;
   toggleDeleteDialog: () => void;
   toggleRemoveUsersDialog: () => void;
 };
@@ -41,6 +42,7 @@ type LdapSettingsHeaderProps = {
 const LdapSettingsHeader = ({
   onChange,
   value,
+  save,
   toggleDeleteDialog,
   toggleRemoveUsersDialog,
 }: LdapSettingsHeaderProps) => {
@@ -50,7 +52,8 @@ const LdapSettingsHeader = ({
     messageKey: "user-federation:userFedDisableConfirm",
     continueButtonLabel: "common:disable",
     onConfirm: () => {
-      onChange(!value);
+      onChange("false");
+      save();
     },
   });
   return (
@@ -92,6 +95,7 @@ const LdapSettingsHeader = ({
             toggleDisableDialog();
           } else {
             onChange("" + value);
+            save();
           }
         }}
       />
@@ -180,7 +184,8 @@ export const UserFederationLdapSettings = () => {
         render={({ onChange, value }) => (
           <LdapSettingsHeader
             value={value}
-            onChange={(value) => onChange("" + value)}
+            save={() => save(form.getValues())}
+            onChange={onChange}
             toggleDeleteDialog={toggleDeleteDialog}
             toggleRemoveUsersDialog={toggleRemoveUsersDialog}
           />

--- a/src/user-federation/messages.json
+++ b/src/user-federation/messages.json
@@ -92,6 +92,11 @@
     "userFedDisableConfirmTitle": "Disable user federation provider?",
     "userFedDisableConfirm": "If you disable this user federation provider, you cannot make changes to the provider.",
 
+    "removeImportedUsers": "Remove imported users?",
+    "removeImportedUsersMessage": "Do you really want to remove all imported users? The option \"Unlink users\" makes sense just for the Edit Mode \"Unsynced\" and there should be a warning that \"unlinked\" users without the password in the Keycloak database won't be able to authenticate.",
+    "removeImportedUsersSuccess": "Imported users have been removed",
+    "removeImportedUsersError": "Could not remove imported users: '{{error}}'",
+
     "validateName": "You must enter a name",
     "validateRealm":"You must enter a realm",
     "validateServerPrincipal":"You must enter a server principal",

--- a/src/user-federation/messages.json
+++ b/src/user-federation/messages.json
@@ -90,7 +90,7 @@
     "userFedDeleteConfirmTitle": "Delete user federation provider?",
     "userFedDeleteConfirm": "If you delete this user federation provider, all associated data will be removed.",
     "userFedDisableConfirmTitle": "Disable user federation provider?",
-    "userFedDisableConfirm": "If you disable this user federation provider, you cannot make changes to the provider.",
+    "userFedDisableConfirm": "If you disable this user federation provider, it will not be considered for queries and imported users will be disabled and read-only until the provider is enabled again.",
 
     "removeImportedUsers": "Remove imported users?",
     "removeImportedUsersMessage": "Do you really want to remove all imported users? The option \"Unlink users\" makes sense just for the Edit Mode \"Unsynced\" and there should be a warning that \"unlinked\" users without the password in the Keycloak database won't be able to authenticate.",


### PR DESCRIPTION
## Motivation
https://issues.redhat.com/browse/APPDUX-719

## Brief Description
Adds layout for Enable toggle switch, Action menu and commands, and Remove imported modal. Adds business logic for the Enable switch and the Delete provider menu command. 

Note that the logic for the 4 user-related menu commands is tracked in a different JIRA (https://issues.redhat.com/browse/APPDUX-724) and will be handled in a separate PR as they will probably require backend work.

## Verification Steps

1. Go to User federation and select an LDAP card.
2. Enable (if disabled) or disable (if enabled) the switch and click **Save**.
3. Verify that the LDAP card you enabled/disabled now appears on the User Fed card view with the correct tag of enabled or disabled.
4. Click the card and verify that the Enabled/Disabled switch is correct.
5. Select **Action > Delete provider** to delete the user fed provider.
6. Go back to the User federation card view and verify that the card is now gone and the provider has been deleted.

Marvel spec:
https://marvelapp.com/prototype/ecjc94b/screen/72379134

## Checklist:
- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [x] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated
- [x] Formatting has been performed via prettier/eslint
- [ ] Type checking has been performed via 'yarn check-types'

## Additional Notes
Screen cap:
![LDAP-enable-action](https://user-images.githubusercontent.com/39063664/106507065-8b4fc700-6498-11eb-8113-b6b5f667b9d6.png)

