### PR TITLE
Users(groups): Adds help text for direct membership

### DIFF
--- a/src/user/UserGroups.tsx
+++ b/src/user/UserGroups.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import {
@@ -7,6 +7,7 @@ import {
   ButtonVariant,
   Checkbox,
   PageSection,
+  Popover,
 } from "@patternfly/react-core";
 import { ListEmptyState } from "../components/list-empty-state/ListEmptyState";
 import { KeycloakDataTable } from "../components/table-toolbar/KeycloakDataTable";
@@ -20,6 +21,8 @@ import { useErrorHandler } from "react-error-boundary";
 import _ from "lodash";
 import UserRepresentation from "keycloak-admin/lib/defs/userRepresentation";
 import { JoinGroupDialog } from "./JoinGroupDialog";
+import { HelpContext } from "../components/help-enabler/HelpHeader";
+import { QuestionCircleIcon } from "@patternfly/react-icons";
 
 type GroupTableData = GroupRepresentation & {
   membersLength?: number;
@@ -54,6 +57,8 @@ export const UserGroups = () => {
     GroupRepresentation[]
   >([]);
   const [open, setOpen] = useState(false);
+
+  const { enabled } = useContext(HelpContext);
 
   const adminClient = useAdminClient();
   const { id } = useParams<{ id: string }>();
@@ -325,6 +330,22 @@ export const UserGroups = () => {
                 onChange={() => setDirectMembership(!isDirectMembership)}
                 isChecked={isDirectMembership}
               />
+              {enabled && (
+                <Popover
+                  aria-label="Basic popover"
+                  position="bottom"
+                  bodyContent={<div>{t("users:whoWillAppearPopoverText")}</div>}
+                >
+                  <Button
+                    variant="link"
+                    className="kc-who-will-appear-button"
+                    key="who-will-appear-button"
+                    icon={<QuestionCircleIcon />}
+                  >
+                    {t("users:whoWillAppearLinkText")}
+                  </Button>
+                </Popover>
+              )}
             </>
           }
           columns={[

--- a/src/user/messages.json
+++ b/src/user/messages.json
@@ -58,6 +58,8 @@
     "updateUserLocale": "Update User Locale",
     "consents": "Consents",
     "noConsents": "No consents",
-    "noConsentsText": "The consents will only be recorded when users try to access a client that is configured to require consent. In that case, users will get a consent page which asks them to grant access to the client."
+    "noConsentsText": "The consents will only be recorded when users try to access a client that is configured to require consent. In that case, users will get a consent page which asks them to grant access to the client.",
+    "whoWillAppearLinkText": "Who will appear in this group list?",
+    "whoWillAppearPopoverText": "Groups are hierarchical. When you select Direct Membership, you see only the child group that the user joined. Ancestor groups are not included."
   }
 }


### PR DESCRIPTION
## Motivation
<!-- Add references to relevant tickets, issues, design specs and/or a short description of what motivated you to do it. -->
Closes #458 

## Brief Description
<!-- Add a short answer for: 
What was done in this PR? (e.g Fix to prevent users from accessing feature X.)
Why it was done? (e.g Feature X was deprecated.)
-->
Adds popover with help text as agreed upon in Keycloak UI meeting.

## Verification Steps
<!--
Add the steps required to verify this change. Keep in mind that these steps should be written so groups unfamiliar with the 
new functionality can follow them, such as QE or documentation. -->

1. Go to Users -> Groups tab
2. Make sure help mode is enabled.
3. Click "Who will appear in this groups list" button.

## Checklist:

- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [x] Help has been implemented
- [x] axe report has been run and resulting a11y issues have been resolved
- [x] Unit tests have been created/updated
- [x] Formatting has been performed via prettier/eslint
- [x] Type checking has been performed via 'yarn check-types'
