### PR TITLE
Users(Consents): add empty state and list consents

### DIFF
--- a/cypress/integration/users_test.spec.ts
+++ b/cypress/integration/users_test.spec.ts
@@ -126,8 +126,19 @@ describe("Users test", () => {
       cy.getId("modalConfirm").click();
     });
 
-    it("Delete user", function () {
+    it("Go to user consents test", function () {
+      cy.wait(1000);
       listingPage.searchItem(itemId).itemExist(itemId);
+
+      cy.wait(1000);
+      listingPage.goToItemDetails(itemId);
+
+      cy.getId("user-consents-tab").click();
+
+      cy.getId("empty-state").contains("No consents");
+    });
+
+    it("Delete user test", function () {
       // Delete
       cy.wait(1000);
       listingPage.deleteItem(itemId);

--- a/src/client-scopes/messages.json
+++ b/src/client-scopes/messages.json
@@ -2,6 +2,7 @@
   "client-scopes": {
     "createClientScope": "Create client scope",
     "clientScopeList": "Client scopes",
+    "grantedClientScopes": "Granted client scopes",
     "clientScopeDetails": "Client scope details",
     "clientScopeExplain": "Client scopes allow you to define a common set of protocol mappers and roles, which are shared between multiple clients",
     "searchFor": "Search for client scope",

--- a/src/clients/ClientsSection.tsx
+++ b/src/clients/ClientsSection.tsx
@@ -99,6 +99,7 @@ export const ClientsSection = () => {
             <DeleteConfirm />
             <KeycloakDataTable
               key={key}
+              emptyState={<> </>}
               loader={loader}
               isPaginated
               ariaLabelKey="clients:clientList"

--- a/src/clients/messages.json
+++ b/src/clients/messages.json
@@ -83,6 +83,8 @@
     "tokenDeleteSuccess": "initial access token created successfully",
     "tokenDeleteError": "Could not delete initial access token: '{{error}}'",
     "timestamp": "Created date",
+    "created": "Created",
+    "lastUpdated": "Last updated",
     "expires": "Expires",
     "count": "Count",
     "remainingCount": "Remaining count",

--- a/src/components/list-empty-state/ListEmptyState.tsx
+++ b/src/components/list-empty-state/ListEmptyState.tsx
@@ -8,6 +8,7 @@ import {
   ButtonVariant,
   EmptyStateSecondaryActions,
 } from "@patternfly/react-core";
+import { SVGIconProps } from "@patternfly/react-icons/dist/js/createIcon";
 import { PlusCircleIcon } from "@patternfly/react-icons";
 import { SearchIcon } from "@patternfly/react-icons";
 
@@ -23,6 +24,7 @@ export type ListEmptyStateProps = {
   primaryActionText?: string;
   onPrimaryAction?: MouseEventHandler<HTMLButtonElement>;
   hasIcon?: boolean;
+  icon?: React.ComponentClass<SVGIconProps>;
   isSearchVariant?: boolean;
   secondaryActions?: Action[];
 };
@@ -35,6 +37,7 @@ export const ListEmptyState = ({
   isSearchVariant,
   primaryActionText,
   secondaryActions,
+  icon,
 }: ListEmptyStateProps) => {
   return (
     <>
@@ -42,7 +45,7 @@ export const ListEmptyState = ({
         {hasIcon && isSearchVariant ? (
           <EmptyStateIcon icon={SearchIcon} />
         ) : (
-          hasIcon && <EmptyStateIcon icon={PlusCircleIcon} />
+          hasIcon && <EmptyStateIcon icon={icon ? icon : PlusCircleIcon} />
         )}
         <Title headingLevel="h4" size="lg">
           {message}

--- a/src/components/table-toolbar/KeycloakDataTable.tsx
+++ b/src/components/table-toolbar/KeycloakDataTable.tsx
@@ -18,6 +18,7 @@ import _ from "lodash";
 import { PaginatingTableToolbar } from "./PaginatingTableToolbar";
 import { asyncStateFetch } from "../../context/auth/AdminClient";
 import { ListEmptyState } from "../list-empty-state/ListEmptyState";
+import { SVGIconProps } from "@patternfly/react-icons/dist/js/createIcon";
 
 type Row<T> = {
   data: T;
@@ -98,6 +99,7 @@ export type DataListProps<T> = {
   searchTypeComponent?: ReactNode;
   toolbarItem?: ReactNode;
   emptyState?: ReactNode;
+  icon?: React.ComponentClass<SVGIconProps>;
 };
 
 /**
@@ -136,6 +138,7 @@ export function KeycloakDataTable<T>({
   searchTypeComponent,
   toolbarItem,
   emptyState,
+  icon,
   ...props
 }: DataListProps<T>) {
   const { t } = useTranslation();
@@ -330,6 +333,7 @@ export function KeycloakDataTable<T>({
             searchPlaceholderKey && (
               <ListEmptyState
                 hasIcon={true}
+                icon={icon}
                 isSearchVariant={true}
                 message={t("noSearchResults")}
                 instructions={t("noSearchResultsInstructions")}

--- a/src/user/UserConsents.tsx
+++ b/src/user/UserConsents.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+import { useParams } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { Button, PageSection } from "@patternfly/react-core";
+import { ListEmptyState } from "../components/list-empty-state/ListEmptyState";
+import { KeycloakDataTable } from "../components/table-toolbar/KeycloakDataTable";
+import { emptyFormatter } from "../util";
+import { useAdminClient } from "../context/auth/AdminClient";
+import { cellWidth } from "@patternfly/react-table";
+import _ from "lodash";
+import UserConsentRepresentation from "keycloak-admin/lib/defs/userConsentRepresentation";
+import { CubesIcon } from "@patternfly/react-icons";
+
+export const UserConsents = () => {
+  const { t } = useTranslation("roles");
+
+  const adminClient = useAdminClient();
+  const { id } = useParams<{ id: string }>();
+  const alphabetize = (consentsList: UserConsentRepresentation[]) => {
+    return _.sortBy(consentsList, (client) => client.clientId?.toUpperCase());
+  };
+
+  const loader = async () => {
+    const consents = await adminClient.users.listConsents({ id });
+
+    return alphabetize(consents);
+  };
+
+  return (
+    <>
+      <PageSection variant="light">
+        <KeycloakDataTable
+          loader={loader}
+          ariaLabelKey="roles:roleList"
+          columns={[
+            {
+              name: "client",
+              displayKey: "clients:Client",
+              cellFormatters: [emptyFormatter()],
+              transforms: [cellWidth(20)],
+            },
+            {
+              name: "grantedClientScopes",
+              displayKey: "client-scopes:grantedClientScopes",
+              cellFormatters: [emptyFormatter()],
+              transforms: [cellWidth(30)],
+            },
+
+            {
+              name: "createDate",
+              displayKey: "clients:created",
+              cellFormatters: [emptyFormatter()],
+              transforms: [cellWidth(20)],
+            },
+            {
+              name: "lastUpdatedDate",
+              displayKey: "clients:lastUpdated",
+              cellFormatters: [emptyFormatter()],
+              transforms: [cellWidth(20)],
+            },
+          ]}
+          emptyState={
+            <ListEmptyState
+              hasIcon={true}
+              icon={CubesIcon}
+              message={t("users:noConsents")}
+              instructions={
+                <div>
+                  {" "}
+                  {t("users:noConsentsText")}{" "}
+                  <Button
+                    variant="link"
+                    className="kc-settings-link-empty-state"
+                  >
+                    {t("common:settings") + "."}
+                  </Button>
+                </div>
+              }
+              onPrimaryAction={() => {}}
+            />
+          }
+        />
+      </PageSection>
+    </>
+  );
+};

--- a/src/user/UserConsents.tsx
+++ b/src/user/UserConsents.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import { Button, PageSection } from "@patternfly/react-core";
+import { PageSection } from "@patternfly/react-core";
 import { ListEmptyState } from "../components/list-empty-state/ListEmptyState";
 import { KeycloakDataTable } from "../components/table-toolbar/KeycloakDataTable";
 import { emptyFormatter } from "../util";
@@ -10,6 +10,7 @@ import { cellWidth } from "@patternfly/react-table";
 import _ from "lodash";
 import UserConsentRepresentation from "keycloak-admin/lib/defs/userConsentRepresentation";
 import { CubesIcon } from "@patternfly/react-icons";
+import moment from "moment";
 
 export const UserConsents = () => {
   const { t } = useTranslation("roles");
@@ -26,6 +27,22 @@ export const UserConsents = () => {
     return alphabetize(consents);
   };
 
+  const clientScopesRenderer = ({
+    grantedClientScopes,
+  }: UserConsentRepresentation) => {
+    return <>{grantedClientScopes!.join(", ")}</>;
+  };
+
+  const createdRenderer = ({ createDate }: UserConsentRepresentation) => {
+    return <>{moment(createDate).format("MM/DD/YY hh:MM A")}</>;
+  };
+
+  const lastUpdatedRenderer = ({
+    lastUpdatedDate,
+  }: UserConsentRepresentation) => {
+    return <>{moment(lastUpdatedDate).format("MM/DD/YY hh:MM A")}</>;
+  };
+
   return (
     <>
       <PageSection variant="light">
@@ -34,7 +51,7 @@ export const UserConsents = () => {
           ariaLabelKey="roles:roleList"
           columns={[
             {
-              name: "client",
+              name: "clientId",
               displayKey: "clients:Client",
               cellFormatters: [emptyFormatter()],
               transforms: [cellWidth(20)],
@@ -43,19 +60,21 @@ export const UserConsents = () => {
               name: "grantedClientScopes",
               displayKey: "client-scopes:grantedClientScopes",
               cellFormatters: [emptyFormatter()],
+              cellRenderer: clientScopesRenderer,
               transforms: [cellWidth(30)],
             },
-
             {
-              name: "createDate",
+              name: "createdDate",
               displayKey: "clients:created",
               cellFormatters: [emptyFormatter()],
+              cellRenderer: createdRenderer,
               transforms: [cellWidth(20)],
             },
             {
               name: "lastUpdatedDate",
               displayKey: "clients:lastUpdated",
               cellFormatters: [emptyFormatter()],
+              cellRenderer: lastUpdatedRenderer,
               transforms: [cellWidth(20)],
             },
           ]}
@@ -64,18 +83,7 @@ export const UserConsents = () => {
               hasIcon={true}
               icon={CubesIcon}
               message={t("users:noConsents")}
-              instructions={
-                <div>
-                  {" "}
-                  {t("users:noConsentsText")}{" "}
-                  <Button
-                    variant="link"
-                    className="kc-settings-link-empty-state"
-                  >
-                    {t("common:settings") + "."}
-                  </Button>
-                </div>
-              }
+              instructions={t("users:noConsentsText")}
               onPrimaryAction={() => {}}
             />
           }

--- a/src/user/UsersTabs.tsx
+++ b/src/user/UsersTabs.tsx
@@ -17,7 +17,6 @@ import { useHistory, useParams, useRouteMatch } from "react-router-dom";
 import { KeycloakTabs } from "../components/keycloak-tabs/KeycloakTabs";
 import { UserGroups } from "./UserGroups";
 import { UserConsents } from "./UserConsents";
-import UserConsentRepresentation from "keycloak-admin/lib/defs/userConsentRepresentation";
 
 export const UsersTabs = () => {
   const { t } = useTranslation("roles");
@@ -27,9 +26,6 @@ export const UsersTabs = () => {
 
   const adminClient = useAdminClient();
   const userForm = useForm<UserRepresentation>({ mode: "onChange" });
-  const userConsentsForm = useForm<UserConsentRepresentation>({
-    mode: "onChange",
-  });
   const { id } = useParams<{ id: string }>();
   const [user, setUser] = useState("");
 
@@ -88,7 +84,7 @@ export const UsersTabs = () => {
               data-testid="user-consents-tab"
               title={<TabTitleText>{t("users:consents")}</TabTitleText>}
             >
-              <UserConsents form={userConsentsForm} />
+              <UserConsents />
             </Tab>
           </KeycloakTabs>
         )}

--- a/src/user/UsersTabs.tsx
+++ b/src/user/UsersTabs.tsx
@@ -16,6 +16,8 @@ import { useAdminClient } from "../context/auth/AdminClient";
 import { useHistory, useParams, useRouteMatch } from "react-router-dom";
 import { KeycloakTabs } from "../components/keycloak-tabs/KeycloakTabs";
 import { UserGroups } from "./UserGroups";
+import { UserConsents } from "./UserConsents";
+import UserConsentRepresentation from "keycloak-admin/lib/defs/userConsentRepresentation";
 
 export const UsersTabs = () => {
   const { t } = useTranslation("roles");
@@ -24,7 +26,10 @@ export const UsersTabs = () => {
   const history = useHistory();
 
   const adminClient = useAdminClient();
-  const form = useForm<UserRepresentation>({ mode: "onChange" });
+  const userForm = useForm<UserRepresentation>({ mode: "onChange" });
+  const userConsentsForm = useForm<UserConsentRepresentation>({
+    mode: "onChange",
+  });
   const { id } = useParams<{ id: string }>();
   const [user, setUser] = useState("");
 
@@ -69,7 +74,7 @@ export const UsersTabs = () => {
               data-testid="user-details-tab"
               title={<TabTitleText>{t("details")}</TabTitleText>}
             >
-              <UserForm form={form} save={save} editMode={true} />
+              <UserForm form={userForm} save={save} editMode={true} />
             </Tab>
             <Tab
               eventKey="groups"
@@ -78,9 +83,16 @@ export const UsersTabs = () => {
             >
               <UserGroups />
             </Tab>
+            <Tab
+              eventKey="consents"
+              data-testid="user-consents-tab"
+              title={<TabTitleText>{t("users:consents")}</TabTitleText>}
+            >
+              <UserConsents form={userConsentsForm} />
+            </Tab>
           </KeycloakTabs>
         )}
-        {!id && <UserForm form={form} save={save} editMode={false} />}
+        {!id && <UserForm form={userForm} save={save} editMode={false} />}
       </PageSection>
     </>
   );

--- a/src/user/messages.json
+++ b/src/user/messages.json
@@ -52,7 +52,11 @@
     "updatePassword": "Update Password",
     "updateProfile": "Update Profile",
     "verifyEmail": "Verify Email",
-    "updateUserLocale": "Update User Locale"
+    "updateUserLocale": "Update User Locale",
+    "consents": "Consents",
+    "noConsents": "No consents",
+    "noConsentsText": "The consents will only be recorded when users try to access a client that is configured to require consent. In that case, users will get a consent page which asks them to grant access to the client. To enable this function, you can turn on the \"Consent Required\" switch in"
+
 
   }
 }

--- a/src/user/messages.json
+++ b/src/user/messages.json
@@ -55,7 +55,7 @@
     "updateUserLocale": "Update User Locale",
     "consents": "Consents",
     "noConsents": "No consents",
-    "noConsentsText": "The consents will only be recorded when users try to access a client that is configured to require consent. In that case, users will get a consent page which asks them to grant access to the client. To enable this function, you can turn on the \"Consent Required\" switch in"
+    "noConsentsText": "The consents will only be recorded when users try to access a client that is configured to require consent. In that case, users will get a consent page which asks them to grant access to the client."
 
 
   }

--- a/src/user/user-section.css
+++ b/src/user/user-section.css
@@ -6,11 +6,3 @@ button.pf-c-button.pf-m-primary.kc-join-group-button {
   margin-left: var(--pf-global--spacer--md);
   margin-right: var(--pf-global--spacer--xl);
 }
-
-button.pf-c-button.pf-m-link.kc-settings-link-empty-state {
-  padding-left: var(--pf-global--spacer--xs);
-  padding-right: var(--pf-global--spacer--xs);
-  padding-top: 0px;
-}
-
-

--- a/src/user/user-section.css
+++ b/src/user/user-section.css
@@ -6,3 +6,11 @@ button.pf-c-button.pf-m-primary.kc-join-group-button {
   margin-left: var(--pf-global--spacer--md);
   margin-right: var(--pf-global--spacer--xl);
 }
+
+button.pf-c-button.pf-m-link.kc-settings-link-empty-state {
+  padding-left: var(--pf-global--spacer--xs);
+  padding-right: var(--pf-global--spacer--xs);
+  padding-top: 0px;
+}
+
+


### PR DESCRIPTION
## Motivation
<!-- Add references to relevant tickets, issues, design specs and/or a short description of what motivated you to do it. -->
JIRA: closes https://issues.redhat.com/browse/APPDUX-919
Github: Closes #517 + #526 

## Verification Steps
<!--
Add the steps required to verify this change. Keep in mind that these steps should be written so groups unfamiliar with the 
new functionality can follow them, such as QE or documentation. -->

1. Go to Users section
2. Create a new user
3. Click on "Consents" tab
4. Verify empty state matches the mock at https://marvelapp.com/prototype/f734jga/screen/73531547


## Checklist:

- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [x] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [x] Unit tests have been created/updated
- [x] Formatting has been performed via prettier/eslint
- [x] Type checking has been performed via 'yarn check-types'

## Additional Notes
<!-- 
Add images and/or screen caps to illustrate what was changed if this pull request adds to or modifies existing user-visible appearance/output. 
-->
