### PR TITLE
now it can't be called without  an error handler

### DIFF
--- a/src/components/download-dialog/DownloadDialog.tsx
+++ b/src/components/download-dialog/DownloadDialog.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, ReactElement, useContext } from "react";
+import { useErrorHandler } from "react-error-boundary";
 import {
   Alert,
   AlertVariant,
@@ -56,6 +57,7 @@ export const DownloadDialog = ({
   protocol = "openid-connect",
 }: DownloadDialogModalProps) => {
   const adminClient = useAdminClient();
+  const handleError = useErrorHandler();
   const { t } = useTranslation("common");
   const { enabled } = useContext(HelpContext);
   const serverInfo = useServerInfo();
@@ -80,7 +82,8 @@ export const DownloadDialog = ({
           return JSON.stringify(snippet, undefined, 3);
         }
       },
-      (snippet) => setSnippet(snippet)
+      (snippet) => setSnippet(snippet),
+      handleError
     );
   }, [selected]);
   return (

--- a/src/context/auth/AdminClient.tsx
+++ b/src/context/auth/AdminClient.tsx
@@ -37,7 +37,7 @@ export const useAdminClient = () => {
 export function asyncStateFetch<T>(
   adminClientCall: () => Promise<T>,
   callback: (param: T) => void,
-  onError?: (error: Error) => void
+  onError: (error: Error) => void
 ) {
   let canceled = false;
 

--- a/src/user-federation/UserFederationSection.tsx
+++ b/src/user-federation/UserFederationSection.tsx
@@ -1,4 +1,6 @@
 import React, { useContext, useEffect, useState } from "react";
+import { useHistory, useRouteMatch } from "react-router-dom";
+import { useErrorHandler } from "react-error-boundary";
 import {
   AlertVariant,
   ButtonVariant,
@@ -24,9 +26,8 @@ import { useTranslation } from "react-i18next";
 import { RealmContext } from "../context/realm-context/RealmContext";
 import { useAdminClient, asyncStateFetch } from "../context/auth/AdminClient";
 import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
-import "./user-federation.css";
 
-import { useHistory, useRouteMatch } from "react-router-dom";
+import "./user-federation.css";
 
 export const UserFederationSection = () => {
   const [userFederations, setUserFederations] = useState<
@@ -39,6 +40,7 @@ export const UserFederationSection = () => {
   const [key, setKey] = useState(0);
   const refresh = () => setKey(new Date().getTime());
 
+  const handleError = useErrorHandler();
   const { url } = useRouteMatch();
   const history = useHistory();
 
@@ -53,7 +55,8 @@ export const UserFederationSection = () => {
       },
       (userFederations) => {
         setUserFederations(userFederations);
-      }
+      },
+      handleError
     );
   }, [key]);
 

--- a/src/user/UsersSection.tsx
+++ b/src/user/UsersSection.tsx
@@ -1,4 +1,5 @@
 import React, { useContext, useEffect, useState } from "react";
+import { useErrorHandler } from "react-error-boundary";
 import { useTranslation } from "react-i18next";
 import {
   AlertVariant,
@@ -34,6 +35,7 @@ type BruteUser = UserRepresentation & {
 
 export const UsersSection = () => {
   const { t } = useTranslation("users");
+  const handleError = useErrorHandler();
   const adminClient = useAdminClient();
   const { addAlert } = useAlerts();
   const { realm: realmName } = useContext(RealmContext);
@@ -61,7 +63,8 @@ export const UsersSection = () => {
         setListUsers(
           !((response[0] && response[0].length > 0) || response[1] > 100)
         );
-      }
+      },
+      handleError
     );
   }, []);
 


### PR DESCRIPTION
## Motivation
<!-- Add references to relevant tickets, issues, design specs and/or a short description of what motivated you to do it. -->
Change the type of asyncFetch so we can't use it without an errorHandler