### PR TITLE
Allow four ways to set location of keycloak server.

### DIFF
--- a/src/context/auth/keycloak.ts
+++ b/src/context/auth/keycloak.ts
@@ -6,23 +6,43 @@ export default async function (): Promise<KcAdminClient> {
 
   const kcAdminClient = new KcAdminClient();
 
-  const authContext = "/auth";
-  const keycloakAuthUrl = window.location.origin + authContext;
-  const devMode = !window.location.pathname.startsWith("/adminv2");
   try {
     await kcAdminClient.init(
       { onLoad: "check-sso", pkceMethod: "S256" },
       {
-        url: devMode ? "http://localhost:8180/auth" : keycloakAuthUrl,
+        url: keycloakAuthUrl(),
         realm: realm,
         clientId: "security-admin-console-v2",
       }
     );
     kcAdminClient.setConfig({ realmName: realm });
-    kcAdminClient.baseUrl = authContext;
+    kcAdminClient.baseUrl = keycloakAuthUrl();
   } catch (error) {
     alert("failed to initialize keycloak");
   }
 
   return kcAdminClient;
 }
+
+const keycloakAuthUrl = () => {
+  // Eventually, authContext should not be hard-coded.
+  // You are allowed to change this context on your keycloak server,
+  // but it is rarely done.
+  const authContext = "/auth";
+
+  const searchParams = new URLSearchParams(window.location.search);
+
+  // passed in as query param
+  const authUrlFromParam = searchParams.get("keycloak-server");
+  if (authUrlFromParam) return authUrlFromParam + authContext;
+
+  // dev mode
+  if (!window.location.pathname.startsWith("/adminv2"))
+    return "http://localhost:8180" + authContext;
+
+  // demo mode
+  if (searchParams.get("demo")) return "http://localhost:8080" + authContext;
+
+  // admin console served from keycloak server
+  return window.location.origin + authContext;
+};

--- a/src/context/auth/keycloak.ts
+++ b/src/context/auth/keycloak.ts
@@ -16,7 +16,10 @@ export default async function (): Promise<KcAdminClient> {
       }
     );
     kcAdminClient.setConfig({ realmName: realm });
-    kcAdminClient.baseUrl = keycloakAuthUrl();
+
+    // we can get rid of devMode once developers upgrade to Keycloak 13
+    const devMode = !window.location.pathname.startsWith("/adminv2");
+    kcAdminClient.baseUrl = devMode ? "/auth" : keycloakAuthUrl();
   } catch (error) {
     alert("failed to initialize keycloak");
   }


### PR DESCRIPTION
## Motivation
Need to be able to run new admin console from keycloak.org.

## Brief Description
Four ways to set location of Keycloak server:

1. http://anydomain/anycontext/?keyclaok-server=http://my-keycloak-server.com
2. Usual dev mode, which defaults server to http://localhost:8180
3. Demo mode, http://anydomain/adminv2/?demo=true, which defaults server to http://localhost:8080
4. Integrated into keycloak server, http://keycloak-server-domain/adminv2

## Verification Steps
Try out any or all of the modes above.

## Checklist:

- [X] Code has been tested locally by PR requester
- [NA] User-visible strings are using the react-i18next framework (useTranslation)
- [NA] Help has been implemented
- [NA] axe report has been run and resulting a11y issues have been resolved
- [NA] Unit tests have been created/updated
- [X] Formatting has been performed via prettier/eslint
- [X] Type checking has been performed via 'yarn check-types'