### PR TITLE
Issue 327: Fix for showing/hiding password text in Bind credentials field

### DIFF
--- a/src/user-federation/ldap/LdapSettingsConnection.tsx
+++ b/src/user-federation/ldap/LdapSettingsConnection.tsx
@@ -36,6 +36,7 @@ export const LdapSettingsConnection = ({
   ] = useState(false);
 
   const [isBindTypeDropdownOpen, setIsBindTypeDropdownOpen] = useState(false);
+  const [isPasswordVisible, setIsPasswordVisible] = useState(false);
 
   return (
     <>
@@ -266,9 +267,9 @@ export const LdapSettingsConnection = ({
           isRequired
         >
           <InputGroup>
-            <TextInput // TODO: Make password field switch to type=text with button
+            <TextInput
               isRequired
-              type="password"
+              type={isPasswordVisible ? "text" : "password"}
               id="kc-console-bind-credentials"
               name="config.bindCredential[0]"
               ref={form.register({
@@ -281,6 +282,7 @@ export const LdapSettingsConnection = ({
             <Button
               variant="control"
               aria-label="show password button for bind credentials"
+              onClick={() => setIsPasswordVisible(!isPasswordVisible)}
             >
               <EyeIcon />
             </Button>

--- a/src/user-federation/ldap/LdapSettingsConnection.tsx
+++ b/src/user-federation/ldap/LdapSettingsConnection.tsx
@@ -12,7 +12,7 @@ import { useTranslation } from "react-i18next";
 import React, { useState } from "react";
 import { HelpItem } from "../../components/help-enabler/HelpItem";
 import { Controller, UseFormMethods } from "react-hook-form";
-import { EyeIcon } from "@patternfly/react-icons";
+import { EyeIcon, EyeSlashIcon } from "@patternfly/react-icons";
 import { FormAccess } from "../../components/form-access/FormAccess";
 import { WizardSectionHeader } from "../../components/wizard-section-header/WizardSectionHeader";
 
@@ -284,7 +284,7 @@ export const LdapSettingsConnection = ({
               aria-label="show password button for bind credentials"
               onClick={() => setIsPasswordVisible(!isPasswordVisible)}
             >
-              <EyeIcon />
+              {!isPasswordVisible ? <EyeIcon /> : <EyeSlashIcon />}
             </Button>
           </InputGroup>
           {form.errors.config &&


### PR DESCRIPTION
## Motivation
https://github.com/keycloak/keycloak-admin-ui/issues/327

## Brief Description
Added ability to show/hide newly-typed passwords in LDAP settings bind credentials field so it works as it did in the old admin UI.

## Verification Steps

1. Go to the User federation card view and click an LDAP card.
2. In the Connection and authentication settings section, enter a new password in the Bind credentials field.
3. Click the eye button on the field. The password should display in plain text. 
4. Edit the password, and click the eye button again to continue to toggle off/on the text visibility of the password.

## Checklist:

- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [x] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated
- [x] Formatting has been performed via prettier/eslint
- [ ] Type checking has been performed via 'yarn check-types'

## Additional Notes
Screen cap before button click:
![pre-click](https://user-images.githubusercontent.com/39063664/106521481-4cc40780-64ac-11eb-94f9-8972c85837d1.png)

Screen cap after button click:
![post-click](https://user-images.githubusercontent.com/39063664/106521503-4fbef800-64ac-11eb-81f5-11435cb08dac.png)


