### PR TITLE
Action menu commands for User Fed LDAP settings

### DIFF
--- a/src/user-federation/UserFederationLdapSettings.tsx
+++ b/src/user-federation/UserFederationLdapSettings.tsx
@@ -68,14 +68,11 @@ const LdapSettingsHeader = ({
           action: "triggerChangedUsersSync",
         });
         if (response.ignored) {
-          addAlert(
-            t("syncUsersSuccess") + ` ${response.status}.`,
-            AlertVariant.success
-          );
+          addAlert(`${response.status}.`, AlertVariant.warning);
         } else {
           addAlert(
             t("syncUsersSuccess") +
-              ` ${response.added} users added, ${response.updated} users updated, ${response.removed} users removed, ${response.failed} users failed.`,
+              `${response.added} users added, ${response.updated} users updated, ${response.removed} users removed, ${response.failed} users failed.`,
             AlertVariant.success
           );
         }
@@ -93,14 +90,11 @@ const LdapSettingsHeader = ({
           action: "triggerFullSync",
         });
         if (response.ignored) {
-          addAlert(
-            t("syncUsersSuccess") + ` ${response.status}.`,
-            AlertVariant.success
-          );
+          addAlert(`${response.status}.`, AlertVariant.warning);
         } else {
           addAlert(
             t("syncUsersSuccess") +
-              ` ${response.added} users added, ${response.updated} users updated, ${response.removed} users removed, ${response.failed} users failed.`,
+              `${response.added} users added, ${response.updated} users updated, ${response.removed} users removed, ${response.failed} users failed.`,
             AlertVariant.success
           );
         }

--- a/src/user-federation/UserFederationLdapSettings.tsx
+++ b/src/user-federation/UserFederationLdapSettings.tsx
@@ -131,25 +131,22 @@ const LdapSettingsHeader = ({
           titleKey="LDAP"
           subKey=""
           dropdownItems={[
-            <DropdownItem key="sync" onClick={() => syncChangedUsers()}>
+            <DropdownItem key="sync" onClick={syncChangedUsers}>
               {t("syncChangedUsers")}
             </DropdownItem>,
-            <DropdownItem key="syncall" onClick={() => syncAllUsers()}>
+            <DropdownItem key="syncall" onClick={syncAllUsers}>
               {t("syncAllUsers")}
             </DropdownItem>,
-            <DropdownItem key="unlink" onClick={() => unlinkUsers()}>
+            <DropdownItem key="unlink" onClick={unlinkUsers}>
               {t("unlinkUsers")}
             </DropdownItem>,
-            <DropdownItem
-              key="remove"
-              onClick={() => toggleRemoveUsersDialog()}
-            >
+            <DropdownItem key="remove" onClick={toggleRemoveUsersDialog}>
               {t("removeImported")}
             </DropdownItem>,
             <DropdownSeparator key="separator" />,
             <DropdownItem
               key="delete"
-              onClick={() => toggleDeleteDialog()}
+              onClick={toggleDeleteDialog}
               data-testid="delete-ldap-cmd"
             >
               {t("deleteProvider")}

--- a/src/user-federation/messages.json
+++ b/src/user-federation/messages.json
@@ -96,8 +96,14 @@
 
     "removeImportedUsers": "Remove imported users?",
     "removeImportedUsersMessage": "Do you really want to remove all imported users? The option \"Unlink users\" makes sense just for the Edit Mode \"Unsynced\" and there should be a warning that \"unlinked\" users without the password in the Keycloak database won't be able to authenticate.",
-    "removeImportedUsersSuccess": "Imported users have been removed",
+    "removeImportedUsersSuccess": "Imported users have been removed.",
     "removeImportedUsersError": "Could not remove imported users: '{{error}}'",
+
+    "syncUsersSuccess": "Sync of users finished successfully.",
+    "syncUsersError": "Could not sync users: '{{error}}'",
+
+    "unlinkUsersSuccess": "Unlink of users finished successfully.",
+    "unlinkUsersError": "Could not unlink users: '{{error}}'",
 
     "validateName": "You must enter a name",
     "validateRealm":"You must enter a realm",


### PR DESCRIPTION
## Motivation
https://issues.redhat.com/browse/APPDUX-724

## Brief Description
Add business logic for the following LDAP settings menu commands that were available in the legacy admin console:
* Sync changed users
* Sync all users
* Unlink users
* Remove imported

## Verification Steps
1. Go to user federation and select an LDAP provider card (or create a new one if it doesn't exist).
2. In the action menu, select 'Sync changed users'. Verify that you get an alert with the status.
3. Repeat for the 'Sync all users', 'Unlink users' and 'Remove imported' commands.

## Checklist:
- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [x] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated
- [x] Formatting has been performed via prettier/eslint
- [x] Type checking has been performed via 'yarn check-types'

## Additional Notes
There are no cypress tests yet, as we discussed, we will need to set up some kind of mock data or equivalent LDAP config to really test this. These commands will eventually need to be revisited.
