### PR TITLE
Nonscrolling action buttons for long forms

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -8,3 +8,13 @@
 .keycloak__form {
   max-width: 1024px;
 }
+
+.keycloak__form_actions {
+  position: fixed;
+  bottom: 0px;
+  background-color: var(--pf-c-page__main-section--m-light--BackgroundColor);
+  padding-top: var(--pf-global--spacer--md);
+  padding-bottom: var(--pf-global--spacer--sm);
+  width: 100%;
+  border-top: 1px solid var(--pf-global--BorderColor--100);
+}

--- a/public/index.css
+++ b/public/index.css
@@ -15,6 +15,8 @@
   background-color: var(--pf-c-page__main-section--m-light--BackgroundColor);
   padding-top: var(--pf-global--spacer--md);
   padding-bottom: var(--pf-global--spacer--sm);
+  padding-left: var(--pf-global--spacer--md);
   width: 100%;
   border-top: 1px solid var(--pf-global--BorderColor--100);
+  margin-left: calc(-1 * var(--pf-global--spacer--lg));
 }

--- a/src/clients/ClientSettings.tsx
+++ b/src/clients/ClientSettings.tsx
@@ -18,8 +18,6 @@ import { MultiLineInput } from "../components/multi-line-input/MultiLineInput";
 import { FormAccess } from "../components/form-access/FormAccess";
 import { HelpItem } from "../components/help-enabler/HelpItem";
 
-import "../common-styles.css";
-
 type ClientSettingsProps = {
   save: () => void;
 };
@@ -145,7 +143,7 @@ export const ClientSettings = ({ save }: ClientSettingsProps) => {
               ref={register}
             />
           </FormGroup>
-          <ActionGroup className="nonscroll-action-group">
+          <ActionGroup className="keycloak__form_actions">
             <Button variant="primary" onClick={save}>
               {t("common:save")}
             </Button>

--- a/src/clients/ClientSettings.tsx
+++ b/src/clients/ClientSettings.tsx
@@ -18,6 +18,8 @@ import { MultiLineInput } from "../components/multi-line-input/MultiLineInput";
 import { FormAccess } from "../components/form-access/FormAccess";
 import { HelpItem } from "../components/help-enabler/HelpItem";
 
+import "../common-styles.css";
+
 type ClientSettingsProps = {
   save: () => void;
 };
@@ -143,7 +145,7 @@ export const ClientSettings = ({ save }: ClientSettingsProps) => {
               ref={register}
             />
           </FormGroup>
-          <ActionGroup>
+          <ActionGroup className="nonscroll-action-group">
             <Button variant="primary" onClick={save}>
               {t("common:save")}
             </Button>

--- a/src/common-styles.css
+++ b/src/common-styles.css
@@ -1,8 +1,0 @@
-.nonscroll-action-group {
-    overflow: hidden;
-    background-color: white;
-    position: fixed;
-    bottom: 0;
-    width: 100%;
-    padding: 15px;
-  }

--- a/src/common-styles.css
+++ b/src/common-styles.css
@@ -1,0 +1,8 @@
+.nonscroll-action-group {
+    overflow: hidden;
+    background-color: white;
+    position: fixed;
+    bottom: 0;
+    width: 100%;
+    padding: 15px;
+  }

--- a/src/user-federation/UserFederationLdapSettings.tsx
+++ b/src/user-federation/UserFederationLdapSettings.tsx
@@ -31,8 +31,6 @@ import { ViewHeader } from "../components/view-header/ViewHeader";
 import { useHistory, useParams } from "react-router-dom";
 import { ScrollForm } from "../components/scroll-form/ScrollForm";
 
-import "../common-styles.css";
-
 type LdapSettingsHeaderProps = {
   onChange: (value: string) => void;
   value: string;
@@ -298,7 +296,7 @@ export const UserFederationLdapSettings = () => {
           <LdapSettingsAdvanced form={form} />
         </ScrollForm>
         <Form onSubmit={form.handleSubmit(save)}>
-          <ActionGroup className="nonscroll-action-group">
+          <ActionGroup className="keycloak__form_actions">
             <Button
               isDisabled={!form.formState.isDirty}
               variant="primary"

--- a/src/user-federation/UserFederationLdapSettings.tsx
+++ b/src/user-federation/UserFederationLdapSettings.tsx
@@ -31,6 +31,8 @@ import { ViewHeader } from "../components/view-header/ViewHeader";
 import { useHistory, useParams } from "react-router-dom";
 import { ScrollForm } from "../components/scroll-form/ScrollForm";
 
+import "../common-styles.css";
+
 type LdapSettingsHeaderProps = {
   onChange: (value: string) => void;
   value: string;
@@ -296,7 +298,7 @@ export const UserFederationLdapSettings = () => {
           <LdapSettingsAdvanced form={form} />
         </ScrollForm>
         <Form onSubmit={form.handleSubmit(save)}>
-          <ActionGroup>
+          <ActionGroup className="nonscroll-action-group">
             <Button
               isDisabled={!form.formState.isDirty}
               variant="primary"


### PR DESCRIPTION
## Motivation
Fixes https://github.com/keycloak/keycloak-admin-ui/issues/398.

## Brief Description
On long forms, aka the forms that have jump links, the action buttons (Save, Cancel, Revert, etc) to the bottom of the screen should be fixed so you don't need to scroll long forms to click them.

## Verification Steps
1. Go to user fed and select an LDAP provider, or create one if it doesn't already exist.
2. Verify that the Save and Cancel buttons are available at the bottom of the screen without scrolling.
3. Verify that you can navigate the long form by scrolling or using the jump links, and the action buttons still remain available at the bottom of the screen.
4. Repeat steps 1-3 for the client details long form.

## Checklist:
- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [x] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [x] Unit tests have been created/updated
- [x] Formatting has been performed via prettier/eslint
- [x] Type checking has been performed via 'yarn check-types'
