### PR TITLE
fix help icon alignment

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -9,10 +9,15 @@
   max-width: 1024px;
 }
 
+label.pf-c-form__label {
+  display: inline-flex;
+}
+
 .pf-c-form__group-label {
   display: flex;
   align-items: end;
 }
+
 .keycloak__form_actions {
   position: fixed;
   bottom: 0px;

--- a/public/index.css
+++ b/public/index.css
@@ -9,6 +9,10 @@
   max-width: 1024px;
 }
 
+.pf-c-form__group-label {
+  display: flex;
+  align-items: end;
+}
 .keycloak__form_actions {
   position: fixed;
   bottom: 0px;


### PR DESCRIPTION
## Motivation
<!-- Add references to relevant tickets, issues, design specs and/or a short description of what motivated you to do it. -->

#434 

## Verification Steps
<!--
Add the steps required to verify this change. Keep in mind that these steps should be written so groups unfamiliar with the 
new functionality can follow them, such as QE or documentation.

1. Enable help mode.
2. Go to any page with a form.
3. Verify that there are no instances that the help wraps to the next line following the label for the input field (help icon should now be adjacent to the input field rather than underneath it)
-->

## Checklist:

- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [x] Help has been implemented
- [x] axe report has been run and resulting a11y issues have been resolved
- [x] Unit tests have been created/updated
- [x] Formatting has been performed via prettier/eslint
- [x] Type checking has been performed via 'yarn check-types'

## Additional Notes
<!-- 
Add images and/or screen caps to illustrate what was changed if this pull request adds to or modifies existing user-visible appearance/output. 
-->
