### PR TITLE
Fix missing borders around Select components

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -18,6 +18,13 @@ label.pf-c-form__label {
   align-items: end;
 }
 
+.pf-c-select__toggle:before {
+  border-top: var(--pf-c-select__toggle--before--BorderTopWidth) solid var(--pf-c-select__toggle--before--BorderTopColor);
+  border-right: var(--pf-c-select__toggle--before--BorderRightWidth) solid var(--pf-c-select__toggle--before--BorderRightColor);
+  border-bottom: var(--pf-c-select__toggle--before--BorderBottomWidth) solid var(--pf-c-select__toggle--before--BorderBottomColor);
+  border-left: var(--pf-c-select__toggle--before--BorderLeftWidth) solid var(--pf-c-select__toggle--before--BorderLeftColor);
+}
+
 .keycloak__form_actions {
   position: fixed;
   bottom: 0px;


### PR DESCRIPTION
## Motivation
Fixes https://github.com/keycloak/keycloak-admin-ui/issues/527.

## Brief Description
When we upgraded Patternfly two releases ago, borders were no longer appearing around Select components. After some due diligence, turns out that PF is using valid CSS but one of our dependencies (postCSS) is not interpreting it correctly. See the issue above for a full explanation and a screen cap of the issue.

Best solution in this case, and recommended by PF team, is to just override the border style to get the borders back.

## Verification Steps
Open any place in the new admin UI and verify that borders now appear around the Select components.

## Checklist:
- [x] Code has been tested locally by PR requester
- [ ] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [x] Unit tests have been created/updated
- [x] Formatting has been performed via prettier/eslint
- [x] Type checking has been performed via 'yarn check-types'

## Additional Notes
**Before:**
![missing-border](https://user-images.githubusercontent.com/39063664/114600265-249e1500-9c62-11eb-9780-b928ac11c7c7.png)

**After:**
![fixed-border](https://user-images.githubusercontent.com/39063664/114600289-2a93f600-9c62-11eb-9201-41e6938d296d.png)


