### PR TITLE
Add missing kerberos-related fields to LDAP settings

### DIFF
--- a/src/user-federation/ldap/LdapSettingsKerberosIntegration.tsx
+++ b/src/user-federation/ldap/LdapSettingsKerberosIntegration.tsx
@@ -1,8 +1,8 @@
-import { FormGroup, Switch } from "@patternfly/react-core";
+import { FormGroup, Switch, TextInput } from "@patternfly/react-core";
 import { useTranslation } from "react-i18next";
 import React from "react";
 import { HelpItem } from "../../components/help-enabler/HelpItem";
-import { UseFormMethods, Controller } from "react-hook-form";
+import { UseFormMethods, Controller, useWatch } from "react-hook-form";
 import { FormAccess } from "../../components/form-access/FormAccess";
 import { WizardSectionHeader } from "../../components/wizard-section-header/WizardSectionHeader";
 
@@ -19,6 +19,12 @@ export const LdapSettingsKerberosIntegration = ({
 }: LdapSettingsKerberosIntegrationProps) => {
   const { t } = useTranslation("user-federation");
   const helpText = useTranslation("user-federation-help").t;
+
+  const allowKerberosAuth: [string] = useWatch({
+    control: form.control,
+    name: "config.allowKerberosAuthentication",
+    defaultValue: ["true"],
+  });
 
   return (
     <>
@@ -59,6 +65,143 @@ export const LdapSettingsKerberosIntegration = ({
             )}
           ></Controller>
         </FormGroup>
+
+        {allowKerberosAuth[0] === "true" && (
+          <>
+            <FormGroup
+              label={t("kerberosRealm")}
+              labelIcon={
+                <HelpItem
+                  helpText={helpText("kerberosRealmHelp")}
+                  forLabel={t("kerberosRealm")}
+                  forID="kc-kerberos-realm"
+                />
+              }
+              fieldId="kc-kerberos-realm"
+              isRequired
+            >
+              <TextInput
+                isRequired
+                type="text"
+                id="kc-kerberos-realm"
+                name="config.kerberosRealm[0]"
+                ref={form.register({
+                  required: {
+                    value: true,
+                    message: `${t("validateRealm")}`,
+                  },
+                })}
+                data-testid="kerberos-realm"
+              />
+              {form.errors.config &&
+                form.errors.config.kerberosRealm &&
+                form.errors.config.kerberosRealm[0] && (
+                  <div className="error">
+                    {form.errors.config.kerberosRealm[0].message}
+                  </div>
+                )}
+            </FormGroup>
+
+            <FormGroup
+              label={t("serverPrincipal")}
+              labelIcon={
+                <HelpItem
+                  helpText={helpText("serverPrincipalHelp")}
+                  forLabel={t("serverPrincipal")}
+                  forID="kc-server-principal"
+                />
+              }
+              fieldId="kc-server-principal"
+              isRequired
+            >
+              <TextInput
+                isRequired
+                type="text"
+                id="kc-server-principal"
+                name="config.serverPrincipal[0]"
+                ref={form.register({
+                  required: {
+                    value: true,
+                    message: `${t("validateServerPrincipal")}`,
+                  },
+                })}
+                data-testid="kerberos-principal"
+              />
+              {form.errors.config &&
+                form.errors.config.serverPrincipal &&
+                form.errors.config.serverPrincipal[0] && (
+                  <div className="error">
+                    {form.errors.config.serverPrincipal[0].message}
+                  </div>
+                )}
+            </FormGroup>
+
+            <FormGroup
+              label={t("keyTab")}
+              labelIcon={
+                <HelpItem
+                  helpText={helpText("keyTabHelp")}
+                  forLabel={t("keyTab")}
+                  forID="kc-key-tab"
+                />
+              }
+              fieldId="kc-key-tab"
+              isRequired
+            >
+              <TextInput
+                isRequired
+                type="text"
+                id="kc-key-tab"
+                name="config.keyTab[0]"
+                ref={form.register({
+                  required: {
+                    value: true,
+                    message: `${t("validateKeyTab")}`,
+                  },
+                })}
+                data-testid="kerberos-keytab"
+              />
+              {form.errors.config &&
+                form.errors.config.keyTab &&
+                form.errors.config.keyTab[0] && (
+                  <div className="error">
+                    {form.errors.config.keyTab[0].message}
+                  </div>
+                )}
+            </FormGroup>
+          </>
+        )}
+
+        <FormGroup
+          label={t("debug")}
+          labelIcon={
+            <HelpItem
+              helpText={helpText("debugHelp")}
+              forLabel={t("debug")}
+              forID="kc-debug"
+            />
+          }
+          fieldId="kc-debug"
+          hasNoPaddingTop
+        >
+          {" "}
+          <Controller
+            name="config.debug"
+            defaultValue={["false"]}
+            control={form.control}
+            render={({ onChange, value }) => (
+              <Switch
+                id={"kc-debug"}
+                isDisabled={false}
+                onChange={(value) => onChange([`${value}`])}
+                isChecked={value[0] === "true"}
+                label={t("common:on")}
+                labelOff={t("common:off")}
+              />
+            )}
+          ></Controller>
+        </FormGroup>
+
         <FormGroup
           label={t("useKerberosForPasswordAuthentication")}
           labelIcon={


### PR DESCRIPTION
## Motivation
Fixes https://github.com/keycloak/keycloak-admin-ui/issues/399.

## Brief Description
In the new console UI, when you enable the 'Allow Kerberos authentication' switch, four kerberos controls were supposed to appear but were missing from the initial implementation (kerberos realm text field, server principal text field, key tab text field, and debug switch). These have been added so the implementation now matches the old console UI.

## Verification Steps
1. Go to user fed and click an existing LDAP card, or create a new LDAP provider.
2. Verify that when you switch Allow Kerberos authentication to ON, the Kerberos realm, Server principal, Keytab, and Debug controls appear.
3. Add values to the fields and click Save.
4. Verify that the new values have been saved by navigating away and returning, or going to the old console, etc.
5. Switch the Allow Kerberos authentication to OFF and verify that the controls are now hidden.

## Checklist:
- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [x] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [x] Unit tests have been created/updated
- [x] Formatting has been performed via prettier/eslint
- [x] Type checking has been performed via 'yarn check-types'

## Additional Notes
None