### PR TITLE
Update LDAP provider default values based on vendor type

### DIFF
--- a/src/user-federation/ldap/LdapSettingsGeneral.tsx
+++ b/src/user-federation/ldap/LdapSettingsGeneral.tsx
@@ -31,6 +31,58 @@ export const LdapSettingsGeneral = ({
 
   const [isVendorDropdownOpen, setIsVendorDropdownOpen] = useState(false);
 
+  const setVendorDefaultValues = () => {
+    switch (form.getValues("config.vendor[0]")) {
+      case "ad":
+        form.setValue("config.usernameLDAPAttribute[0]", "cn");
+        form.setValue("config.rdnLDAPAttribute[0]", "cn");
+        form.setValue("config.uuidLDAPAttribute[0]", "objectGUID");
+        form.setValue(
+          "config.userObjectClasses[0]",
+          "person, organizationalPerson, user"
+        );
+        break;
+      case "rhds":
+        form.setValue("config.usernameLDAPAttribute[0]", "uid");
+        form.setValue("config.rdnLDAPAttribute[0]", "uid");
+        form.setValue("config.uuidLDAPAttribute[0]", "nsuniqueid");
+        form.setValue(
+          "config.userObjectClasses[0]",
+          "inetOrgPerson, organizationalPerson"
+        );
+        break;
+      case "tivoli":
+        form.setValue("config.usernameLDAPAttribute[0]", "uid");
+        form.setValue("config.rdnLDAPAttribute[0]", "uid");
+        form.setValue("config.uuidLDAPAttribute[0]", "uniqueidentifier");
+        form.setValue(
+          "config.userObjectClasses[0]",
+          "inetOrgPerson, organizationalPerson"
+        );
+        break;
+      case "edirectory":
+        form.setValue("config.usernameLDAPAttribute[0]", "uid");
+        form.setValue("config.rdnLDAPAttribute[0]", "uid");
+        form.setValue("config.uuidLDAPAttribute[0]", "guid");
+        form.setValue(
+          "config.userObjectClasses[0]",
+          "inetOrgPerson, organizationalPerson"
+        );
+        break;
+      case "other":
+        form.setValue("config.usernameLDAPAttribute[0]", "uid");
+        form.setValue("config.rdnLDAPAttribute[0]", "uid");
+        form.setValue("config.uuidLDAPAttribute[0]", "entryUUID");
+        form.setValue(
+          "config.userObjectClasses[0]",
+          "inetOrgPerson, organizationalPerson"
+        );
+        break;
+      default:
+        return "";
+    }
+  };
+
   return (
     <>
       {showSectionHeading && (
@@ -110,7 +162,7 @@ export const LdapSettingsGeneral = ({
         >
           <Controller
             name="config.vendor[0]"
-            defaultValue=""
+            defaultValue="ad"
             control={form.control}
             render={({ onChange, value }) => (
               <Select
@@ -121,10 +173,10 @@ export const LdapSettingsGeneral = ({
                 onSelect={(_, value) => {
                   onChange(value as string);
                   setIsVendorDropdownOpen(false);
+                  setVendorDefaultValues();
                 }}
                 selections={value}
                 variant={SelectVariant.single}
-                // data-testid="ldap-vendor"
               >
                 <SelectOption key={0} value="ad" isPlaceholder>
                   Active Directory

--- a/src/user-federation/ldap/LdapSettingsSearching.tsx
+++ b/src/user-federation/ldap/LdapSettingsSearching.tsx
@@ -96,6 +96,7 @@ export const LdapSettingsSearching = ({
           <TextInput
             isRequired
             type="text"
+            defaultValue=""
             id="kc-console-users-dn"
             data-testid="ldap-users-dn"
             name="config.usersDn[0]"
@@ -129,6 +130,7 @@ export const LdapSettingsSearching = ({
           <TextInput
             isRequired
             type="text"
+            defaultValue="cn"
             id="kc-username-ldap-attribute"
             data-testid="ldap-username-attribute"
             name="config.usernameLDAPAttribute[0]"
@@ -162,6 +164,7 @@ export const LdapSettingsSearching = ({
           <TextInput
             isRequired
             type="text"
+            defaultValue="cn"
             id="kc-rdn-ldap-attribute"
             data-testid="ldap-rdn-attribute"
             name="config.rdnLDAPAttribute[0]"
@@ -195,6 +198,7 @@ export const LdapSettingsSearching = ({
           <TextInput
             isRequired
             type="text"
+            defaultValue="objectGUID"
             id="kc-uuid-ldap-attribute"
             data-testid="ldap-uuid-attribute"
             name="config.uuidLDAPAttribute[0]"
@@ -228,6 +232,7 @@ export const LdapSettingsSearching = ({
           <TextInput
             isRequired
             type="text"
+            defaultValue="person, organizationalPerson, user"
             id="kc-user-object-classes"
             data-testid="ldap-user-object-classes"
             name="config.userObjectClasses[0]"


### PR DESCRIPTION
## Motivation
Partially fixes https://github.com/keycloak/keycloak-admin-ui/issues/436.

## Brief Description
When creating an LDAP user federation provider, if you change the Vendor type, the Username LDAP attribute, RDN LDAP attribute, UUID LDAP attribute, and User Object Classes fields should be populated with values specific to the 5 vendor types.

## Verification Steps
1. Go to User Fed and click the LDAP card to create a new LDAP user fed provider.
2. Verify that choosing the 5 vendor types will change the values of the above mentioned fields.

## Checklist:
- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [x] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [x] Unit tests have been created/updated
- [x] Formatting has been performed via prettier/eslint
- [x] Type checking has been performed via 'yarn check-types'

## Additional Notes
This issue is flagged as high priority for the user testing effort.