### PR TITLE
Show hand cursor when hovering over User Fed empty state cards

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -19,10 +19,14 @@ label.pf-c-form__label {
 }
 
 .pf-c-select__toggle:before {
-  border-top: var(--pf-c-select__toggle--before--BorderTopWidth) solid var(--pf-c-select__toggle--before--BorderTopColor);
-  border-right: var(--pf-c-select__toggle--before--BorderRightWidth) solid var(--pf-c-select__toggle--before--BorderRightColor);
-  border-bottom: var(--pf-c-select__toggle--before--BorderBottomWidth) solid var(--pf-c-select__toggle--before--BorderBottomColor);
-  border-left: var(--pf-c-select__toggle--before--BorderLeftWidth) solid var(--pf-c-select__toggle--before--BorderLeftColor);
+  border-top: var(--pf-c-select__toggle--before--BorderTopWidth) solid
+    var(--pf-c-select__toggle--before--BorderTopColor);
+  border-right: var(--pf-c-select__toggle--before--BorderRightWidth) solid
+    var(--pf-c-select__toggle--before--BorderRightColor);
+  border-bottom: var(--pf-c-select__toggle--before--BorderBottomWidth) solid
+    var(--pf-c-select__toggle--before--BorderBottomColor);
+  border-left: var(--pf-c-select__toggle--before--BorderLeftWidth) solid
+    var(--pf-c-select__toggle--before--BorderLeftColor);
 }
 
 .keycloak__form_actions {
@@ -35,4 +39,8 @@ label.pf-c-form__label {
   width: 100%;
   border-top: 1px solid var(--pf-global--BorderColor--100);
   margin-left: calc(-1 * var(--pf-global--spacer--lg));
+}
+
+.keycloak-empty-state-card:hover {
+  cursor: pointer;
 }

--- a/src/identity-providers/IdentityProvidersSection.tsx
+++ b/src/identity-providers/IdentityProvidersSection.tsx
@@ -171,6 +171,7 @@ export const IdentityProvidersSection = () => {
                   {_.sortBy(identityProviders[group], "name").map(
                     (provider) => (
                       <Card
+                        className="keycloak-empty-state-card"
                         key={provider.id}
                         isHoverable
                         data-testid={`${provider.id}-card`}

--- a/src/user-federation/UserFederationSection.tsx
+++ b/src/user-federation/UserFederationSection.tsx
@@ -177,6 +177,7 @@ export const UserFederationSection = () => {
             <hr className="pf-u-mb-lg" />
             <Gallery hasGutter>
               <Card
+                className="keycloak-empty-state-card"
                 isHoverable
                 onClick={() => history.push(`${url}/kerberos/new`)}
                 data-testid="kerberos-card"
@@ -191,6 +192,7 @@ export const UserFederationSection = () => {
                 </CardTitle>
               </Card>
               <Card
+                className="keycloak-empty-state-card"
                 isHoverable
                 onClick={() => history.push(`${url}/ldap/new`)}
                 data-testid="ldap-card"

--- a/src/user-federation/ldap/LdapSettingsGeneral.tsx
+++ b/src/user-federation/ldap/LdapSettingsGeneral.tsx
@@ -83,6 +83,7 @@ export const LdapSettingsGeneral = ({
             type="text"
             id="kc-console-display-name"
             name="name"
+            defaultValue="ldap"
             ref={form.register({
               required: {
                 value: true,

--- a/src/user-federation/user-federation.css
+++ b/src/user-federation/user-federation.css
@@ -9,7 +9,3 @@
 .error {
   color: red;
 }
-
-.keycloak-empty-state-card:hover {
-  cursor: pointer;
-}

--- a/src/user-federation/user-federation.css
+++ b/src/user-federation/user-federation.css
@@ -9,3 +9,7 @@
 .error {
   color: red;
 }
+
+.keycloak-empty-state-card:hover {
+  cursor: pointer;
+}


### PR DESCRIPTION
## Motivation
Partially fixes https://github.com/keycloak/keycloak-admin-ui/issues/436.

## Brief Description
Adds a hand cursor icon when hovering over the User federation empty state cards. Also adds a default value of 'ldap' to the console name field when creating a new LDAP provider.

## Verification Steps
1. Go to User Federation.
2. If there are existing LDAP/Kerberos providers configured, delete them from the card view.
3. Verify that the cursor changes to a hand icon when hovering over either of the cards in empty state view.
4. Click the LDAP card and verify that the default console name is listed as 'ldap'.

## Checklist:
- [x] Code has been tested locally by PR requester
- [ ] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated
- [x] Formatting has been performed via prettier/eslint
- [x] Type checking has been performed via 'yarn check-types'

## Additional Notes
None