### PR TITLE
Cypress tests for initial 8 LDAP mappers

### DIFF
--- a/cypress/integration/user_fed_ldap_mapper_test.spec.ts
+++ b/cypress/integration/user_fed_ldap_mapper_test.spec.ts
@@ -1,0 +1,302 @@
+import LoginPage from "../support/pages/LoginPage";
+import SidebarPage from "../support/pages/admin_console/SidebarPage";
+import ListingPage from "../support/pages/admin_console/ListingPage";
+import GroupModal from "../support/pages/admin_console/manage/groups/GroupModal";
+import ProviderPage from "../support/pages/admin_console/manage/providers/ProviderPage";
+import Masthead from "../support/pages/admin_console/Masthead";
+import ModalUtils from "../support/util/ModalUtils";
+import { keycloakBefore } from "../support/util/keycloak_before";
+
+const loginPage = new LoginPage();
+const masthead = new Masthead();
+const sidebarPage = new SidebarPage();
+const listingPage = new ListingPage();
+const groupModal = new GroupModal();
+
+const providersPage = new ProviderPage();
+const modalUtils = new ModalUtils();
+
+const provider = "ldap";
+const allCapProvider = provider.toUpperCase();
+
+const ldapName = "ldap-mappers-testing";
+const ldapVendor = "Active Directory";
+
+const connectionUrl = "ldap://";
+const firstBindType = "simple";
+const firstBindDn = "user-1";
+const firstBindCreds = "password1";
+
+const firstUsersDn = "user-dn-1";
+const firstUserLdapAtt = "uid";
+const firstRdnLdapAtt = "uid";
+const firstUuidLdapAtt = "entryUUID";
+const firstUserObjClasses = "inetOrgPerson, organizationalPerson";
+
+const addProviderMenu = "Add new provider";
+const providerCreatedSuccess = "User federation provider successfully created";
+const mapperCreatedSuccess = "Mapping successfully created";
+const providerDeleteSuccess = "The user federation provider has been deleted.";
+const providerDeleteTitle = "Delete user federation provider?";
+// const savedSuccessMessage = "User federation provider successfully saved";
+const mapperDeletedSuccess = "Mapping successfully deleted";
+const mapperDeleteTitle = "Delete mapping?";
+// const disableModalTitle = "Disable user federation provider?";
+
+const groupName = "my-mappers-group";
+
+// mapperType variables
+const msadUserAcctMapper = "msad-user-account-control-mapper";
+const msadLdsUserAcctMapper = "msad-lds-user-account-control-mapper";
+const userAttLdapMapper = "user-attribute-ldap-mapper";
+const hcAttMapper = "hardcoded-attribute-mapper";
+const certLdapMapper = "certificate-ldap-mapper";
+const fullNameLdapMapper = "full-name-ldap-mapper";
+const hcLdapGroupMapper = "hardcoded-ldap-group-mapper";
+const hcLdapAttMapper = "hardcoded-ldap-attribute-mapper";
+// const groupLdapMapper = "group-ldap-mapper";
+// const roleMapper = "role-ldap-mapper";
+// const hcLdapRoleMapper = "hardcoded-ldap-role-mapper";
+
+const creationDateMapper = "creation date";
+const emailMapper = "email";
+const lastNameMapper = "last name";
+const modifyDateMapper = "modify date";
+const usernameMapper = "username";
+const firstNameMapper = "first name";
+
+
+
+
+
+describe("User Fed LDAP mapper tests", () => {
+  beforeEach(() => {
+    keycloakBefore();
+    loginPage.logIn();
+    sidebarPage.goToUserFederation();
+  });
+
+  it("Create LDAP provider from empty state", () => {
+    // if tests don't start at empty state, e.g. user has providers configured locally,
+    // create a new card from the card view instead
+    cy.get("body").then(($body) => {
+      if ($body.find(`[data-testid=ldap-card]`).length > 0) {
+        providersPage.clickNewCard(provider);
+      } else {
+        providersPage.clickMenuCommand(addProviderMenu, allCapProvider);
+      }
+    });
+    providersPage.fillLdapRequiredGeneralData(ldapName, ldapVendor);
+    providersPage.fillLdapRequiredConnectionData(
+      connectionUrl,
+      firstBindType,
+      firstBindDn,
+      firstBindCreds
+    );
+    providersPage.fillLdapRequiredSearchingData(
+      firstUsersDn,
+      firstUserLdapAtt,
+      firstRdnLdapAtt,
+      firstUuidLdapAtt,
+      firstUserObjClasses
+    );
+
+    providersPage.save(provider);
+
+    masthead.checkNotificationMessage(providerCreatedSuccess);
+    sidebarPage.goToUserFederation();
+  });
+
+  // create a new group
+  it("Create group", () => {
+    sidebarPage.goToGroups();
+    groupModal
+      .open("empty-primary-action")
+      .fillGroupForm(groupName)
+      .clickCreate();
+
+    masthead.checkNotificationMessage("Group created");
+  });
+
+  // delete default mappers
+  it("Delete default mappers", () => {
+    providersPage.clickExistingCard(ldapName);
+    providersPage.goToMappers();
+
+    listingPage.itemExist(creationDateMapper).deleteItem(creationDateMapper);
+    modalUtils.checkModalTitle(mapperDeleteTitle).confirmModal();
+    masthead.checkNotificationMessage(mapperDeletedSuccess);
+    listingPage.itemExist(creationDateMapper, false);
+  
+    listingPage.itemExist(emailMapper).deleteItem(emailMapper);
+    modalUtils.checkModalTitle(mapperDeleteTitle).confirmModal();
+    masthead.checkNotificationMessage(mapperDeletedSuccess);
+    listingPage.itemExist(emailMapper, false);
+
+    listingPage.itemExist(lastNameMapper).deleteItem(lastNameMapper);
+    modalUtils.checkModalTitle(mapperDeleteTitle).confirmModal();
+    masthead.checkNotificationMessage(mapperDeletedSuccess);
+    listingPage.itemExist(lastNameMapper, false);
+
+    listingPage.itemExist(modifyDateMapper).deleteItem(modifyDateMapper);
+    modalUtils.checkModalTitle(mapperDeleteTitle).confirmModal();
+    masthead.checkNotificationMessage(mapperDeletedSuccess);
+    listingPage.itemExist(modifyDateMapper, false);
+
+    listingPage.itemExist(usernameMapper).deleteItem(usernameMapper);
+    modalUtils.checkModalTitle(mapperDeleteTitle).confirmModal();
+    masthead.checkNotificationMessage(mapperDeletedSuccess);
+    listingPage.itemExist(usernameMapper, false);
+
+    listingPage.itemExist(firstNameMapper).deleteItem(firstNameMapper);
+    modalUtils.checkModalTitle(mapperDeleteTitle).confirmModal();
+    masthead.checkNotificationMessage(mapperDeletedSuccess);
+    listingPage.itemExist(firstNameMapper, false);
+
+    // listingPage.itemExist(msadLdsUserAcctMapper).deleteItem(msadLdsUserAcctMapper);
+    // modalUtils.checkModalTitle(mapperDeleteTitle).confirmModal();
+    // masthead.checkNotificationMessage(mapperDeletedSuccess);
+    // listingPage.itemExist(msadLdsUserAcctMapper, false);
+  });
+
+  // create one of every kind (8) mappers
+  it("Create user account control mapper", () => {
+    providersPage.clickExistingCard(ldapName);
+    providersPage.goToMappers();
+
+    providersPage.createNewMapper(msadUserAcctMapper);
+    providersPage.save("ldap-mapper");
+
+    masthead.checkNotificationMessage(mapperCreatedSuccess);
+    listingPage.itemExist(msadUserAcctMapper, true);
+  });
+
+  it("Create msad lds user account control mapper", () => {
+    providersPage.clickExistingCard(ldapName);
+    providersPage.goToMappers();
+
+    providersPage.createNewMapper(msadLdsUserAcctMapper);
+    providersPage.save("ldap-mapper");
+
+    masthead.checkNotificationMessage(mapperCreatedSuccess);
+    listingPage.itemExist(msadLdsUserAcctMapper, true);
+  });
+
+  it("Create user attribute ldap mapper", () => {
+    providersPage.clickExistingCard(ldapName);
+    providersPage.goToMappers();
+
+    providersPage.createNewMapper(userAttLdapMapper);
+    providersPage.save("ldap-mapper");
+
+    masthead.checkNotificationMessage(mapperCreatedSuccess);
+    listingPage.itemExist(userAttLdapMapper, true);
+  });
+
+  it("Create hardcoded attribute mapper", () => {
+    providersPage.clickExistingCard(ldapName);
+    providersPage.goToMappers();
+
+    providersPage.createNewMapper(hcAttMapper);
+    providersPage.save("ldap-mapper");
+
+    masthead.checkNotificationMessage(mapperCreatedSuccess);
+    listingPage.itemExist(hcAttMapper, true);
+  });
+
+  it("Create certificate ldap mapper", () => {
+    providersPage.clickExistingCard(ldapName);
+    providersPage.goToMappers();
+
+    providersPage.createNewMapper(certLdapMapper);
+    providersPage.save("ldap-mapper");
+
+    masthead.checkNotificationMessage(mapperCreatedSuccess);
+    listingPage.itemExist(certLdapMapper, true);
+  });
+
+  it("Create full name ldap mapper", () => {
+    providersPage.clickExistingCard(ldapName);
+    providersPage.goToMappers();
+
+    providersPage.createNewMapper(fullNameLdapMapper);
+    providersPage.save("ldap-mapper");
+
+    masthead.checkNotificationMessage(mapperCreatedSuccess);
+    listingPage.itemExist(fullNameLdapMapper, true);
+  });
+
+  it("Create hardcoded ldap group mapper", () => {
+    providersPage.clickExistingCard(ldapName);
+    providersPage.goToMappers();
+
+    providersPage.createNewMapper(hcLdapGroupMapper);
+    providersPage.save("ldap-mapper");
+
+    masthead.checkNotificationMessage(mapperCreatedSuccess);
+    listingPage.itemExist(hcLdapGroupMapper, true);
+  });
+
+  it("Create hardcoded ldap attribute mapper", () => {
+    providersPage.clickExistingCard(ldapName);
+    providersPage.goToMappers();
+
+    providersPage.createNewMapper(hcLdapAttMapper);
+    providersPage.save("ldap-mapper");
+
+    masthead.checkNotificationMessage(mapperCreatedSuccess);
+    listingPage.itemExist(hcLdapAttMapper, true);
+  });
+
+    // update and cancel mapper
+    it("Update and cancel mapper", () => {
+    //   providersPage.clickExistingCard(ldapName);
+    //   providersPage.goToMappers();
+  
+    //   listingPage.clickRowDetails();
+  
+    //   providersPage.createNewMapper();
+    //   providersPage.save("ldap-mapper");
+  
+    //   masthead.checkNotificationMessage(mapperCreatedSuccess);
+    //   listingPage.itemExist(, true);
+    });
+  
+    // update and save mapper
+    it("Update and save mapper", () => {
+    //   providersPage.clickExistingCard(ldapName);
+    //   providersPage.goToMappers();
+  
+  
+    //   providersPage.createNewMapper();
+    //   providersPage.save("ldap-mapper");
+  
+    //   masthead.checkNotificationMessage(mapperCreatedSuccess);
+    //   listingPage.itemExist(, true);
+    });
+  
+    // delete mapper
+    it("Delete mapper", () => {
+      providersPage.clickExistingCard(ldapName);
+      providersPage.goToMappers();
+  
+      listingPage.deleteItem(msadLdsUserAcctMapper);
+      modalUtils.checkModalTitle(mapperDeleteTitle).confirmModal();
+      masthead.checkNotificationMessage(mapperDeletedSuccess);
+      listingPage.itemExist(msadLdsUserAcctMapper, false);
+    });
+
+  // *** test cleanup ***
+  it("Cleanup - delete group", () => {
+    sidebarPage.goToGroups();
+    listingPage.deleteItem(groupName);
+    masthead.checkNotificationMessage("Group deleted");
+  });
+
+  it("Cleanup - delete LDAP provider", () => {
+    providersPage.deleteCardFromMenu(provider, ldapName);
+    modalUtils.checkModalTitle(providerDeleteTitle).confirmModal();
+    masthead.checkNotificationMessage(providerDeleteSuccess);
+  });
+
+});

--- a/cypress/integration/user_fed_ldap_mapper_test.spec.ts
+++ b/cypress/integration/user_fed_ldap_mapper_test.spec.ts
@@ -36,12 +36,11 @@ const firstUserObjClasses = "inetOrgPerson, organizationalPerson";
 const addProviderMenu = "Add new provider";
 const providerCreatedSuccess = "User federation provider successfully created";
 const mapperCreatedSuccess = "Mapping successfully created";
+const mapperUpdatedSuccess = "Mapping successfully updated";
 const providerDeleteSuccess = "The user federation provider has been deleted.";
 const providerDeleteTitle = "Delete user federation provider?";
-// const savedSuccessMessage = "User federation provider successfully saved";
 const mapperDeletedSuccess = "Mapping successfully deleted";
 const mapperDeleteTitle = "Delete mapping?";
-// const disableModalTitle = "Disable user federation provider?";
 
 const groupName = "my-mappers-group";
 
@@ -64,10 +63,7 @@ const lastNameMapper = "last name";
 const modifyDateMapper = "modify date";
 const usernameMapper = "username";
 const firstNameMapper = "first name";
-
-
-
-
+const MsadAccountControlsMapper = "MSAD account controls";
 
 describe("User Fed LDAP mapper tests", () => {
   beforeEach(() => {
@@ -127,7 +123,7 @@ describe("User Fed LDAP mapper tests", () => {
     modalUtils.checkModalTitle(mapperDeleteTitle).confirmModal();
     masthead.checkNotificationMessage(mapperDeletedSuccess);
     listingPage.itemExist(creationDateMapper, false);
-  
+
     listingPage.itemExist(emailMapper).deleteItem(emailMapper);
     modalUtils.checkModalTitle(mapperDeleteTitle).confirmModal();
     masthead.checkNotificationMessage(mapperDeletedSuccess);
@@ -153,20 +149,51 @@ describe("User Fed LDAP mapper tests", () => {
     masthead.checkNotificationMessage(mapperDeletedSuccess);
     listingPage.itemExist(firstNameMapper, false);
 
-    // listingPage.itemExist(msadLdsUserAcctMapper).deleteItem(msadLdsUserAcctMapper);
-    // modalUtils.checkModalTitle(mapperDeleteTitle).confirmModal();
-    // masthead.checkNotificationMessage(mapperDeletedSuccess);
-    // listingPage.itemExist(msadLdsUserAcctMapper, false);
+    listingPage
+      .itemExist(MsadAccountControlsMapper)
+      .deleteItem(MsadAccountControlsMapper);
+    modalUtils.checkModalTitle(mapperDeleteTitle).confirmModal();
+    masthead.checkNotificationMessage(mapperDeletedSuccess);
   });
 
-  // create one of every kind (8) mappers
-  it("Create user account control mapper", () => {
+  // create mapper
+  it("Create certificate ldap mapper", () => {
+    providersPage.clickExistingCard(ldapName);
+    providersPage.goToMappers();
+    providersPage.createNewMapper(certLdapMapper);
+    providersPage.save("ldap-mapper");
+    masthead.checkNotificationMessage(mapperCreatedSuccess);
+    listingPage.itemExist(certLdapMapper, true);
+  });
+
+  // update mapper
+  it("Update certificate ldap mapper", () => {
     providersPage.clickExistingCard(ldapName);
     providersPage.goToMappers();
 
+    listingPage.goToItemDetails(`${certLdapMapper}-test`);
+    providersPage.updateMapper(certLdapMapper);
+
+    providersPage.save("ldap-mapper");
+    masthead.checkNotificationMessage(mapperUpdatedSuccess);
+  });
+
+  // delete mapper
+  it("Delete certificate ldap mapper", () => {
+    providersPage.clickExistingCard(ldapName);
+    providersPage.goToMappers();
+
+    listingPage.deleteItem(`${certLdapMapper}-test`);
+    modalUtils.checkModalTitle(mapperDeleteTitle).confirmModal();
+    masthead.checkNotificationMessage(mapperDeletedSuccess);
+  });
+
+  // create one of every kind of non-group/role mapper (8)
+  it("Create user account control mapper", () => {
+    providersPage.clickExistingCard(ldapName);
+    providersPage.goToMappers();
     providersPage.createNewMapper(msadUserAcctMapper);
     providersPage.save("ldap-mapper");
-
     masthead.checkNotificationMessage(mapperCreatedSuccess);
     listingPage.itemExist(msadUserAcctMapper, true);
   });
@@ -174,21 +201,26 @@ describe("User Fed LDAP mapper tests", () => {
   it("Create msad lds user account control mapper", () => {
     providersPage.clickExistingCard(ldapName);
     providersPage.goToMappers();
-
     providersPage.createNewMapper(msadLdsUserAcctMapper);
     providersPage.save("ldap-mapper");
-
     masthead.checkNotificationMessage(mapperCreatedSuccess);
     listingPage.itemExist(msadLdsUserAcctMapper, true);
+  });
+
+  it("Create certificate ldap mapper", () => {
+    providersPage.clickExistingCard(ldapName);
+    providersPage.goToMappers();
+    providersPage.createNewMapper(certLdapMapper);
+    providersPage.save("ldap-mapper");
+    masthead.checkNotificationMessage(mapperCreatedSuccess);
+    listingPage.itemExist(certLdapMapper, true);
   });
 
   it("Create user attribute ldap mapper", () => {
     providersPage.clickExistingCard(ldapName);
     providersPage.goToMappers();
-
     providersPage.createNewMapper(userAttLdapMapper);
     providersPage.save("ldap-mapper");
-
     masthead.checkNotificationMessage(mapperCreatedSuccess);
     listingPage.itemExist(userAttLdapMapper, true);
   });
@@ -196,32 +228,17 @@ describe("User Fed LDAP mapper tests", () => {
   it("Create hardcoded attribute mapper", () => {
     providersPage.clickExistingCard(ldapName);
     providersPage.goToMappers();
-
     providersPage.createNewMapper(hcAttMapper);
     providersPage.save("ldap-mapper");
-
     masthead.checkNotificationMessage(mapperCreatedSuccess);
     listingPage.itemExist(hcAttMapper, true);
-  });
-
-  it("Create certificate ldap mapper", () => {
-    providersPage.clickExistingCard(ldapName);
-    providersPage.goToMappers();
-
-    providersPage.createNewMapper(certLdapMapper);
-    providersPage.save("ldap-mapper");
-
-    masthead.checkNotificationMessage(mapperCreatedSuccess);
-    listingPage.itemExist(certLdapMapper, true);
   });
 
   it("Create full name ldap mapper", () => {
     providersPage.clickExistingCard(ldapName);
     providersPage.goToMappers();
-
     providersPage.createNewMapper(fullNameLdapMapper);
     providersPage.save("ldap-mapper");
-
     masthead.checkNotificationMessage(mapperCreatedSuccess);
     listingPage.itemExist(fullNameLdapMapper, true);
   });
@@ -229,10 +246,8 @@ describe("User Fed LDAP mapper tests", () => {
   it("Create hardcoded ldap group mapper", () => {
     providersPage.clickExistingCard(ldapName);
     providersPage.goToMappers();
-
     providersPage.createNewMapper(hcLdapGroupMapper);
     providersPage.save("ldap-mapper");
-
     masthead.checkNotificationMessage(mapperCreatedSuccess);
     listingPage.itemExist(hcLdapGroupMapper, true);
   });
@@ -240,51 +255,11 @@ describe("User Fed LDAP mapper tests", () => {
   it("Create hardcoded ldap attribute mapper", () => {
     providersPage.clickExistingCard(ldapName);
     providersPage.goToMappers();
-
     providersPage.createNewMapper(hcLdapAttMapper);
     providersPage.save("ldap-mapper");
-
     masthead.checkNotificationMessage(mapperCreatedSuccess);
     listingPage.itemExist(hcLdapAttMapper, true);
   });
-
-    // update and cancel mapper
-    it("Update and cancel mapper", () => {
-    //   providersPage.clickExistingCard(ldapName);
-    //   providersPage.goToMappers();
-  
-    //   listingPage.clickRowDetails();
-  
-    //   providersPage.createNewMapper();
-    //   providersPage.save("ldap-mapper");
-  
-    //   masthead.checkNotificationMessage(mapperCreatedSuccess);
-    //   listingPage.itemExist(, true);
-    });
-  
-    // update and save mapper
-    it("Update and save mapper", () => {
-    //   providersPage.clickExistingCard(ldapName);
-    //   providersPage.goToMappers();
-  
-  
-    //   providersPage.createNewMapper();
-    //   providersPage.save("ldap-mapper");
-  
-    //   masthead.checkNotificationMessage(mapperCreatedSuccess);
-    //   listingPage.itemExist(, true);
-    });
-  
-    // delete mapper
-    it("Delete mapper", () => {
-      providersPage.clickExistingCard(ldapName);
-      providersPage.goToMappers();
-  
-      listingPage.deleteItem(msadLdsUserAcctMapper);
-      modalUtils.checkModalTitle(mapperDeleteTitle).confirmModal();
-      masthead.checkNotificationMessage(mapperDeletedSuccess);
-      listingPage.itemExist(msadLdsUserAcctMapper, false);
-    });
 
   // *** test cleanup ***
   it("Cleanup - delete group", () => {
@@ -298,5 +273,4 @@ describe("User Fed LDAP mapper tests", () => {
     modalUtils.checkModalTitle(providerDeleteTitle).confirmModal();
     masthead.checkNotificationMessage(providerDeleteSuccess);
   });
-
 });

--- a/cypress/support/pages/admin_console/manage/providers/ProviderPage.ts
+++ b/cypress/support/pages/admin_console/manage/providers/ProviderPage.ts
@@ -29,6 +29,29 @@ export default class ProviderPage {
   cachePolicyInput: string;
   cachePolicyList: string;
 
+  userModelAttInput: string;
+  ldapAttInput: string;
+  userModelAttNameInput: string;
+  attValueInput: string;
+  ldapFullNameAttInput: string;
+  ldapAttNameInput: string;
+  ldapAttValueInput: string;
+  groupInput: string;
+
+  msadUserAcctMapper: string;
+  msadLdsUserAcctMapper: string;
+  userAttLdapMapper: string;
+  hcAttMapper: string;
+  certLdapMapper: string;
+  fullNameLdapMapper: string;
+  hcLdapAttMapper: string;
+  hcLdapGroupMapper: string;
+  // roleMapper: string;
+  // groupLdapMapper: string;
+  // hcLdapRoleMapper string;
+
+  groupName: string;
+
   constructor() {
     // KerberosSettingsRequired required input values
     this.kerberosNameInput = "data-testid=kerberos-name";
@@ -64,6 +87,33 @@ export default class ProviderPage {
     this.cacheMinuteList = "#kc-eviction-minute + ul";
     this.cachePolicyInput = "#kc-cache-policy";
     this.cachePolicyList = "#kc-cache-policy + ul";
+
+    // Mapper required input values
+    this.userModelAttInput = "data-testid=mapper-userModelAttribute-fld";
+    this.ldapAttInput = "data-testid=mapper-ldapAttribute-fld";
+    this.userModelAttNameInput =
+      "data-testid=mapper-userModelAttributeName-fld";
+    this.attValueInput = "data-testid=mapper-attributeValue-fld";
+    this.ldapFullNameAttInput = "data-testid=mapper-fullNameAttribute-fld";
+    this.ldapAttNameInput = "data-testid=mapper-ldapAttributeName-fld";
+    this.ldapAttValueInput = "data-testid=mapper-ldapAttributeValue-fld";
+    this.groupInput = "data-testid=mapper-group-fld";
+
+    // mapper types
+    this.msadUserAcctMapper = "msad-user-account-control-mapper";
+    this.msadLdsUserAcctMapper = "msad-lds-user-account-control-mapper";
+    this.userAttLdapMapper = "user-attribute-ldap-mapper";
+    this.hcAttMapper = "hardcoded-attribute-mapper";
+    this.certLdapMapper = "certificate-ldap-mapper";
+    this.fullNameLdapMapper = "full-name-ldap-mapper";
+    this.hcLdapAttMapper = "hardcoded-ldap-attribute-mapper";
+    this.hcLdapGroupMapper = "hardcoded-ldap-group-mapper";
+    // this.groupLdapMapper = "group-ldap-mapper";
+    // this.roleMapper = "role-ldap-mapper";
+    // this.hcLdapRoleMapper = "hardcoded-ldap-role-mapper";
+
+    this.groupName = "my-mappers-group";
+
   }
 
   changeCacheTime(unit: string, time: string) {
@@ -99,7 +149,7 @@ export default class ProviderPage {
     cy.get(`[data-testid="delete-${providerType}-cmd"]`).click();
     return this;
   }
-  
+
   fillKerberosRequiredData(
     name: string,
     realm: string,
@@ -183,6 +233,63 @@ export default class ProviderPage {
     cy.get(this.cachePolicyInput).click();
     cy.get(this.cachePolicyList).contains(cacheType).click();
     return this;
+  }
+
+  goToMappers() {
+    // click Mappers tab
+    cy.get(`[data-testid="ldap-mappers-tab"]`).click();
+  }
+
+  createNewMapper(mapperType: string) {
+    const userModelAttValue = "firstName";
+    const ldapAttValue = "cn";
+
+    // click Add Mapper
+    cy.get(`[data-testid="add-mapper-btn"]`).click();
+    cy.wait(1000);
+
+    // click mapper type select drop-down
+    cy.get("#kc-providerId").click();
+
+    // click specific mapper in the list
+    cy.get("#kc-providerId + ul").contains(mapperType).click();
+
+    // enter a name in the Name field
+    cy.get(`[data-testid="ldap-mapper-name"]`).type(`${mapperType}-test`);
+
+    switch (mapperType) {
+      case this.msadUserAcctMapper:
+      case this.msadLdsUserAcctMapper:
+        break;
+      case this.userAttLdapMapper:
+      case this.certLdapMapper:
+        cy.get(`[${this.userModelAttInput}]`).type(userModelAttValue);
+        cy.get(`[${this.ldapAttInput}]`).type(ldapAttValue);
+        break;
+      case this.hcAttMapper:
+        cy.get(`[${this.userModelAttNameInput}]`).type(userModelAttValue);
+        cy.get(`[${this.attValueInput}]`).type(ldapAttValue);
+        break;
+      case this.fullNameLdapMapper:
+        cy.get(`[${this.ldapFullNameAttInput}]`).type(ldapAttValue);
+        break;
+      case this.hcLdapAttMapper:
+        cy.get(`[${this.ldapAttNameInput}]`).type(userModelAttValue);
+        cy.get(`[${this.ldapAttValueInput}]`).type(ldapAttValue);
+        break;
+      case this.hcLdapGroupMapper:
+        cy.get(`[${this.groupInput}]`).type(this.groupName);
+        break;
+      // case this.groupLdapMapper:
+      //   break;
+      // case this.roleMapper:
+      //   break;
+      // case this.hcLdapRoleMapper:
+      //   break;
+      default:
+        console.log("Invalid mapper type.");
+        break;
+    }
   }
 
   clickExistingCard(cardName: string) {

--- a/cypress/support/pages/admin_console/manage/providers/ProviderPage.ts
+++ b/cypress/support/pages/admin_console/manage/providers/ProviderPage.ts
@@ -113,7 +113,6 @@ export default class ProviderPage {
     // this.hcLdapRoleMapper = "hardcoded-ldap-role-mapper";
 
     this.groupName = "my-mappers-group";
-
   }
 
   changeCacheTime(unit: string, time: string) {
@@ -236,7 +235,6 @@ export default class ProviderPage {
   }
 
   goToMappers() {
-    // click Mappers tab
     cy.get(`[data-testid="ldap-mappers-tab"]`).click();
   }
 
@@ -244,17 +242,12 @@ export default class ProviderPage {
     const userModelAttValue = "firstName";
     const ldapAttValue = "cn";
 
-    // click Add Mapper
     cy.get(`[data-testid="add-mapper-btn"]`).click();
     cy.wait(1000);
 
-    // click mapper type select drop-down
     cy.get("#kc-providerId").click();
-
-    // click specific mapper in the list
     cy.get("#kc-providerId + ul").contains(mapperType).click();
 
-    // enter a name in the Name field
     cy.get(`[data-testid="ldap-mapper-name"]`).type(`${mapperType}-test`);
 
     switch (mapperType) {
@@ -288,6 +281,51 @@ export default class ProviderPage {
       //   break;
       default:
         console.log("Invalid mapper type.");
+        break;
+    }
+  }
+
+  updateMapper(mapperType: string) {
+    const userModelAttValue = "lastName";
+    const ldapAttValue = "sn";
+
+    switch (mapperType) {
+      case this.msadUserAcctMapper:
+      case this.msadLdsUserAcctMapper:
+        break;
+      case this.userAttLdapMapper:
+      case this.certLdapMapper:
+        cy.get(`[${this.userModelAttInput}]`).clear();
+        cy.get(`[${this.userModelAttInput}]`).type(userModelAttValue);
+        cy.get(`[${this.ldapAttInput}]`).clear();
+        cy.get(`[${this.ldapAttInput}]`).type(ldapAttValue);
+        break;
+      case this.hcAttMapper:
+        cy.get(`[${this.userModelAttNameInput}]`).clear();
+        cy.get(`[${this.userModelAttNameInput}]`).type(userModelAttValue);
+        cy.get(`[${this.attValueInput}]`).clear();
+        cy.get(`[${this.attValueInput}]`).type(ldapAttValue);
+        break;
+      case this.fullNameLdapMapper:
+        cy.get(`[${this.ldapFullNameAttInput}]`).clear();
+        cy.get(`[${this.ldapFullNameAttInput}]`).type(ldapAttValue);
+        break;
+      case this.hcLdapAttMapper:
+        cy.get(`[${this.ldapAttNameInput}]`).clear();
+        cy.get(`[${this.ldapAttNameInput}]`).type(userModelAttValue);
+        cy.get(`[${this.ldapAttValueInput}]`).clear;
+        cy.get(`[${this.ldapAttValueInput}]`).type(ldapAttValue);
+        break;
+      // case this.hcLdapGroupMapper:
+      //   break;
+      // case this.groupLdapMapper:
+      //   break;
+      // case this.roleMapper:
+      //   break;
+      // case this.hcLdapRoleMapper:
+      //   break;
+      default:
+        console.log("Invalid mapper name.");
         break;
     }
   }

--- a/src/user-federation/UserFederationLdapSettings.tsx
+++ b/src/user-federation/UserFederationLdapSettings.tsx
@@ -325,6 +325,7 @@ export const UserFederationLdapSettings = () => {
               id="mappers"
               eventKey="mappers"
               title={<TabTitleText>{t("common:mappers")}</TabTitleText>}
+              data-testid="ldap-mappers-tab"
             >
               <LdapMapperList />
             </Tab>

--- a/src/user-federation/ldap/mappers/LdapMapperDetails.tsx
+++ b/src/user-federation/ldap/mappers/LdapMapperDetails.tsx
@@ -165,7 +165,7 @@ export const LdapMapperDetails = () => {
               defaultValue={isNew ? id : mapping ? mapping.parentId : ""}
               type="text"
               id="kc-ldap-parentId"
-              data-testid="ldap-parentId"
+              data-testid="ldap-mapper-parentId"
               name="parentId"
               ref={form.register}
             />
@@ -174,7 +174,7 @@ export const LdapMapperDetails = () => {
               defaultValue="org.keycloak.storage.ldap.mappers.LDAPStorageMapper"
               type="text"
               id="kc-ldap-provider-type"
-              data-testid="ldap-provider-type"
+              data-testid="ldap-mapper-provider-type"
               name="providerType"
               ref={form.register}
             />
@@ -197,7 +197,7 @@ export const LdapMapperDetails = () => {
                 isRequired
                 type="text"
                 id="kc-ldap-mapper-type"
-                data-testid="ldap-mapper-type"
+                data-testid="ldap-mapper-type-fld"
                 name="providerId"
                 ref={form.register}
               />
@@ -219,6 +219,7 @@ export const LdapMapperDetails = () => {
                 name="providerId"
                 defaultValue=" "
                 control={form.control}
+                data-testid="ldap-mapper-type-select"
                 render={({ onChange, value }) => (
                   <Select
                     toggleId="kc-providerId"
@@ -366,7 +367,7 @@ export const LdapMapperDetails = () => {
               isDisabled={!form.formState.isDirty}
               variant="primary"
               type="submit"
-              data-testid="ldap-save"
+              data-testid="ldap-mapper-save"
             >
               {t("common:save")}
             </Button>
@@ -381,7 +382,7 @@ export const LdapMapperDetails = () => {
                       }/mappers`
                     )
               }
-              data-testid="ldap-cancel"
+              data-testid="ldap-mapper-cancel"
             >
               {t("common:cancel")}
             </Button>

--- a/src/user-federation/ldap/mappers/LdapMapperFullNameAttribute.tsx
+++ b/src/user-federation/ldap/mappers/LdapMapperFullNameAttribute.tsx
@@ -32,7 +32,7 @@ export const LdapMapperFullNameAttribute = ({
           isRequired
           type="text"
           id="kc-full-name-attribute"
-          data-testid="full-name-attribute"
+          data-testid="mapper-fullNameAttribute-fld"
           name="config.ldap-full-name-attribute[0]"
           ref={form.register}
         />

--- a/src/user-federation/ldap/mappers/LdapMapperHardcodedAttribute.tsx
+++ b/src/user-federation/ldap/mappers/LdapMapperHardcodedAttribute.tsx
@@ -32,7 +32,7 @@ export const LdapMapperHardcodedAttribute = ({
           isRequired
           type="text"
           id="kc-user-model-attribute"
-          data-testid="user-model-attribute"
+          data-testid="mapper-userModelAttributeName-fld"
           name="config.user-model-attribute[0]"
           ref={form.register}
         />
@@ -53,7 +53,7 @@ export const LdapMapperHardcodedAttribute = ({
           isRequired
           type="text"
           id="kc-attribute-value"
-          data-testid="attribute-value"
+          data-testid="mapper-attributeValue-fld"
           name="config.attribute-value[0]"
           ref={form.register}
         />

--- a/src/user-federation/ldap/mappers/LdapMapperHardcodedLdapAttribute.tsx
+++ b/src/user-federation/ldap/mappers/LdapMapperHardcodedLdapAttribute.tsx
@@ -32,7 +32,7 @@ export const LdapMapperHardcodedLdapAttribute = ({
           isRequired
           type="text"
           id="kc-ldap-attribute-name"
-          data-testid="ldap-attribute-name"
+          data-testid="mapper-ldapAttributeName-fld"
           name="config.ldap-attribute-name[0]"
           ref={form.register}
         />
@@ -53,7 +53,7 @@ export const LdapMapperHardcodedLdapAttribute = ({
           isRequired
           type="text"
           id="kc-ldap-attribute-value"
-          data-testid="ldap-attribute-value"
+          data-testid="mapper-ldapAttributeValue-fld"
           name="config.ldap-attribute-value[0]"
           ref={form.register}
         />

--- a/src/user-federation/ldap/mappers/LdapMapperHardcodedLdapGroup.tsx
+++ b/src/user-federation/ldap/mappers/LdapMapperHardcodedLdapGroup.tsx
@@ -32,7 +32,7 @@ export const LdapMapperHardcodedLdapGroup = ({
           isRequired
           type="text"
           id="kc-group"
-          data-testid="group"
+          data-testid="mapper-group-fld"
           name="config.group[0]"
           ref={form.register}
         />

--- a/src/user-federation/ldap/mappers/LdapMapperList.tsx
+++ b/src/user-federation/ldap/mappers/LdapMapperList.tsx
@@ -96,7 +96,7 @@ export const LdapMapperList = () => {
         toolbarItem={
           <ToolbarItem>
             <Button
-              data-testid="createMapperBtn"
+              data-testid="add-mapper-btn"
               variant="primary"
               onClick={() => history.push(`${url}/new`)}
             >

--- a/src/user-federation/ldap/mappers/LdapMapperUserAttribute.tsx
+++ b/src/user-federation/ldap/mappers/LdapMapperUserAttribute.tsx
@@ -34,7 +34,7 @@ export const LdapMapperUserAttribute = ({
           isRequired
           type="text"
           id="kc-user-model-attribute"
-          data-testid="user-model-attribute"
+          data-testid="mapper-userModelAttribute-fld"
           name="config.user-model-attribute[0]"
           ref={form.register}
         />
@@ -55,7 +55,7 @@ export const LdapMapperUserAttribute = ({
           isRequired
           type="text"
           id="kc-ldap-attribute"
-          data-testid="ldap-attribute"
+          data-testid="mapper-ldapAttribute-fld"
           name="config.ldap-attribute[0]"
           ref={form.register}
         />


### PR DESCRIPTION
## Motivation
https://issues.redhat.com/browse/APPDUX-867

## Brief Description
Adds cypress CRUD tests for the existing 8 implemented LDAP mapper types:

- msad-user-account-control-mapper
- msad-lds-user-account-control-mapper
- user-attribute-ldap-mapper
- hardcoded-attribute-mapper
- certificate-ldap-mapper
- full-name-ldap-mapper
- hardcoded-ldap-group-mapper
- hardcoded-ldap-attribute-mapper

## Verification Steps
Run the new user_fed_ldap_mapper_test cypress test and verify that all tests complete without failing.
