### PR TITLE
Users(groups): set leave buttons  only on groups with direct membership

### DIFF
--- a/src/user/UserGroups.tsx
+++ b/src/user/UserGroups.tsx
@@ -32,6 +32,9 @@ export const UserGroups = () => {
   const [username, setUsername] = useState("");
 
   const [isDirectMembership, setDirectMembership] = useState(true);
+  const [directMembershipList, setDirectMembershipList] = useState<
+    GroupRepresentation[]
+  >([]);
   const [open, setOpen] = useState(false);
 
   const adminClient = useAdminClient();
@@ -137,6 +140,7 @@ export const UserGroups = () => {
       (value) => !topLevelGroups.includes(value)
     );
 
+    setDirectMembershipList(directMembership);
     const filterDupesfromGroups = allPaths.filter(
       (thing, index, self) =>
         index === self.findIndex((t) => t.name === thing.name)
@@ -167,16 +171,6 @@ export const UserGroups = () => {
 
   const AliasRenderer = (group: GroupRepresentation) => {
     return <>{group.name}</>;
-  };
-
-  const LeaveButtonRenderer = (group: GroupRepresentation) => {
-    return (
-      <>
-        <Button onClick={() => leave(group)} variant="link">
-          {t("users:Leave")}
-        </Button>
-      </>
-    );
   };
 
   const toggleModal = () => setOpen(!open);
@@ -211,6 +205,23 @@ export const UserGroups = () => {
   const leave = (group: GroupRepresentation) => {
     setSelectedGroup(group);
     toggleDeleteDialog();
+  };
+
+  const LeaveButtonRenderer = (group: GroupRepresentation) => {
+    if (
+      directMembershipList.some((item) => item.id === group.id) ||
+      directMembershipList.length === 0
+    ) {
+      return (
+        <>
+          <Button onClick={() => leave(group)} variant="link">
+            {t("users:Leave")}
+          </Button>
+        </>
+      );
+    } else {
+      return <> </>;
+    }
   };
 
   return (
@@ -258,6 +269,7 @@ export const UserGroups = () => {
               cellFormatters: [emptyFormatter()],
               transforms: [cellWidth(45)],
             },
+
             {
               name: "",
               cellRenderer: LeaveButtonRenderer,


### PR DESCRIPTION
## Motivation
<!-- Add references to relevant tickets, issues, design specs and/or a short description of what motivated you to do it. -->

Towards #496 

## Brief Description
<!-- Add a short answer for: 
What was done in this PR? (e.g Fix to prevent users from accessing feature X.)
Why it was done? (e.g Feature X was deprecated.)
-->

Set "Leave" button only on "direct membership" groups

## Verification Steps
<!--
Add the steps required to verify this change. Keep in mind that these steps should be written so groups unfamiliar with the 
new functionality can follow them, such as QE or documentation.

1. Go to Users -> Groups
2. Direct membership is checked by default - all the inital groups listed should have a "Leave" button
3. Uncheck "Direct membership". Now only the groups that were previously listed under the "Direct membership" check should be the groups with a "Leave" button rendered beside them. A user should not be able to leave the other groups. 
-->

## Checklist:

- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [x] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated
- [x] Formatting has been performed via prettier/eslint
- [x] Type checking has been performed via 'yarn check-types'

## Additional Notes
<!-- 
Add images and/or screen caps to illustrate what was changed if this pull request adds to or modifies existing user-visible appearance/output. 
-->
