### PR TITLE
removed double query for realm roles

### DIFF
--- a/src/realm-roles/RealmRolesSection.tsx
+++ b/src/realm-roles/RealmRolesSection.tsx
@@ -1,29 +1,13 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { PageSection } from "@patternfly/react-core";
 import { ViewHeader } from "../components/view-header/ViewHeader";
-import { asyncStateFetch, useAdminClient } from "../context/auth/AdminClient";
+import { useAdminClient } from "../context/auth/AdminClient";
 import { RolesList } from "./RolesList";
-import { useErrorHandler } from "react-error-boundary";
 
 export const RealmRolesSection = () => {
   const adminClient = useAdminClient();
-  const [listRoles, setListRoles] = useState(false);
-  const handleError = useErrorHandler();
 
-  useEffect(() => {
-    return asyncStateFetch(
-      () => {
-        return Promise.all([adminClient.roles.find()]);
-      },
-
-      (response) => {
-        setListRoles(!(response[0] && response[0].length > 0));
-      },
-      handleError
-    );
-  }, []);
-
-  const loader = async (first?: number, max?: number, search?: string) => {
+  const loader = (first?: number, max?: number, search?: string) => {
     const params: { [name: string]: string | number } = {
       first: first!,
       max: max!,
@@ -35,11 +19,7 @@ export const RealmRolesSection = () => {
       params.search = searchParam;
     }
 
-    if (!listRoles && !searchParam) {
-      return [];
-    }
-
-    return await adminClient.roles.find(params);
+    return adminClient.roles.find(params);
   };
 
   return (


### PR DESCRIPTION
## Motivation
<!-- Add references to relevant tickets, issues, design specs and/or a short description of what motivated you to do it. -->
I don't know why this was added, it might break something somewhere else, but for me realm roles list was empty every time.
Also it was fetching the list twice.

## Brief Description
<!-- Add a short answer for: 
What was done in this PR? (e.g Fix to prevent users from accessing feature X.)
Why it was done? (e.g Feature X was deprecated.)
-->
Realm roles was always empty

## Verification Steps
<!--
Add the steps required to verify this change. Keep in mind that these steps should be written so groups unfamiliar with the 
new functionality can follow them, such as QE or documentation.

1. Go to `XX >> YY >> SS`.
2. Create a new item `N` with info `X`.
3. Right-click the item and select Delete.
4. Verify that the item is no longer present in the left navigation menu.
-->
Go to realm roles and see realm roles

## Checklist:

- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [x] Help has been implemented
- [x] axe report has been run and resulting a11y issues have been resolved
- [x] Unit tests have been created/updated
- [x] Formatting has been performed via prettier/eslint
- [x] Type checking has been performed via 'yarn check-types'

## Additional Notes
<!-- 
Add images and/or screen caps to illustrate what was changed if this pull request adds to or modifies existing user-visible appearance/output. 
-->