### PR TITLE
Realm roles: fix pagination by 10

### DIFF
--- a/src/realm-roles/RealmRolesSection.tsx
+++ b/src/realm-roles/RealmRolesSection.tsx
@@ -6,9 +6,9 @@ import { RolesList } from "./RolesList";
 
 export const RealmRolesSection = () => {
   const adminClient = useAdminClient();
-  const loader = async (to?: number, max?: number, search?: string) => {
+  const loader = async (first?: number, max?: number, search?: string) => {
     const params: { [name: string]: string | number } = {
-      to: to!,
+      first: first!,
       max: max!,
       search: search!,
     };

--- a/src/realm-roles/RolesList.tsx
+++ b/src/realm-roles/RolesList.tsx
@@ -12,9 +12,16 @@ import { useAlerts } from "../components/alert/Alerts";
 import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
 import { emptyFormatter, boolFormatter } from "../util";
 
+const adminClient = useAdminClient();
+
 type RolesListProps = {
   paginated?: boolean;
   parentRoleId?: string;
+  loader?: (
+    first?: number,
+    max?: number,
+    search?: string
+  ) => Promise<RoleRepresentation[]>;
 };
 
 export const RolesList = ({
@@ -24,20 +31,10 @@ export const RolesList = ({
 }: RolesListProps) => {
   const { t } = useTranslation("roles");
   const history = useHistory();
-  const adminClient = useAdminClient();
   const { addAlert } = useAlerts();
   const { url } = useRouteMatch();
 
-  const loader = async (first?: number, max?: number, search?: string) => {
-    const params: { [name: string]: string | number } = {
-      first: first!,
-      max: max!,
-    };
-    if (search) {
-      params.search = search;
-    }
-    return await adminClient.roles.find({ ...params });
-  };
+
 
   const [selectedRole, setSelectedRole] = useState<RoleRepresentation>();
 
@@ -81,7 +78,7 @@ export const RolesList = ({
       <DeleteConfirm />
       <KeycloakDataTable
         key={selectedRole ? selectedRole.id : "roleList"}
-        loader={loader}
+        loader={loader!}
         ariaLabelKey="roles:roleList"
         searchPlaceholderKey="roles:searchFor"
         isPaginated={paginated}

--- a/src/realm-roles/RolesList.tsx
+++ b/src/realm-roles/RolesList.tsx
@@ -13,11 +13,6 @@ import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
 import { emptyFormatter, boolFormatter } from "../util";
 
 type RolesListProps = {
-  loader: (
-    first?: number,
-    max?: number,
-    search?: string
-  ) => Promise<RoleRepresentation[]>;
   paginated?: boolean;
   parentRoleId?: string;
 };
@@ -32,6 +27,17 @@ export const RolesList = ({
   const adminClient = useAdminClient();
   const { addAlert } = useAlerts();
   const { url } = useRouteMatch();
+
+  const loader = async (first?: number, max?: number, search?: string) => {
+    const params: { [name: string]: string | number } = {
+      first: first!,
+      max: max!,
+    };
+    if (search) {
+      params.search = search;
+    }
+    return await adminClient.roles.find({ ...params });
+  };
 
   const [selectedRole, setSelectedRole] = useState<RoleRepresentation>();
 

--- a/src/realm-roles/RolesList.tsx
+++ b/src/realm-roles/RolesList.tsx
@@ -34,8 +34,6 @@ export const RolesList = ({
   const { addAlert } = useAlerts();
   const { url } = useRouteMatch();
 
-
-
   const [selectedRole, setSelectedRole] = useState<RoleRepresentation>();
 
   const RoleDetailLink = (role: RoleRepresentation) => (

--- a/src/realm-roles/RolesList.tsx
+++ b/src/realm-roles/RolesList.tsx
@@ -12,8 +12,6 @@ import { useAlerts } from "../components/alert/Alerts";
 import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
 import { emptyFormatter, boolFormatter } from "../util";
 
-const adminClient = useAdminClient();
-
 type RolesListProps = {
   paginated?: boolean;
   parentRoleId?: string;
@@ -31,6 +29,7 @@ export const RolesList = ({
 }: RolesListProps) => {
   const { t } = useTranslation("roles");
   const history = useHistory();
+  const adminClient = useAdminClient();
   const { addAlert } = useAlerts();
   const { url } = useRouteMatch();
 


### PR DESCRIPTION
## Motivation
<!-- Add references to relevant tickets, issues, design specs and/or a short description of what motivated you to do it. -->
#365 : Upon reviewing/testing Erik's PR I noticed a bug in the realm roles section when paginating by 10 items per page. This PR addresses and fixes the bug described below.

## Brief Description
<!-- Add a short answer for: 
What was done in this PR? (e.g Fix to prevent users from accessing feature X.)
Why it was done? (e.g Feature X was deprecated.)
-->

When a user would select 10 items per page, it was possible to infinitely paginate with the same data showing on every page. 

## Verification Steps
<!--
Add the steps required to verify this change. Keep in mind that these steps should be written so groups unfamiliar with the 
new functionality can follow them, such as QE or documentation.

1. Go to Realm Roles section.
2. Make sure there are > 10 roles.
3. Select pagination dropdown and click "10 per page"
4. Click to the next page and make sure the remaining roles are there and you cannot paginate further.
-->

## Checklist:

- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated
- [x] Formatting has been performed via prettier/eslint
- [x] Type checking has been performed via 'yarn check-types'

## Additional Notes
<!-- 
Add images and/or screen caps to illustrate what was changed if this pull request adds to or modifies existing user-visible appearance/output. 
-->
