### PR TITLE
Users: Adds create user page to users section

### DIFF
--- a/cypress/integration/users_test.spec.ts
+++ b/cypress/integration/users_test.spec.ts
@@ -1,9 +1,17 @@
 import SidebarPage from "../support/pages/admin_console/SidebarPage";
 import LoginPage from "../support/pages/LoginPage";
+import CreateUserPage from "../support/pages/admin_console/manage/users/CreateUserPage";
+import Masthead from "../support/pages/admin_console/Masthead";
+import ListingPage from "../support/pages/admin_console/ListingPage";
 
 describe("Users test", () => {
   const loginPage = new LoginPage();
   const sidebarPage = new SidebarPage();
+  const createUserPage = new CreateUserPage();
+  const masthead = new Masthead();
+  const listingPage = new ListingPage();
+
+  let itemId = "user_crud";
 
   describe("User creation", () => {
     beforeEach(function () {
@@ -13,10 +21,25 @@ describe("Users test", () => {
     });
 
     it("Go to create User page", () => {
-      cy.get("[data-testid=add-user").click();
+      createUserPage.goToCreateUser();
       cy.url().should("include", "users/add-user");
-      cy.get("[data-testid=cancel-create-user").click();
+
+      // Verify Cancel button works
+      createUserPage.cancel();
       cy.url().should("not.include", "/add-user");
+    });
+
+    it("Create user test", function () {
+      itemId += "_" + (Math.random() + 1).toString(36).substring(7);
+ 
+      // Create
+      createUserPage.goToCreateUser();
+      createUserPage.fillRealmRoleData(itemId).save();
+
+      masthead.checkNotificationMessage("The user has been created");
+
+      sidebarPage.goToUsers();
+      listingPage.searchItem(itemId).itemExist(itemId);
     });
   });
 });

--- a/cypress/integration/users_test.spec.ts
+++ b/cypress/integration/users_test.spec.ts
@@ -1,0 +1,22 @@
+import SidebarPage from "../support/pages/admin_console/SidebarPage";
+import LoginPage from "../support/pages/LoginPage";
+
+describe("Users test", () => {
+  const loginPage = new LoginPage();
+  const sidebarPage = new SidebarPage();
+
+  describe("User creation", () => {
+    beforeEach(function () {
+      cy.visit("");
+      loginPage.logIn();
+      sidebarPage.goToUsers();
+    });
+
+    it("Go to create User page", () => {
+      cy.get("[data-testid=add-user").click();
+      cy.url().should("include", "users/add-user");
+      cy.get("[data-testid=cancel-create-user").click();
+      cy.url().should("not.include", "/add-user");
+    });
+  });
+});

--- a/cypress/integration/users_test.spec.ts
+++ b/cypress/integration/users_test.spec.ts
@@ -21,6 +21,8 @@ describe("Users test", () => {
     });
 
     it("Go to create User page", () => {
+      cy.wait(100);
+
       createUserPage.goToCreateUser();
       cy.url().should("include", "users/add-user");
 
@@ -31,9 +33,12 @@ describe("Users test", () => {
 
     it("Create user test", function () {
       itemId += "_" + (Math.random() + 1).toString(36).substring(7);
- 
+
       // Create
+      cy.wait(100);
+
       createUserPage.goToCreateUser();
+
       createUserPage.fillRealmRoleData(itemId).save();
 
       masthead.checkNotificationMessage("The user has been created");

--- a/cypress/support/pages/admin_console/manage/users/CreateUserPage.ts
+++ b/cypress/support/pages/admin_console/manage/users/CreateUserPage.ts
@@ -1,11 +1,17 @@
 export default class CreateUserPage {
   usernameInput: string;
+  usersEmptyState: string;
+  emptyStateCreateUserBtn: string;
+  searchPgCreateUserBtn: string;
   saveBtn: string;
   cancelBtn: string;
 
   constructor() {
     this.usernameInput = "#kc-username";
 
+    this.usersEmptyState = "[data-testid=empty-state]";
+    this.emptyStateCreateUserBtn = "[data-testid=empty-primary-action]";
+    this.searchPgCreateUserBtn = "[data-testid=create-new-user]";
     this.saveBtn = "[data-testid=create-user]";
     this.cancelBtn = "[data-testid=cancel-create-user]";
   }
@@ -22,7 +28,16 @@ export default class CreateUserPage {
   }
 
   goToCreateUser() {
-    cy.get("[data-testid=add-user").click();
+    cy.wait(100);
+    cy.get("body").then((body) => {
+      if (body.find(this.usersEmptyState).length > 0) {
+        cy.get(this.emptyStateCreateUserBtn).click();
+      } else if (body.find("[data-testid=search-users-title]").length > 0) {
+        cy.get(this.searchPgCreateUserBtn).click();
+      } else {
+        cy.get("[data-testid=add-user]").click();
+      }
+    });
 
     return this;
   }

--- a/cypress/support/pages/admin_console/manage/users/CreateUserPage.ts
+++ b/cypress/support/pages/admin_console/manage/users/CreateUserPage.ts
@@ -1,0 +1,41 @@
+export default class CreateUserPage {
+  usernameInput: string;
+  saveBtn: string;
+  cancelBtn: string;
+
+  constructor() {
+    this.usernameInput = "#kc-username";
+
+    this.saveBtn = "[data-testid=create-user]";
+    this.cancelBtn = "[data-testid=cancel-create-user]";
+  }
+
+  //#region General Settings
+  fillRealmRoleData(username: string) {
+    cy.get(this.usernameInput).clear();
+
+    if (username) {
+      cy.get(this.usernameInput).type(username);
+    }
+
+    return this;
+  }
+
+  goToCreateUser() {
+    cy.get("[data-testid=add-user").click();
+
+    return this;
+  }
+
+  save() {
+    cy.get(this.saveBtn).click();
+
+    return this;
+  }
+
+  cancel() {
+    cy.get(this.cancelBtn).click();
+
+    return this;
+  }
+}

--- a/src/components/list-empty-state/ListEmptyState.tsx
+++ b/src/components/list-empty-state/ListEmptyState.tsx
@@ -19,7 +19,7 @@ export type Action = {
 
 export type ListEmptyStateProps = {
   message: string;
-  instructions: string;
+  instructions: React.ReactNode;
   primaryActionText?: string;
   onPrimaryAction?: MouseEventHandler<HTMLButtonElement>;
   hasIcon?: boolean;

--- a/src/components/list-empty-state/ListEmptyState.tsx
+++ b/src/components/list-empty-state/ListEmptyState.tsx
@@ -38,7 +38,7 @@ export const ListEmptyState = ({
 }: ListEmptyStateProps) => {
   return (
     <>
-      <EmptyState variant="large">
+      <EmptyState data-testid="empty-state" variant="large">
         {hasIcon && isSearchVariant ? (
           <EmptyStateIcon icon={SearchIcon} />
         ) : (

--- a/src/components/list-empty-state/_tests_/__snapshots__/ListEmptyState.test.tsx.snap
+++ b/src/components/list-empty-state/_tests_/__snapshots__/ListEmptyState.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`<ListEmptyState /> render 1`] = `
 <DocumentFragment>
   <div
     class="pf-c-empty-state pf-m-lg"
+    data-testid="empty-state"
   >
     <div
       class="pf-c-empty-state__content"

--- a/src/components/view-header/ViewHeader.tsx
+++ b/src/components/view-header/ViewHeader.tsx
@@ -27,6 +27,7 @@ export type ViewHeaderProps = {
   badge?: string;
   badgeId?: string;
   badgeIsRead?: boolean;
+  dividerComponent?: "div" | "hr" | "li" | undefined;
   subKey: string;
   actionsDropdownId?: string;
   subKeyLinkProps?: FormattedLinkProps;
@@ -43,6 +44,7 @@ export const ViewHeader = ({
   badge,
   badgeId,
   badgeIsRead,
+  dividerComponent,
   subKey,
   subKeyLinkProps,
   dropdownItems,
@@ -157,7 +159,7 @@ export const ViewHeader = ({
           />
         )}
       </PageSection>
-      <Divider />
+      <Divider component={dividerComponent} />
     </>
   );
 };

--- a/src/route-config.ts
+++ b/src/route-config.ts
@@ -21,6 +21,7 @@ import { UserFederationSection } from "./user-federation/UserFederationSection";
 import { UsersSection } from "./user/UsersSection";
 import { MappingDetails } from "./client-scopes/details/MappingDetails";
 import { ClientDetails } from "./clients/ClientDetails";
+import { UsersTabs } from "./user/UsersTabs";
 import { UserFederationKerberosSettings } from "./user-federation/UserFederationKerberosSettings";
 import { UserFederationLdapSettings } from "./user-federation/UserFederationLdapSettings";
 import { RoleMappingForm } from "./client-scopes/add/RoleMappingForm";
@@ -160,6 +161,12 @@ export const routes: RoutesFn = (t: TFunction) => [
     component: UsersSection,
     breadcrumb: t("users:title"),
     access: "query-users",
+  },
+  {
+    path: "/:realm/users/add-user",
+    component: UsersTabs,
+    breadcrumb: t("users:createUser"),
+    access: "manage-users",
   },
   {
     path: "/:realm/sessions",

--- a/src/user/SearchUser.tsx
+++ b/src/user/SearchUser.tsx
@@ -12,6 +12,7 @@ import {
 } from "@patternfly/react-core";
 import { SearchIcon } from "@patternfly/react-icons";
 import { useForm } from "react-hook-form";
+import { useHistory, useRouteMatch } from "react-router-dom";
 
 type SearchUserProps = {
   onSearch: (search: string) => void;
@@ -20,6 +21,11 @@ type SearchUserProps = {
 export const SearchUser = ({ onSearch }: SearchUserProps) => {
   const { t } = useTranslation("users");
   const { register, handleSubmit } = useForm<{ search: string }>();
+  const { url } = useRouteMatch();
+  const history = useHistory();
+
+  const goToCreate = () => history.push(`${url}/add-user`);
+
   return (
     <EmptyState>
       <Title headingLevel="h4" size="lg">
@@ -44,7 +50,7 @@ export const SearchUser = ({ onSearch }: SearchUserProps) => {
           </InputGroup>
         </Form>
       </EmptyStateBody>
-      <Button variant="link" onClick={() => {}}>
+      <Button variant="link" onClick={goToCreate}>
         {t("createNewUser")}
       </Button>
     </EmptyState>

--- a/src/user/SearchUser.tsx
+++ b/src/user/SearchUser.tsx
@@ -28,7 +28,7 @@ export const SearchUser = ({ onSearch }: SearchUserProps) => {
 
   return (
     <EmptyState>
-      <Title headingLevel="h4" size="lg">
+      <Title data-testid="search-users-title" headingLevel="h4" size="lg">
         {t("startBySearchingAUser")}
       </Title>
       <EmptyStateBody>
@@ -50,7 +50,7 @@ export const SearchUser = ({ onSearch }: SearchUserProps) => {
           </InputGroup>
         </Form>
       </EmptyStateBody>
-      <Button variant="link" onClick={goToCreate}>
+      <Button data-testid="create-new-user" variant="link" onClick={goToCreate}>
         {t("createNewUser")}
       </Button>
     </EmptyState>

--- a/src/user/UserForm.tsx
+++ b/src/user/UserForm.tsx
@@ -1,88 +1,226 @@
-import React from "react";
+import React, { useState } from "react";
 import {
   ActionGroup,
   Button,
   FormGroup,
+  Select,
+  SelectOption,
+  Switch,
   TextArea,
   TextInput,
-//   ValidatedOptions,
 } from "@patternfly/react-core";
 import { useTranslation } from "react-i18next";
-import { UseFormMethods } from "react-hook-form";
-
+import { Controller, UseFormMethods } from "react-hook-form";
+import { useHistory } from "react-router-dom";
 import { FormAccess } from "../components/form-access/FormAccess";
 import UserRepresentation from "keycloak-admin/lib/defs/userRepresentation";
-// import { RoleFormType } from "./RealmRoleTabs";
+import { HelpItem } from "../components/help-enabler/HelpItem";
+import { useRealm } from "../context/realm-context/RealmContext";
 
 export type UserFormProps = {
   form: UseFormMethods<UserRepresentation>;
   save: (user: UserRepresentation) => void;
-  editMode: boolean;
-  reset: () => void;
 };
 
-export const UserForm = ({
-  form,
-  save,
-  editMode,
-  reset,
-}: UserFormProps) => {
+export const UserForm = ({ form, save }: UserFormProps) => {
   const { t } = useTranslation("users");
+  const { realm } = useRealm();
+
+  const [
+    isRequiredUserActionsDropdownOpen,
+    setRequiredUserActionsDropdownOpen,
+  ] = useState(false);
+  const [selected, setSelected] = useState<string[]>([]);
+  const history = useHistory();
+
+  const requiredUserActionsOptions = [
+    <SelectOption key={0} value="Configure OTP">
+      {t("configureOTP")}
+    </SelectOption>,
+    <SelectOption key={1} value="Update Password">
+      {t("updatePassword")}
+    </SelectOption>,
+    <SelectOption key={2} value="Update Profile">
+      {t("updateProfile")}
+    </SelectOption>,
+    <SelectOption key={3} value="Verify Email">
+      {t("verifyEmail")}
+    </SelectOption>,
+    <SelectOption key={4} value="Update User Locale">
+      {t("updateUserLocale")}
+    </SelectOption>,
+  ];
+
+  const clearSelection = () => {
+    setSelected([]);
+    setRequiredUserActionsDropdownOpen(false);
+  };
+
   return (
     <FormAccess
       isHorizontal
       onSubmit={form.handleSubmit(save)}
-      role="manage-realm"
+      role="manage-users"
       className="pf-u-mt-lg"
     >
       <FormGroup
-        label={t("roleName")}
-        fieldId="kc-name"
+        label={t("username")}
+        fieldId="kc-username"
         isRequired
-        // validated={form.errors.name ? "error" : "default"}
+        validated={form.errors.username ? "error" : "default"}
         helperTextInvalid={t("common:required")}
       >
         <TextInput
-          ref={form.register({ required: !editMode })}
+          ref={form.register()}
           type="text"
-          id="kc-name"
-          name="name"
-          isReadOnly={editMode}
+          id="kc-username"
+          name="username"
         />
       </FormGroup>
       <FormGroup
-        label={t("common:description")}
+        label={t("email")}
         fieldId="kc-description"
-        // validated={
-        //   form.errors.description
-        //     ? ValidatedOptions.error
-        //     : ValidatedOptions.default
-        // }
-        // helperTextInvalid={form.errors.description?.message}
+        validated={form.errors.email ? "error" : "default"}
+        helperTextInvalid={form.errors.email?.message}
       >
-        <TextArea
-          name="description"
-          ref={form.register({
-            maxLength: {
-              value: 255,
-              message: t("common:maxLength", { length: 255 }),
-            },
-          })}
+        <TextInput
+          ref={form.register()}
           type="text"
-        //   validated={
-        //     form.errors.description
-        //       ? ValidatedOptions.error
-        //       : ValidatedOptions.default
-        //   }
-          id="kc-role-description"
+          id="kc-email"
+          name="email"
         />
+      </FormGroup>
+      <FormGroup
+        label={t("emailVerified")}
+        fieldId="kc-email-verified"
+        helperTextInvalid={t("common:required")}
+        labelIcon={
+          <HelpItem
+            helpText={t("emailVerifiedHelpText")}
+            forLabel={t("emailVerified")}
+            forID="email-verified"
+          />
+        }
+      >
+        <Controller
+          name="user-email-verified"
+          defaultValue={false}
+          control={form.control}
+          render={({ onChange, value }) => (
+            <Switch
+              id={"kc-user-email-verified"}
+              isDisabled={false}
+              onChange={(value) => onChange([`${value}`])}
+              isChecked={value[0] === "true"}
+              label={t("common:on")}
+              labelOff={t("common:off")}
+            />
+          )}
+        ></Controller>
+      </FormGroup>
+      <FormGroup
+        label={t("firstName")}
+        fieldId="kc-firstname"
+        validated={form.errors.firstName ? "error" : "default"}
+        helperTextInvalid={t("common:required")}
+      >
+        <TextInput
+          ref={form.register()}
+          type="text"
+          id="kc-firstname"
+          name="firstname"
+        />
+      </FormGroup>
+      <FormGroup
+        label={t("lastName")}
+        fieldId="kc-name"
+        validated={form.errors.lastName ? "error" : "default"}
+      >
+        <TextInput
+          ref={form.register()}
+          type="text"
+          id="kc-lastname"
+          name="lastname"
+        />
+      </FormGroup>
+      <FormGroup
+        label={t("common:enabled")}
+        fieldId="kc-enabled"
+        labelIcon={
+          <HelpItem
+            helpText={t("disabledHelpText")}
+            forLabel={t("enabled")}
+            forID="enabled-label"
+          />
+        }
+      >
+        <Controller
+          name="user-enabled"
+          defaultValue={false}
+          control={form.control}
+          render={({ onChange, value }) => (
+            <Switch
+              id={"kc-user-enabled"}
+              isDisabled={false}
+              onChange={(value) => onChange([`${value}`])}
+              isChecked={value[0] === "true"}
+              label={t("common:on")}
+              labelOff={t("common:off")}
+            />
+          )}
+        ></Controller>
+      </FormGroup>
+      <FormGroup
+        label={t("requiredUserActions")}
+        fieldId="kc-required-user-actions"
+        validated={form.errors.requiredActions ? "error" : "default"}
+        helperTextInvalid={t("common:required")}
+        labelIcon={
+          <HelpItem
+            helpText={t("requiredUserActionsHelpText")}
+            forLabel={t("requiredUserActions")}
+            forID="required-user-actions-label"
+          />
+        }
+      >
+        <Controller
+          name="required-user-actions"
+          defaultValue={["0"]}
+          typeAheadAriaLabel="Select an action"
+          control={form.control}
+          render={() => (
+            <Select
+              placeholderText="Select action"
+              toggleId="kc-required-user-actions"
+              onToggle={() =>
+                setRequiredUserActionsDropdownOpen(
+                  !isRequiredUserActionsDropdownOpen
+                )
+              }
+              isOpen={isRequiredUserActionsDropdownOpen}
+              selections={selected}
+              onSelect={(_, value) => {
+                const option = value as string;
+                if (selected.includes(option)) {
+                  setSelected(selected.filter((item) => item !== option));
+                } else {
+                  setSelected([...selected, option]);
+                }
+              }}
+              onClear={clearSelection}
+              variant="typeaheadmulti"
+            >
+              {requiredUserActionsOptions}
+            </Select>
+          )}
+        ></Controller>
       </FormGroup>
       <ActionGroup>
         <Button variant="primary" type="submit">
-          {t("common:save")}
+          {t("common:Create")}
         </Button>
-        <Button onClick={() => reset()} variant="link">
-          {editMode ? t("common:reload") : t("common:cancel")}
+        <Button onClick={() => history.push(`/${realm}/users`)} variant="link">
+          {t("common:cancel")}
         </Button>
       </ActionGroup>
     </FormAccess>

--- a/src/user/UserForm.tsx
+++ b/src/user/UserForm.tsx
@@ -1,0 +1,90 @@
+import React from "react";
+import {
+  ActionGroup,
+  Button,
+  FormGroup,
+  TextArea,
+  TextInput,
+//   ValidatedOptions,
+} from "@patternfly/react-core";
+import { useTranslation } from "react-i18next";
+import { UseFormMethods } from "react-hook-form";
+
+import { FormAccess } from "../components/form-access/FormAccess";
+import UserRepresentation from "keycloak-admin/lib/defs/userRepresentation";
+// import { RoleFormType } from "./RealmRoleTabs";
+
+export type UserFormProps = {
+  form: UseFormMethods<UserRepresentation>;
+  save: (user: UserRepresentation) => void;
+  editMode: boolean;
+  reset: () => void;
+};
+
+export const UserForm = ({
+  form,
+  save,
+  editMode,
+  reset,
+}: UserFormProps) => {
+  const { t } = useTranslation("users");
+  return (
+    <FormAccess
+      isHorizontal
+      onSubmit={form.handleSubmit(save)}
+      role="manage-realm"
+      className="pf-u-mt-lg"
+    >
+      <FormGroup
+        label={t("roleName")}
+        fieldId="kc-name"
+        isRequired
+        // validated={form.errors.name ? "error" : "default"}
+        helperTextInvalid={t("common:required")}
+      >
+        <TextInput
+          ref={form.register({ required: !editMode })}
+          type="text"
+          id="kc-name"
+          name="name"
+          isReadOnly={editMode}
+        />
+      </FormGroup>
+      <FormGroup
+        label={t("common:description")}
+        fieldId="kc-description"
+        // validated={
+        //   form.errors.description
+        //     ? ValidatedOptions.error
+        //     : ValidatedOptions.default
+        // }
+        // helperTextInvalid={form.errors.description?.message}
+      >
+        <TextArea
+          name="description"
+          ref={form.register({
+            maxLength: {
+              value: 255,
+              message: t("common:maxLength", { length: 255 }),
+            },
+          })}
+          type="text"
+        //   validated={
+        //     form.errors.description
+        //       ? ValidatedOptions.error
+        //       : ValidatedOptions.default
+        //   }
+          id="kc-role-description"
+        />
+      </FormGroup>
+      <ActionGroup>
+        <Button variant="primary" type="submit">
+          {t("common:save")}
+        </Button>
+        <Button onClick={() => reset()} variant="link">
+          {editMode ? t("common:reload") : t("common:cancel")}
+        </Button>
+      </ActionGroup>
+    </FormAccess>
+  );
+};

--- a/src/user/UserForm.tsx
+++ b/src/user/UserForm.tsx
@@ -10,7 +10,7 @@ import {
 } from "@patternfly/react-core";
 import { useTranslation } from "react-i18next";
 import { Controller, UseFormMethods } from "react-hook-form";
-import { useHistory, useRouteMatch } from "react-router-dom";
+import { useHistory } from "react-router-dom";
 import { FormAccess } from "../components/form-access/FormAccess";
 import UserRepresentation from "keycloak-admin/lib/defs/userRepresentation";
 import { HelpItem } from "../components/help-enabler/HelpItem";
@@ -27,7 +27,6 @@ export const UserForm = ({
 }: UserFormProps) => {
   const { t } = useTranslation("users");
   const { realm } = useRealm();
-  const { url } = useRouteMatch();
 
   const [
     isRequiredUserActionsDropdownOpen,
@@ -37,6 +36,8 @@ export const UserForm = ({
   const history = useHistory();
 
   const watchUsernameInput = watch("username");
+
+  const emailRegexPattern = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
 
   const requiredUserActionsOptions = [
     <SelectOption key={0} value="Configure OTP">
@@ -61,8 +62,6 @@ export const UserForm = ({
     setRequiredUserActionsDropdownOpen(false);
   };
 
-  const goToCreate = () => history.push(`${url}/add-user`);
-
   return (
     <FormAccess
       isHorizontal
@@ -84,16 +83,17 @@ export const UserForm = ({
           name="username"
         />
       </FormGroup>
-
       <FormGroup
         label={t("email")}
         fieldId="kc-description"
         validated={errors.email ? "error" : "default"}
-        helperTextInvalid={errors.email?.message}
+        helperTextInvalid={t("users:emailInvalid")}
       >
         <TextInput
-          ref={register()}
-          type="text"
+          ref={register({
+            pattern: emailRegexPattern,
+          })}
+          type="email"
           id="kc-email"
           name="email"
           aria-label={t("emailInput")}
@@ -137,7 +137,7 @@ export const UserForm = ({
           ref={register()}
           type="text"
           id="kc-firstname"
-          name="firstname"
+          name="firstName"
         />
       </FormGroup>
       <FormGroup
@@ -149,7 +149,7 @@ export const UserForm = ({
           ref={register()}
           type="text"
           id="kc-lastname"
-          name="lastname"
+          name="lastName"
           aria-label={t("lastName")}
         />
       </FormGroup>

--- a/src/user/UserForm.tsx
+++ b/src/user/UserForm.tsx
@@ -21,7 +21,10 @@ export type UserFormProps = {
   save: (user: UserRepresentation) => void;
 };
 
-export const UserForm = ({ form, save }: UserFormProps) => {
+export const UserForm = ({
+  form: { handleSubmit, register, errors, watch, control },
+  save,
+}: UserFormProps) => {
   const { t } = useTranslation("users");
   const { realm } = useRealm();
 
@@ -31,6 +34,8 @@ export const UserForm = ({ form, save }: UserFormProps) => {
   ] = useState(false);
   const [selected, setSelected] = useState<string[]>([]);
   const history = useHistory();
+
+  const watchUsernameInput = watch("username");
 
   const requiredUserActionsOptions = [
     <SelectOption key={0} value="Configure OTP">
@@ -58,7 +63,7 @@ export const UserForm = ({ form, save }: UserFormProps) => {
   return (
     <FormAccess
       isHorizontal
-      onSubmit={form.handleSubmit(save)}
+      onSubmit={handleSubmit(save)}
       role="manage-users"
       className="pf-u-mt-lg"
     >
@@ -66,24 +71,25 @@ export const UserForm = ({ form, save }: UserFormProps) => {
         label={t("username")}
         fieldId="kc-username"
         isRequired
-        validated={form.errors.username ? "error" : "default"}
+        validated={errors.username ? "error" : "default"}
         helperTextInvalid={t("common:required")}
       >
         <TextInput
-          ref={form.register()}
+          ref={register({ required: true })}
           type="text"
           id="kc-username"
           name="username"
         />
       </FormGroup>
+
       <FormGroup
         label={t("email")}
         fieldId="kc-description"
-        validated={form.errors.email ? "error" : "default"}
-        helperTextInvalid={form.errors.email?.message}
+        validated={errors.email ? "error" : "default"}
+        helperTextInvalid={errors.email?.message}
       >
         <TextInput
-          ref={form.register()}
+          ref={register()}
           type="text"
           id="kc-email"
           name="email"
@@ -105,7 +111,7 @@ export const UserForm = ({ form, save }: UserFormProps) => {
         <Controller
           name="user-email-verified"
           defaultValue={false}
-          control={form.control}
+          control={control}
           render={({ onChange, value }) => (
             <Switch
               id={"kc-user-email-verified"}
@@ -121,11 +127,11 @@ export const UserForm = ({ form, save }: UserFormProps) => {
       <FormGroup
         label={t("firstName")}
         fieldId="kc-firstname"
-        validated={form.errors.firstName ? "error" : "default"}
+        validated={errors.firstName ? "error" : "default"}
         helperTextInvalid={t("common:required")}
       >
         <TextInput
-          ref={form.register()}
+          ref={register()}
           type="text"
           id="kc-firstname"
           name="firstname"
@@ -134,10 +140,10 @@ export const UserForm = ({ form, save }: UserFormProps) => {
       <FormGroup
         label={t("lastName")}
         fieldId="kc-name"
-        validated={form.errors.lastName ? "error" : "default"}
+        validated={errors.lastName ? "error" : "default"}
       >
         <TextInput
-          ref={form.register()}
+          ref={register()}
           type="text"
           id="kc-lastname"
           name="lastname"
@@ -158,7 +164,7 @@ export const UserForm = ({ form, save }: UserFormProps) => {
         <Controller
           name="user-enabled"
           defaultValue={false}
-          control={form.control}
+          control={control}
           render={({ onChange, value }) => (
             <Switch
               id={"kc-user-enabled"}
@@ -174,7 +180,7 @@ export const UserForm = ({ form, save }: UserFormProps) => {
       <FormGroup
         label={t("requiredUserActions")}
         fieldId="kc-required-user-actions"
-        validated={form.errors.requiredActions ? "error" : "default"}
+        validated={errors.requiredActions ? "error" : "default"}
         helperTextInvalid={t("common:required")}
         labelIcon={
           <HelpItem
@@ -188,7 +194,7 @@ export const UserForm = ({ form, save }: UserFormProps) => {
           name="required-user-actions"
           defaultValue={["0"]}
           typeAheadAriaLabel="Select an action"
-          control={form.control}
+          control={control}
           render={() => (
             <Select
               placeholderText="Select action"
@@ -217,7 +223,11 @@ export const UserForm = ({ form, save }: UserFormProps) => {
         ></Controller>
       </FormGroup>
       <ActionGroup>
-        <Button variant="primary" type="submit">
+        <Button
+          isDisabled={!watchUsernameInput}
+          variant="primary"
+          type="submit"
+        >
           {t("common:Create")}
         </Button>
         <Button

--- a/src/user/UserForm.tsx
+++ b/src/user/UserForm.tsx
@@ -10,7 +10,7 @@ import {
 } from "@patternfly/react-core";
 import { useTranslation } from "react-i18next";
 import { Controller, UseFormMethods } from "react-hook-form";
-import { useHistory } from "react-router-dom";
+import { useHistory, useRouteMatch } from "react-router-dom";
 import { FormAccess } from "../components/form-access/FormAccess";
 import UserRepresentation from "keycloak-admin/lib/defs/userRepresentation";
 import { HelpItem } from "../components/help-enabler/HelpItem";
@@ -27,6 +27,7 @@ export const UserForm = ({
 }: UserFormProps) => {
   const { t } = useTranslation("users");
   const { realm } = useRealm();
+  const { url } = useRouteMatch();
 
   const [
     isRequiredUserActionsDropdownOpen,
@@ -59,6 +60,8 @@ export const UserForm = ({
     setSelected([]);
     setRequiredUserActionsDropdownOpen(false);
   };
+
+  const goToCreate = () => history.push(`${url}/add-user`);
 
   return (
     <FormAccess

--- a/src/user/UserForm.tsx
+++ b/src/user/UserForm.tsx
@@ -224,6 +224,7 @@ export const UserForm = ({
       </FormGroup>
       <ActionGroup>
         <Button
+          data-testid="create-user"
           isDisabled={!watchUsernameInput}
           variant="primary"
           type="submit"

--- a/src/user/UserForm.tsx
+++ b/src/user/UserForm.tsx
@@ -6,7 +6,6 @@ import {
   Select,
   SelectOption,
   Switch,
-  TextArea,
   TextInput,
 } from "@patternfly/react-core";
 import { useTranslation } from "react-i18next";
@@ -219,7 +218,11 @@ export const UserForm = ({ form, save }: UserFormProps) => {
         <Button variant="primary" type="submit">
           {t("common:Create")}
         </Button>
-        <Button onClick={() => history.push(`/${realm}/users`)} variant="link">
+        <Button
+          data-testid="cancel-create-user"
+          onClick={() => history.push(`/${realm}/users`)}
+          variant="link"
+        >
           {t("common:cancel")}
         </Button>
       </ActionGroup>

--- a/src/user/UserForm.tsx
+++ b/src/user/UserForm.tsx
@@ -87,6 +87,7 @@ export const UserForm = ({ form, save }: UserFormProps) => {
           type="text"
           id="kc-email"
           name="email"
+          aria-label={t("emailInput")}
         />
       </FormGroup>
       <FormGroup
@@ -140,6 +141,7 @@ export const UserForm = ({ form, save }: UserFormProps) => {
           type="text"
           id="kc-lastname"
           name="lastname"
+          aria-label={t("lastName")}
         />
       </FormGroup>
       <FormGroup

--- a/src/user/UsersSection.tsx
+++ b/src/user/UsersSection.tsx
@@ -166,7 +166,7 @@ export const UsersSection = () => {
     <>
       <DeleteConfirm />
       <ViewHeader titleKey="users:title" subKey="" />
-      <PageSection variant="light">
+      <PageSection data-testid="users-page" variant="light">
         {!listUsers && !initialSearch && (
           <SearchUser
             onSearch={(search) => {

--- a/src/user/UsersSection.tsx
+++ b/src/user/UsersSection.tsx
@@ -28,6 +28,7 @@ import { emptyFormatter } from "../util";
 import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
 
 import "./user-section.css";
+import { useHistory, useRouteMatch } from "react-router-dom";
 
 type BruteUser = UserRepresentation & {
   brute?: Record<string, object>;
@@ -39,6 +40,8 @@ export const UsersSection = () => {
   const adminClient = useAdminClient();
   const { addAlert } = useAlerts();
   const { realm: realmName } = useContext(RealmContext);
+  const history = useHistory();
+  const { url } = useRouteMatch();
   const [listUsers, setListUsers] = useState(false);
   const [initialSearch, setInitialSearch] = useState("");
   const [selectedRows, setSelectedRows] = useState<UserRepresentation[]>([]);
@@ -157,6 +160,8 @@ export const UsersSection = () => {
     );
   };
 
+  const goToCreate = () => history.push(`${url}/add-user`);
+
   return (
     <>
       <DeleteConfirm />
@@ -189,7 +194,7 @@ export const UsersSection = () => {
             toolbarItem={
               <>
                 <ToolbarItem>
-                  <Button>{t("addUser")}</Button>
+                  <Button onClick={goToCreate}>{t("addUser")}</Button>
                 </ToolbarItem>
                 <ToolbarItem>
                   <Button

--- a/src/user/UsersSection.tsx
+++ b/src/user/UsersSection.tsx
@@ -194,7 +194,9 @@ export const UsersSection = () => {
             toolbarItem={
               <>
                 <ToolbarItem>
-                  <Button onClick={goToCreate}>{t("addUser")}</Button>
+                  <Button data-testid="add-user" onClick={goToCreate}>
+                    {t("addUser")}
+                  </Button>
                 </ToolbarItem>
                 <ToolbarItem>
                   <Button

--- a/src/user/UsersSection.tsx
+++ b/src/user/UsersSection.tsx
@@ -188,7 +188,7 @@ export const UsersSection = () => {
                 message={t("noUsersFound")}
                 instructions={t("emptyInstructions")}
                 primaryActionText={t("createNewUser")}
-                onPrimaryAction={() => {}}
+                onPrimaryAction={goToCreate}
               />
             }
             toolbarItem={

--- a/src/user/UsersTabs.tsx
+++ b/src/user/UsersTabs.tsx
@@ -1,15 +1,34 @@
 import React from "react";
-import { PageSection } from "@patternfly/react-core";
+import { AlertVariant, PageSection } from "@patternfly/react-core";
 import { useTranslation } from "react-i18next";
 import { useForm } from "react-hook-form";
 
 import { ViewHeader } from "../components/view-header/ViewHeader";
 import UserRepresentation from "keycloak-admin/lib/defs/userRepresentation";
 import { UserForm } from "./UserForm";
+import { useAlerts } from "../components/alert/Alerts";
+import { useAdminClient } from "../context/auth/AdminClient";
 
 export const UsersTabs = () => {
   const { t } = useTranslation("roles");
   const form = useForm<UserRepresentation>({ mode: "onChange" });
+  const { addAlert } = useAlerts();
+  const adminClient = useAdminClient();
+
+  const save = async (user: UserRepresentation) => {
+    try {
+      await adminClient.users.create({ username: user!.username });
+
+      addAlert(t("users:userCreated"), AlertVariant.success);
+    } catch (error) {
+      addAlert(
+        t("users:userCreateError", {
+          error: error.response.data?.errorMessage || error,
+        }),
+        AlertVariant.danger
+      );
+    }
+  };
 
   return (
     <>
@@ -19,7 +38,7 @@ export const UsersTabs = () => {
         dividerComponent="div"
       />
       <PageSection variant="light">
-        <UserForm form={form} save={() => {}} />
+        <UserForm form={form} save={save} />
       </PageSection>
     </>
   );

--- a/src/user/UsersTabs.tsx
+++ b/src/user/UsersTabs.tsx
@@ -1,112 +1,25 @@
-import React, { useEffect, useState } from "react";
-import { useHistory, useParams, useRouteMatch } from "react-router-dom";
-import { Divider, PageSection } from "@patternfly/react-core";
+import React from "react";
+import { PageSection } from "@patternfly/react-core";
 import { useTranslation } from "react-i18next";
-import { useFieldArray, useForm } from "react-hook-form";
+import { useForm } from "react-hook-form";
 
-import { useAlerts } from "../components/alert/Alerts";
-import { useAdminClient } from "../context/auth/AdminClient";
 import { ViewHeader } from "../components/view-header/ViewHeader";
-import { useRealm } from "../context/realm-context/RealmContext";
 import UserRepresentation from "keycloak-admin/lib/defs/userRepresentation";
 import { UserForm } from "./UserForm";
 
 export const UsersTabs = () => {
   const { t } = useTranslation("roles");
   const form = useForm<UserRepresentation>({ mode: "onChange" });
-  //   const history = useHistory();
-
-  //   const adminClient = useAdminClient();
-  //   const [role, setRole] = useState<RoleFormType>();
-
-  //   const { id, clientId } = useParams<{ id: string; clientId: string }>();
-  //   const { url } = useRouteMatch();
-
-  //   const { realm } = useRealm();
-
-  //   const [key, setKey] = useState("");
-
-  //   const { addAlert } = useAlerts();
-
-  //   const { fields, append, remove } = useFieldArray({
-  //     control: form.control,
-  //     name: "attributes",
-  //   });
-
-  //   useEffect(() => append({ key: "", value: "" }), [append, role]);
-
-  //   const save = async (user: UserRepresentation) => {
-  // try {
-  //   const { attributes, ...rest } = role;
-  //   const roleRepresentation: RoleRepresentation = rest;
-  //   if (id) {
-  //     if (attributes) {
-  //       roleRepresentation.attributes = arrayToAttributes(attributes);
-  //     }
-  //     if (!clientId) {
-  //       await adminClient.roles.updateById({ id }, roleRepresentation);
-  //     } else {
-  //       await adminClient.clients.updateRole(
-  //         { id: clientId, roleName: role.name! },
-  //         roleRepresentation
-  //       );
-  //     }
-
-  //     await adminClient.roles.createComposite(
-  //       { roleId: id, realm },
-  //       additionalRoles
-  //     );
-
-  //     setRole(role);
-  //   } else {
-  //     let createdRole;
-  //     if (!clientId) {
-  //       await adminClient.roles.create(roleRepresentation);
-  //       createdRole = await adminClient.roles.findOneByName({
-  //         name: role.name!,
-  //       });
-  //     } else {
-  //       await adminClient.clients.createRole({
-  //         id: clientId,
-  //         name: role.name,
-  //       });
-  //       if (role.description) {
-  //         await adminClient.clients.updateRole(
-  //           { id: clientId, roleName: role.name! },
-  //           roleRepresentation
-  //         );
-  //       }
-  //       createdRole = await adminClient.clients.findRole({
-  //         id: clientId,
-  //         roleName: role.name!,
-  //       });
-  //     }
-  //     setRole(convert(createdRole));
-  //     history.push(
-  //       url.substr(0, url.lastIndexOf("/") + 1) + createdRole.id + "/details"
-  //     );
-  //   }
-  //   addAlert(t(id ? "roleSaveSuccess" : "roleCreated"), AlertVariant.success);
-  // } catch (error) {
-  //   addAlert(
-  //     t((id ? "roleSave" : "roleCreate") + "Error", {
-  //       error: error.response.data?.errorMessage || error,
-  //     }),
-  //     AlertVariant.danger
-  //   );
-  // }
-  //   };
 
   return (
     <>
-      <ViewHeader titleKey={t("users:createUser")} subKey="" dividerComponent="div" />
+      <ViewHeader
+        titleKey={t("users:createUser")}
+        subKey=""
+        dividerComponent="div"
+      />
       <PageSection variant="light">
-        <UserForm
-          reset={() => form.reset()}
-          form={form}
-          save={() => {}}
-          editMode={false}
-        />
+        <UserForm form={form} save={() => {}} />
       </PageSection>
     </>
   );

--- a/src/user/UsersTabs.tsx
+++ b/src/user/UsersTabs.tsx
@@ -1,8 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { useHistory, useParams, useRouteMatch } from "react-router-dom";
-import {
-  PageSection,
-} from "@patternfly/react-core";
+import { Divider, PageSection } from "@patternfly/react-core";
 import { useTranslation } from "react-i18next";
 import { useFieldArray, useForm } from "react-hook-form";
 
@@ -16,104 +14,99 @@ import { UserForm } from "./UserForm";
 export const UsersTabs = () => {
   const { t } = useTranslation("roles");
   const form = useForm<UserRepresentation>({ mode: "onChange" });
-//   const history = useHistory();
+  //   const history = useHistory();
 
-//   const adminClient = useAdminClient();
-//   const [role, setRole] = useState<RoleFormType>();
+  //   const adminClient = useAdminClient();
+  //   const [role, setRole] = useState<RoleFormType>();
 
-//   const { id, clientId } = useParams<{ id: string; clientId: string }>();
-//   const { url } = useRouteMatch();
+  //   const { id, clientId } = useParams<{ id: string; clientId: string }>();
+  //   const { url } = useRouteMatch();
 
-//   const { realm } = useRealm();
+  //   const { realm } = useRealm();
 
-//   const [key, setKey] = useState("");
+  //   const [key, setKey] = useState("");
 
+  //   const { addAlert } = useAlerts();
 
-//   const { addAlert } = useAlerts();
+  //   const { fields, append, remove } = useFieldArray({
+  //     control: form.control,
+  //     name: "attributes",
+  //   });
 
-//   const { fields, append, remove } = useFieldArray({
-//     control: form.control,
-//     name: "attributes",
-//   });
+  //   useEffect(() => append({ key: "", value: "" }), [append, role]);
 
-  useEffect(() => append({ key: "", value: "" }), [append, role]);
+  //   const save = async (user: UserRepresentation) => {
+  // try {
+  //   const { attributes, ...rest } = role;
+  //   const roleRepresentation: RoleRepresentation = rest;
+  //   if (id) {
+  //     if (attributes) {
+  //       roleRepresentation.attributes = arrayToAttributes(attributes);
+  //     }
+  //     if (!clientId) {
+  //       await adminClient.roles.updateById({ id }, roleRepresentation);
+  //     } else {
+  //       await adminClient.clients.updateRole(
+  //         { id: clientId, roleName: role.name! },
+  //         roleRepresentation
+  //       );
+  //     }
 
-//   const save = async (user: UserRepresentation) => {
-    // try {
-    //   const { attributes, ...rest } = role;
-    //   const roleRepresentation: RoleRepresentation = rest;
-    //   if (id) {
-    //     if (attributes) {
-    //       roleRepresentation.attributes = arrayToAttributes(attributes);
-    //     }
-    //     if (!clientId) {
-    //       await adminClient.roles.updateById({ id }, roleRepresentation);
-    //     } else {
-    //       await adminClient.clients.updateRole(
-    //         { id: clientId, roleName: role.name! },
-    //         roleRepresentation
-    //       );
-    //     }
+  //     await adminClient.roles.createComposite(
+  //       { roleId: id, realm },
+  //       additionalRoles
+  //     );
 
-    //     await adminClient.roles.createComposite(
-    //       { roleId: id, realm },
-    //       additionalRoles
-    //     );
-
-    //     setRole(role);
-    //   } else {
-    //     let createdRole;
-    //     if (!clientId) {
-    //       await adminClient.roles.create(roleRepresentation);
-    //       createdRole = await adminClient.roles.findOneByName({
-    //         name: role.name!,
-    //       });
-    //     } else {
-    //       await adminClient.clients.createRole({
-    //         id: clientId,
-    //         name: role.name,
-    //       });
-    //       if (role.description) {
-    //         await adminClient.clients.updateRole(
-    //           { id: clientId, roleName: role.name! },
-    //           roleRepresentation
-    //         );
-    //       }
-    //       createdRole = await adminClient.clients.findRole({
-    //         id: clientId,
-    //         roleName: role.name!,
-    //       });
-    //     }
-    //     setRole(convert(createdRole));
-    //     history.push(
-    //       url.substr(0, url.lastIndexOf("/") + 1) + createdRole.id + "/details"
-    //     );
-    //   }
-    //   addAlert(t(id ? "roleSaveSuccess" : "roleCreated"), AlertVariant.success);
-    // } catch (error) {
-    //   addAlert(
-    //     t((id ? "roleSave" : "roleCreate") + "Error", {
-    //       error: error.response.data?.errorMessage || error,
-    //     }),
-    //     AlertVariant.danger
-    //   );
-    // }
-//   };
+  //     setRole(role);
+  //   } else {
+  //     let createdRole;
+  //     if (!clientId) {
+  //       await adminClient.roles.create(roleRepresentation);
+  //       createdRole = await adminClient.roles.findOneByName({
+  //         name: role.name!,
+  //       });
+  //     } else {
+  //       await adminClient.clients.createRole({
+  //         id: clientId,
+  //         name: role.name,
+  //       });
+  //       if (role.description) {
+  //         await adminClient.clients.updateRole(
+  //           { id: clientId, roleName: role.name! },
+  //           roleRepresentation
+  //         );
+  //       }
+  //       createdRole = await adminClient.clients.findRole({
+  //         id: clientId,
+  //         roleName: role.name!,
+  //       });
+  //     }
+  //     setRole(convert(createdRole));
+  //     history.push(
+  //       url.substr(0, url.lastIndexOf("/") + 1) + createdRole.id + "/details"
+  //     );
+  //   }
+  //   addAlert(t(id ? "roleSaveSuccess" : "roleCreated"), AlertVariant.success);
+  // } catch (error) {
+  //   addAlert(
+  //     t((id ? "roleSave" : "roleCreate") + "Error", {
+  //       error: error.response.data?.errorMessage || error,
+  //     }),
+  //     AlertVariant.danger
+  //   );
+  // }
+  //   };
 
   return (
     <>
-      <ViewHeader
-        titleKey={role?.name || t("createRole")}
-        subKey={id ? "" : "roles:roleCreateExplain"}
-        actionsDropdownId="roles-actions-dropdown"
-      />
+      <ViewHeader titleKey={t("users:createUser")} subKey="" dividerComponent="div" />
       <PageSection variant="light">
-          <UserForm
-            reset={() => form.reset()}
-            form={form}
-            save={save}
-            editMode={false}
-          />
+        <UserForm
+          reset={() => form.reset()}
+          form={form}
+          save={() => {}}
+          editMode={false}
+        />
       </PageSection>
     </>
   );

--- a/src/user/UsersTabs.tsx
+++ b/src/user/UsersTabs.tsx
@@ -1,0 +1,120 @@
+import React, { useEffect, useState } from "react";
+import { useHistory, useParams, useRouteMatch } from "react-router-dom";
+import {
+  PageSection,
+} from "@patternfly/react-core";
+import { useTranslation } from "react-i18next";
+import { useFieldArray, useForm } from "react-hook-form";
+
+import { useAlerts } from "../components/alert/Alerts";
+import { useAdminClient } from "../context/auth/AdminClient";
+import { ViewHeader } from "../components/view-header/ViewHeader";
+import { useRealm } from "../context/realm-context/RealmContext";
+import UserRepresentation from "keycloak-admin/lib/defs/userRepresentation";
+import { UserForm } from "./UserForm";
+
+export const UsersTabs = () => {
+  const { t } = useTranslation("roles");
+  const form = useForm<UserRepresentation>({ mode: "onChange" });
+//   const history = useHistory();
+
+//   const adminClient = useAdminClient();
+//   const [role, setRole] = useState<RoleFormType>();
+
+//   const { id, clientId } = useParams<{ id: string; clientId: string }>();
+//   const { url } = useRouteMatch();
+
+//   const { realm } = useRealm();
+
+//   const [key, setKey] = useState("");
+
+
+//   const { addAlert } = useAlerts();
+
+//   const { fields, append, remove } = useFieldArray({
+//     control: form.control,
+//     name: "attributes",
+//   });
+
+  useEffect(() => append({ key: "", value: "" }), [append, role]);
+
+//   const save = async (user: UserRepresentation) => {
+    // try {
+    //   const { attributes, ...rest } = role;
+    //   const roleRepresentation: RoleRepresentation = rest;
+    //   if (id) {
+    //     if (attributes) {
+    //       roleRepresentation.attributes = arrayToAttributes(attributes);
+    //     }
+    //     if (!clientId) {
+    //       await adminClient.roles.updateById({ id }, roleRepresentation);
+    //     } else {
+    //       await adminClient.clients.updateRole(
+    //         { id: clientId, roleName: role.name! },
+    //         roleRepresentation
+    //       );
+    //     }
+
+    //     await adminClient.roles.createComposite(
+    //       { roleId: id, realm },
+    //       additionalRoles
+    //     );
+
+    //     setRole(role);
+    //   } else {
+    //     let createdRole;
+    //     if (!clientId) {
+    //       await adminClient.roles.create(roleRepresentation);
+    //       createdRole = await adminClient.roles.findOneByName({
+    //         name: role.name!,
+    //       });
+    //     } else {
+    //       await adminClient.clients.createRole({
+    //         id: clientId,
+    //         name: role.name,
+    //       });
+    //       if (role.description) {
+    //         await adminClient.clients.updateRole(
+    //           { id: clientId, roleName: role.name! },
+    //           roleRepresentation
+    //         );
+    //       }
+    //       createdRole = await adminClient.clients.findRole({
+    //         id: clientId,
+    //         roleName: role.name!,
+    //       });
+    //     }
+    //     setRole(convert(createdRole));
+    //     history.push(
+    //       url.substr(0, url.lastIndexOf("/") + 1) + createdRole.id + "/details"
+    //     );
+    //   }
+    //   addAlert(t(id ? "roleSaveSuccess" : "roleCreated"), AlertVariant.success);
+    // } catch (error) {
+    //   addAlert(
+    //     t((id ? "roleSave" : "roleCreate") + "Error", {
+    //       error: error.response.data?.errorMessage || error,
+    //     }),
+    //     AlertVariant.danger
+    //   );
+    // }
+//   };
+
+  return (
+    <>
+      <ViewHeader
+        titleKey={role?.name || t("createRole")}
+        subKey={id ? "" : "roles:roleCreateExplain"}
+        actionsDropdownId="roles-actions-dropdown"
+      />
+      <PageSection variant="light">
+          <UserForm
+            reset={() => form.reset()}
+            form={form}
+            save={save}
+            editMode={false}
+          />
+      </PageSection>
+    </>
+  );
+};

--- a/src/user/UsersTabs.tsx
+++ b/src/user/UsersTabs.tsx
@@ -8,18 +8,30 @@ import UserRepresentation from "keycloak-admin/lib/defs/userRepresentation";
 import { UserForm } from "./UserForm";
 import { useAlerts } from "../components/alert/Alerts";
 import { useAdminClient } from "../context/auth/AdminClient";
+import { useHistory, useRouteMatch } from "react-router-dom";
 
 export const UsersTabs = () => {
   const { t } = useTranslation("roles");
-  const form = useForm<UserRepresentation>({ mode: "onChange" });
   const { addAlert } = useAlerts();
+  const { url } = useRouteMatch();
+  const history = useHistory();
+
   const adminClient = useAdminClient();
+  const form = useForm<UserRepresentation>({ mode: "onChange" });
 
   const save = async (user: UserRepresentation) => {
     try {
-      await adminClient.users.create({ username: user!.username });
-
+      await adminClient.users.create({
+        username: user!.username,
+        email: user!.email,
+        emailVerified: user!.emailVerified,
+        firstName: user!.firstName,
+        lastName: user!.lastName,
+        enabled: user!.enabled,
+        requiredActions: user!.requiredActions,
+      });
       addAlert(t("users:userCreated"), AlertVariant.success);
+      history.push(url.substr(0, url.lastIndexOf("/")));
     } catch (error) {
       addAlert(
         t("users:userCreateError", {

--- a/src/user/messages.json
+++ b/src/user/messages.json
@@ -17,6 +17,7 @@
     "disabled": "Disabled",
     "disabledHelpText": "A disabled user cannot log in.",
     "emailVerifiedHelpText": "Has the user's email been verified?",
+    "emailInvalid": "You must enter a valid email.",
     "temporaryDisabled": "Temporarily disabled",
     "notVerified": "Not verified",
     "requiredUserActions": "Required user actions",

--- a/src/user/messages.json
+++ b/src/user/messages.json
@@ -10,18 +10,29 @@
     "emptyInstructions": "Change your search criteria or add a user",
     "username": "Username",
     "email": "Email",
+    "emailVerified": "Email verified",
     "lastName": "Last name",
     "firstName": "First name",
     "status": "Status",
     "disabled": "Disabled",
+    "disabledHelpText": "A disabled user cannot log in.",
+    "emailVerifiedHelpText": "Has the user's email been verified?",
     "temporaryDisabled": "Temporarily disabled",
     "notVerified": "Not verified",
+    "requiredUserActions": "Required user actions",
+    "requiredUserActionsHelpText": "Require an action when the user logs in. 'Verify email' sends an email to the user to verify their email address. 'Update profile' requires user to enter in new personal information. 'Update password' requires user to enter in a new password. 'Configure OTP' requires setup of a mobile password generator.",
     "addUser": "Add user",
     "deleteUser": "Delete user",
     "deleteConfirm": "Delete user?",
     "deleteConfirmDialog": "Are you sure you want to permanently delete {{count}} selected user",
     "deleteConfirmDialog_plural": "Are you sure you want to permanently delete {{count}} selected users",
     "userDeletedSuccess": "The user has been deleted",
-    "userDeletedError": "The user could not be deleted {{error}}"
+    "userDeletedError": "The user could not be deleted {{error}}",
+    "configureOTP": "Configure OTP",
+    "updatePassword": "Update Password",
+    "updateProfile": "Update Profile",
+    "verifyEmail": "Verify Email",
+    "updateUserLocale": "Update User Locale"
+
   }
 }

--- a/src/user/messages.json
+++ b/src/user/messages.json
@@ -26,6 +26,8 @@
     "deleteConfirm": "Delete user?",
     "deleteConfirmDialog": "Are you sure you want to permanently delete {{count}} selected user",
     "deleteConfirmDialog_plural": "Are you sure you want to permanently delete {{count}} selected users",
+    "userCreated": "The user has been created",
+    "userCreateError": "Could not create user: {{error}}",
     "userDeletedSuccess": "The user has been deleted",
     "userDeletedError": "The user could not be deleted {{error}}",
     "configureOTP": "Configure OTP",

--- a/src/user/messages.json
+++ b/src/user/messages.json
@@ -3,6 +3,7 @@
     "title": "Users",
     "searchForUser": "Search user",
     "startBySearchingAUser": "Start by searching for users",
+    "createUser": "Create user",
     "createNewUser": "Create new user",
     "noUsersFound": "No users found",
     "noUsersFoundError": "No users found due to {{error}}",


### PR DESCRIPTION
## Motivation
<!-- Add references to relevant tickets, issues, design specs and/or a short description of what motivated you to do it. -->

- https://issues.redhat.com/browse/APPDUX-860
- Towards https://issues.redhat.com/browse/APPDUX-861

## Brief Description
<!-- Add a short answer for: 
What was done in this PR? (e.g Fix to prevent users from accessing feature X.)
Why it was done? (e.g Feature X was deprecated.)
-->
This PR adds a "Create User" page to the Users section of Keycloak. 

## Verification Steps
<!--
Add the steps required to verify this change. Keep in mind that these steps should be written so groups unfamiliar with the 
new functionality can follow them, such as QE or documentation.-->

1. Go to Users section of Keycloak.
2. Click "Add User".
3. Verify the page matches the mock: https://marvelapp.com/prototype/7i7ja65/screen/75693207
4. Toggle help and confirm that the text content matches what is expected.
5. Click "Cancel" and make sure you are navigated back to the initial users page.
6. Click the "Add User" button again and fill in the Username.
7. Go back to the table and verify that the new user is in the table.

## Checklist:

- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [x] Help has been implemented
- [x] axe report has been run and resulting a11y issues have been resolved
- [x] Unit tests have been created/updated
- [x] Formatting has been performed via prettier/eslint
- [x] Type checking has been performed via 'yarn check-types'

## Additional Notes
<!-- 
Add images and/or screen caps to illustrate what was changed if this pull request adds to or modifies existing user-visible appearance/output. 
-->
