### PR TITLE
Rename Reload buttons to Revert

### DIFF
--- a/cypress/integration/clients_test.spec.ts
+++ b/cypress/integration/clients_test.spec.ts
@@ -158,7 +158,7 @@ describe("Clients test", function () {
 
       advancedTab
         .selectAccessTokenSignatureAlgorithm("HS384")
-        .clickReloadFineGrain();
+        .clickRevertFineGrain();
       advancedTab.checkAccessTokenSignatureAlgorithm(algorithm);
     });
   });

--- a/cypress/support/pages/admin_console/manage/clients/AdvancedTab.ts
+++ b/cypress/support/pages/admin_console/manage/clients/AdvancedTab.ts
@@ -15,7 +15,7 @@ export default class AdvancedTab {
 
   private accessTokenSignatureAlgorithm = "#accessTokenSignatureAlgorithm";
   private fineGrainSave = "#fineGrainSave";
-  private fineGrainReload = "#fineGrainReload";
+  private fineGrainRevert = "#fineGrainRevert";
 
   private advancedTab = "#pf-tab-advanced-advanced";
 
@@ -98,8 +98,8 @@ export default class AdvancedTab {
     return this;
   }
 
-  clickReloadFineGrain() {
-    cy.get(this.fineGrainReload).click();
+  clickRevertFineGrain() {
+    cy.get(this.fineGrainRevert).click();
     return this;
   }
 }

--- a/src/clients/advanced/AdvancedSettings.tsx
+++ b/src/clients/advanced/AdvancedSettings.tsx
@@ -154,7 +154,7 @@ export const AdvancedSettings = ({
           {t("common:save")}
         </Button>
         <Button variant="link" onClick={reset}>
-          {t("common:reload")}
+          {t("common:revert")}
         </Button>
       </ActionGroup>
     </FormAccess>

--- a/src/clients/advanced/FineGrainOpenIdConnect.tsx
+++ b/src/clients/advanced/FineGrainOpenIdConnect.tsx
@@ -348,8 +348,8 @@ export const FineGrainOpenIdConnect = ({
         <Button id="fineGrainSave" variant="tertiary" onClick={save}>
           {t("common:save")}
         </Button>
-        <Button id="fineGrainReload" variant="link" onClick={reset}>
-          {t("common:reload")}
+        <Button id="fineGrainRevert" variant="link" onClick={reset}>
+          {t("common:revert")}
         </Button>
       </ActionGroup>
     </FormAccess>

--- a/src/clients/advanced/FineGrainSamlEndpointConfig.tsx
+++ b/src/clients/advanced/FineGrainSamlEndpointConfig.tsx
@@ -103,7 +103,7 @@ export const FineGrainSamlEndpointConfig = ({
           {t("common:save")}
         </Button>
         <Button variant="link" onClick={reset}>
-          {t("common:reload")}
+          {t("common:revert")}
         </Button>
       </ActionGroup>
     </FormAccess>

--- a/src/clients/advanced/OpenIdConnectCompatibilityModes.tsx
+++ b/src/clients/advanced/OpenIdConnectCompatibilityModes.tsx
@@ -51,7 +51,7 @@ export const OpenIdConnectCompatibilityModes = ({
           {t("common:save")}
         </Button>
         <Button variant="link" onClick={reset}>
-          {t("common:reload")}
+          {t("common:revert")}
         </Button>
       </ActionGroup>
     </FormAccess>

--- a/src/clients/advanced/SaveReset.tsx
+++ b/src/clients/advanced/SaveReset.tsx
@@ -15,8 +15,8 @@ export const SaveReset = ({ name, save, reset }: SaveResetProps) => {
       <Button data-testid={name + "Save"} variant="tertiary" onClick={save}>
         {t("common:save")}
       </Button>
-      <Button data-testid={name + "Reload"} variant="link" onClick={reset}>
-        {t("common:reload")}
+      <Button data-testid={name + "Revert"} variant="link" onClick={reset}>
+        {t("common:revert")}
       </Button>
     </ActionGroup>
   );

--- a/src/common-messages.json
+++ b/src/common-messages.json
@@ -8,7 +8,7 @@
     "no": "No",
     "create": "Create",
     "save": "Save",
-    "reload": "Reload",
+    "revert": "Revert",
     "cancel": "Cancel",
     "continue": "Continue",
     "delete": "Delete",

--- a/src/realm-roles/RealmRoleForm.tsx
+++ b/src/realm-roles/RealmRoleForm.tsx
@@ -81,7 +81,7 @@ export const RealmRoleForm = ({
           {t("common:save")}
         </Button>
         <Button onClick={() => reset()} variant="link">
-          {editMode ? t("common:reload") : t("common:cancel")}
+          {editMode ? t("common:revert") : t("common:cancel")}
         </Button>
       </ActionGroup>
     </FormAccess>

--- a/src/realm-roles/RoleAttributes.tsx
+++ b/src/realm-roles/RoleAttributes.tsx
@@ -146,7 +146,7 @@ export const RoleAttributes = ({
             {t("common:save")}
           </Button>
           <Button onClick={reset} variant="link">
-            {t("common:reload")}
+            {t("common:revert")}
           </Button>
         </ActionGroup>
       </FormAccess>

--- a/src/realm-settings/RealmSettingsSection.tsx
+++ b/src/realm-settings/RealmSettingsSection.tsx
@@ -324,7 +324,7 @@ export const RealmSettingsSection = () => {
                   {t("common:save")}
                 </Button>
                 <Button variant="link" onClick={() => setupForm(realm!)}>
-                  {t("common:reload")}
+                  {t("common:revert")}
                 </Button>
               </ActionGroup>
             </FormAccess>


### PR DESCRIPTION
## Motivation
Fixes https://github.com/keycloak/keycloak-admin-ui/issues/397.

## Brief Description
Changes all references of 'Reload' (in most cases, the action button) to 'Revert'. This was brought up during the UXD App Services demo and the change was agreed upon during the Keycloak team meeting on 2/23.

"Revert" is more intuitive and conveys the form is being reverted to the existing values from the server.

## Verification Steps
Verify that Reload buttons are now replaced with Revert buttons throughout the UI.

## Checklist:
- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [x] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [x] Unit tests have been created/updated
- [x] Formatting has been performed via prettier/eslint
- [x] Type checking has been performed via 'yarn check-types'

## Additional Notes
None