### PR TITLE
LDAP Providers - do not show DN and Credentials when bind type is none

### DIFF
--- a/cypress/integration/user_fed_ldap_test.spec.ts
+++ b/cypress/integration/user_fed_ldap_test.spec.ts
@@ -32,8 +32,6 @@ const secondLdapName = `${firstLdapName}-2`;
 const secondLdapVendor = "Other";
 
 const secondBindType = "none";
-const secondBindDn = "user-2";
-const secondBindCreds = "password2";
 
 const secondUsersDn = "user-dn-2";
 const secondUserLdapAtt = "cn";
@@ -165,8 +163,6 @@ describe("User Fed LDAP tests", () => {
     providersPage.fillLdapRequiredConnectionData(
       connectionUrl,
       secondBindType,
-      secondBindDn,
-      secondBindCreds
     );
     providersPage.fillLdapRequiredSearchingData(
       secondUsersDn,

--- a/cypress/support/pages/admin_console/manage/providers/ProviderPage.ts
+++ b/cypress/support/pages/admin_console/manage/providers/ProviderPage.ts
@@ -129,8 +129,8 @@ export default class ProviderPage {
   fillLdapRequiredConnectionData(
     connectionUrl: string,
     bindType: string,
-    bindDn: string,
-    bindCreds: string
+    bindDn?: string,
+    bindCreds?: string
   ) {
     if (connectionUrl) {
       cy.get(`[${this.ldapConnectionUrlInput}]`).type(connectionUrl);

--- a/src/user-federation/UserFederationLdapSettings.tsx
+++ b/src/user-federation/UserFederationLdapSettings.tsx
@@ -26,7 +26,7 @@ import ComponentRepresentation from "keycloak-admin/lib/defs/componentRepresenta
 
 import { Controller, useForm } from "react-hook-form";
 import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
-import { useAdminClient } from "../context/auth/AdminClient";
+import { asyncStateFetch, useAdminClient } from "../context/auth/AdminClient";
 import { useAlerts } from "../components/alert/Alerts";
 import { useTranslation } from "react-i18next";
 import { ViewHeader } from "../components/view-header/ViewHeader";
@@ -35,6 +35,7 @@ import { ScrollForm } from "../components/scroll-form/ScrollForm";
 
 import { KeycloakTabs } from "../components/keycloak-tabs/KeycloakTabs";
 import { LdapMapperList } from "./ldap/mappers/LdapMapperList";
+import { useErrorHandler } from "react-error-boundary";
 
 type LdapSettingsHeaderProps = {
   onChange: (value: string) => void;
@@ -171,29 +172,31 @@ export const UserFederationLdapSettings = () => {
   const history = useHistory();
   const adminClient = useAdminClient();
   const { realm } = useRealm();
+  const errorHandler = useErrorHandler();
 
   const { id } = useParams<{ id: string }>();
   const { addAlert } = useAlerts();
 
   useEffect(() => {
-    (async () => {
-      if (id) {
-        const fetchedComponent = await adminClient.components.findOne({ id });
-        if (fetchedComponent) {
-          setupForm(fetchedComponent);
-        }
-      }
-    })();
+    if (id) {
+      return asyncStateFetch(
+        () => adminClient.components.findOne({ id }),
+        (fetchedComponent) => {
+          if (fetchedComponent) {
+            setupForm(fetchedComponent);
+          }
+        },
+        errorHandler
+      );
+    }
   }, []);
 
   const setupForm = (component: ComponentRepresentation) => {
-    form.reset();
     Object.entries(component).map((entry) => {
       if (entry[0] === "config") {
         convertToFormValues(entry[1], "config", form.setValue);
-      } else {
-        form.setValue(entry[0], entry[1]);
       }
+      form.setValue(entry[0], entry[1]);
     });
   };
 
@@ -216,11 +219,10 @@ export const UserFederationLdapSettings = () => {
       } else {
         await adminClient.components.update({ id }, component);
       }
-      setupForm(component as ComponentRepresentation);
       addAlert(t(id ? "saveSuccess" : "createSuccess"), AlertVariant.success);
     } catch (error) {
       addAlert(
-        `${t(id ? "saveError" : "createError")} '${error}'`,
+        t(id ? "saveError" : "createError", { error }),
         AlertVariant.danger
       );
     }

--- a/src/user-federation/UserFederationLdapSettings.tsx
+++ b/src/user-federation/UserFederationLdapSettings.tsx
@@ -167,7 +167,7 @@ const LdapSettingsHeader = ({
 
 export const UserFederationLdapSettings = () => {
   const { t } = useTranslation("user-federation");
-  const form = useForm<ComponentRepresentation>();
+  const form = useForm<ComponentRepresentation>({ mode: "onChange" });
   const history = useHistory();
   const adminClient = useAdminClient();
   const { realm } = useRealm();

--- a/src/user-federation/UserFederationLdapSettings.tsx
+++ b/src/user-federation/UserFederationLdapSettings.tsx
@@ -194,6 +194,16 @@ export const UserFederationLdapSettings = () => {
   const setupForm = (component: ComponentRepresentation) => {
     Object.entries(component).map((entry) => {
       if (entry[0] === "config") {
+        form.setValue(
+          "config.periodicChangedUsersSync",
+          entry[1].changedSyncPeriod[0] !== "-1"
+        );
+
+        form.setValue(
+          "config.periodicFullSync",
+          entry[1].fullSyncPeriod[0] !== "-1"
+        );
+
         convertToFormValues(entry[1], "config", form.setValue);
       }
       form.setValue(entry[0], entry[1]);
@@ -212,6 +222,18 @@ export const UserFederationLdapSettings = () => {
   };
 
   const save = async (component: ComponentRepresentation) => {
+    if (component?.config?.periodicChangedUsersSync !== null) {
+      if (component?.config?.periodicChangedUsersSync === false) {
+        component.config.changedSyncPeriod = ["-1"];
+      }
+      delete component?.config?.periodicChangedUsersSync;
+    }
+    if (component?.config?.periodicFullSync !== null) {
+      if (component?.config?.periodicFullSync === false) {
+        component.config.fullSyncPeriod = ["-1"];
+      }
+      delete component?.config?.periodicFullSync;
+    }
     try {
       if (!id) {
         await adminClient.components.create(component);

--- a/src/user-federation/UserFederationLdapSettings.tsx
+++ b/src/user-federation/UserFederationLdapSettings.tsx
@@ -37,6 +37,13 @@ import { KeycloakTabs } from "../components/keycloak-tabs/KeycloakTabs";
 import { LdapMapperList } from "./ldap/mappers/LdapMapperList";
 import { useErrorHandler } from "react-error-boundary";
 
+type ldapComponentRepresentation = ComponentRepresentation & {
+  config?: {
+    periodicChangedUsersSync?: boolean;
+    periodicFullSync?: boolean;
+  };
+};
+
 type LdapSettingsHeaderProps = {
   onChange: (value: string) => void;
   value: string;
@@ -221,7 +228,7 @@ export const UserFederationLdapSettings = () => {
     }
   };
 
-  const save = async (component: ComponentRepresentation) => {
+  const save = async (component: ldapComponentRepresentation) => {
     if (component?.config?.periodicChangedUsersSync !== null) {
       if (component?.config?.periodicChangedUsersSync === false) {
         component.config.changedSyncPeriod = ["-1"];

--- a/src/user-federation/ldap/LdapSettingsConnection.tsx
+++ b/src/user-federation/ldap/LdapSettingsConnection.tsx
@@ -7,6 +7,7 @@ import {
   SelectVariant,
   Switch,
   TextInput,
+  ValidatedOptions,
 } from "@patternfly/react-core";
 import { useTranslation } from "react-i18next";
 import React, { useState } from "react";
@@ -282,7 +283,7 @@ export const LdapSettingsConnection = ({
           ></Controller>
         </FormGroup>
 
-        {_.isEqual(ldapBindType, ["simple"]) ? (
+        {_.isEqual(ldapBindType, ["simple"]) && (
           <>
             <FormGroup
               label={t("bindDn")}
@@ -294,6 +295,12 @@ export const LdapSettingsConnection = ({
                 />
               }
               fieldId="kc-console-bind-dn"
+              helperTextInvalid={t("validateBindDn")}
+              validated={
+                form.errors.config?.bindDn
+                  ? ValidatedOptions.error
+                  : ValidatedOptions.default
+              }
               isRequired
             >
               <TextInput
@@ -301,20 +308,8 @@ export const LdapSettingsConnection = ({
                 id="kc-console-bind-dn"
                 data-testid="ldap-bind-dn"
                 name="config.bindDn[0]"
-                ref={form.register({
-                  required: {
-                    value: true,
-                    message: `${t("validateBindDn")}`,
-                  },
-                })}
+                ref={form.register({ required: true })}
               />
-              {form.errors.config &&
-                form.errors.config.bindDn &&
-                form.errors.config.bindDn[0] && (
-                  <div className="error">
-                    {form.errors.config.bindDn[0].message}
-                  </div>
-                )}
             </FormGroup>
             <FormGroup
               label={t("bindCredentials")}
@@ -326,6 +321,12 @@ export const LdapSettingsConnection = ({
                 />
               }
               fieldId="kc-console-bind-credentials"
+              helperTextInvalid={t("validateBindCredentials")}
+              validated={
+                form.errors.config?.bindCredential
+                  ? ValidatedOptions.error
+                  : ValidatedOptions.default
+              }
               isRequired
             >
               <PasswordInput
@@ -334,19 +335,9 @@ export const LdapSettingsConnection = ({
                 data-testid="ldap-bind-credentials"
                 name="config.bindCredential[0]"
                 ref={form.register({
-                  required: {
-                    value: true,
-                    message: `${t("validateBindCredentials")}`,
-                  },
+                  required: true,
                 })}
               />
-              {form.errors.config &&
-                form.errors.config.bindCredential &&
-                form.errors.config.bindCredential[0] && (
-                  <div className="error">
-                    {form.errors.config.bindCredential[0].message}
-                  </div>
-                )}
             </FormGroup>
             <FormGroup fieldId="kc-test-button">
               <Button
@@ -359,8 +350,6 @@ export const LdapSettingsConnection = ({
               </Button>
             </FormGroup>
           </>
-        ) : (
-          <></>
         )}
       </FormAccess>
     </>

--- a/src/user-federation/ldap/LdapSettingsConnection.tsx
+++ b/src/user-federation/ldap/LdapSettingsConnection.tsx
@@ -9,8 +9,9 @@ import {
 } from "@patternfly/react-core";
 import { useTranslation } from "react-i18next";
 import React, { useState } from "react";
+import _ from "lodash";
 import { HelpItem } from "../../components/help-enabler/HelpItem";
-import { Controller, UseFormMethods } from "react-hook-form";
+import { Controller, UseFormMethods, useWatch } from "react-hook-form";
 import { FormAccess } from "../../components/form-access/FormAccess";
 import { WizardSectionHeader } from "../../components/wizard-section-header/WizardSectionHeader";
 import { PasswordInput } from "../../components/password-input/PasswordInput";
@@ -35,6 +36,11 @@ export const LdapSettingsConnection = ({
   ] = useState(false);
 
   const [isBindTypeDropdownOpen, setIsBindTypeDropdownOpen] = useState(false);
+
+  const ldapBindType = useWatch({
+    control: form.control,
+    name: "config.authType",
+  });
 
   return (
     <>
@@ -231,83 +237,90 @@ export const LdapSettingsConnection = ({
                 variant={SelectVariant.single}
                 data-testid="ldap-bind-type"
               >
-                <SelectOption key={3} value="simple" />
-                <SelectOption key={4} value="none" />
+                <SelectOption key={0} value="simple" />
+                <SelectOption key={1} value="none" isPlaceholder />
               </Select>
             )}
           ></Controller>
         </FormGroup>
-        <FormGroup
-          label={t("bindDn")}
-          labelIcon={
-            <HelpItem
-              helpText={helpText("bindDnHelp")}
-              forLabel={t("bindDn")}
-              forID="kc-console-bind-dn"
-            />
-          }
-          fieldId="kc-console-bind-dn"
-          isRequired
-        >
-          <TextInput
-            type="text"
-            id="kc-console-bind-dn"
-            data-testid="ldap-bind-dn"
-            name="config.bindDn[0]"
-            ref={form.register({
-              required: {
-                value: true,
-                message: `${t("validateBindDn")}`,
-              },
-            })}
-          />
-          {form.errors.config &&
-            form.errors.config.bindDn &&
-            form.errors.config.bindDn[0] && (
-              <div className="error">
-                {form.errors.config.bindDn[0].message}
-              </div>
-            )}
-        </FormGroup>
-        <FormGroup
-          label={t("bindCredentials")}
-          labelIcon={
-            <HelpItem
-              helpText={helpText("bindCredentialsHelp")}
-              forLabel={t("bindCredentials")}
-              forID="kc-console-bind-credentials"
-            />
-          }
-          fieldId="kc-console-bind-credentials"
-          isRequired
-        >
-          <PasswordInput
-            isRequired
-            id="kc-console-bind-credentials"
-            data-testid="ldap-bind-credentials"
-            name="config.bindCredential[0]"
-            ref={form.register({
-              required: {
-                value: true,
-                message: `${t("validateBindCredentials")}`,
-              },
-            })}
-          />
-          {form.errors.config &&
-            form.errors.config.bindCredential &&
-            form.errors.config.bindCredential[0] && (
-              <div className="error">
-                {form.errors.config.bindCredential[0].message}
-              </div>
-            )}
-        </FormGroup>
-        <FormGroup fieldId="kc-test-button">
-          {" "}
-          {/* TODO: whatever this button is supposed to do */}
-          <Button variant="secondary" id="kc-test-button">
-            {t("common:test")}
-          </Button>
-        </FormGroup>
+
+        {_.isEqual(ldapBindType, ["simple"]) ? (
+          <>
+            <FormGroup
+              label={t("bindDn")}
+              labelIcon={
+                <HelpItem
+                  helpText={helpText("bindDnHelp")}
+                  forLabel={t("bindDn")}
+                  forID="kc-console-bind-dn"
+                />
+              }
+              fieldId="kc-console-bind-dn"
+              isRequired
+            >
+              <TextInput
+                type="text"
+                id="kc-console-bind-dn"
+                data-testid="ldap-bind-dn"
+                name="config.bindDn[0]"
+                ref={form.register({
+                  required: {
+                    value: true,
+                    message: `${t("validateBindDn")}`,
+                  },
+                })}
+              />
+              {form.errors.config &&
+                form.errors.config.bindDn &&
+                form.errors.config.bindDn[0] && (
+                  <div className="error">
+                    {form.errors.config.bindDn[0].message}
+                  </div>
+                )}
+            </FormGroup>
+            <FormGroup
+              label={t("bindCredentials")}
+              labelIcon={
+                <HelpItem
+                  helpText={helpText("bindCredentialsHelp")}
+                  forLabel={t("bindCredentials")}
+                  forID="kc-console-bind-credentials"
+                />
+              }
+              fieldId="kc-console-bind-credentials"
+              isRequired
+            >
+              <PasswordInput
+                isRequired
+                id="kc-console-bind-credentials"
+                data-testid="ldap-bind-credentials"
+                name="config.bindCredential[0]"
+                ref={form.register({
+                  required: {
+                    value: true,
+                    message: `${t("validateBindCredentials")}`,
+                  },
+                })}
+              />
+              {form.errors.config &&
+                form.errors.config.bindCredential &&
+                form.errors.config.bindCredential[0] && (
+                  <div className="error">
+                    {form.errors.config.bindCredential[0].message}
+                  </div>
+                )}
+            </FormGroup>
+            <FormGroup fieldId="kc-test-button">
+              {" "}
+              {/* TODO: whatever this button is supposed to do */}
+              <Button variant="secondary" id="kc-test-button">
+                {t("common:test")}
+              </Button>
+            </FormGroup>
+          </>
+        ) : (
+          <></>
+        )}
       </FormAccess>
     </>
   );

--- a/src/user-federation/ldap/LdapSettingsSynchronization.tsx
+++ b/src/user-federation/ldap/LdapSettingsSynchronization.tsx
@@ -22,7 +22,7 @@ export const LdapSettingsSynchronization = ({
 
   const watchPeriodicSync = form.watch("config.periodicFullSync", false);
   const watchChangedSync = form.watch("config.periodicChangedUsersSync", false);
-  
+
   return (
     <>
       {showSectionHeading && (

--- a/src/user-federation/ldap/LdapSettingsSynchronization.tsx
+++ b/src/user-federation/ldap/LdapSettingsSynchronization.tsx
@@ -20,6 +20,9 @@ export const LdapSettingsSynchronization = ({
   const { t } = useTranslation("user-federation");
   const helpText = useTranslation("user-federation-help").t;
 
+  const watchPeriodicSync = form.watch("config.periodicFullSync", false);
+  const watchChangedSync = form.watch("config.periodicChangedUsersSync", false);
+  
   return (
     <>
       {showSectionHeading && (
@@ -78,50 +81,110 @@ export const LdapSettingsSynchronization = ({
             ref={form.register}
           />
         </FormGroup>
-
-        {/* Enter -1 to switch off, otherwise enter value */}
         <FormGroup
-          hasNoPaddingTop
-          label={t("fullSyncPeriod")}
+          label={"Periodic full sync"}
           labelIcon={
             <HelpItem
-              helpText={helpText("fullSyncPeriodHelp")}
-              forLabel={t("fullSyncPeriod")}
-              forID="kc-full-sync-period"
+              helpText={helpText("periodicFullSyncHelp")}
+              forLabel={"periodicFullSync"}
+              forID="kc-periodic-full-sync"
             />
           }
-          fieldId="kc-full-sync-period"
-        >
-          <TextInput
-            type="number"
-            min={-1}
-            id="kc-full-sync-period"
-            name="config.fullSyncPeriod[0]"
-            ref={form.register}
-          />
-        </FormGroup>
-
-        {/* Enter -1 to switch off, otherwise enter value */}
-        <FormGroup
-          label={t("changedUsersSyncPeriod")}
-          labelIcon={
-            <HelpItem
-              helpText={helpText("changedUsersSyncHelp")}
-              forLabel={t("changedUsersSyncPeriod")}
-              forID="kc-changed-users-sync-period"
-            />
-          }
-          fieldId="kc-changed-users-sync-period"
+          fieldId="kc-periodic-full-sync"
           hasNoPaddingTop
         >
-          <TextInput
-            type="number"
-            min={-1}
-            id="kc-changed-users-sync-period"
-            name="config.changedSyncPeriod[0]"
-            ref={form.register}
-          />
+          <Controller
+            name="config.periodicFullSync"
+            defaultValue={false}
+            control={form.control}
+            render={({ onChange, value }) => (
+              <Switch
+                id={"kc-periodic-full-sync"}
+                isDisabled={false}
+                onChange={(value) => onChange(value)}
+                isChecked={value === true}
+                label={t("common:on")}
+                labelOff={t("common:off")}
+                ref={form.register}
+              />
+            )}
+          ></Controller>
         </FormGroup>
+        {watchPeriodicSync && (
+          <FormGroup
+            hasNoPaddingTop
+            label={t("fullSyncPeriod")}
+            labelIcon={
+              <HelpItem
+                helpText={helpText("fullSyncPeriodHelp")}
+                forLabel={t("fullSyncPeriod")}
+                forID="kc-full-sync-period"
+              />
+            }
+            fieldId="kc-full-sync-period"
+          >
+            <TextInput
+              type="number"
+              min={-1}
+              defaultValue={604800}
+              id="kc-full-sync-period"
+              name="config.fullSyncPeriod[0]"
+              ref={form.register}
+            />
+          </FormGroup>
+        )}
+        <FormGroup
+          label={"Periodic Changed Users Sync"}
+          labelIcon={
+            <HelpItem
+              helpText={helpText("periodicChangedUsersSyncHelp")}
+              forLabel={"periodicChangedUsersSync"}
+              forID="kc-periodic-changed-users-sync"
+            />
+          }
+          fieldId="kc-periodic-changed-users-sync"
+          hasNoPaddingTop
+        >
+          <Controller
+            name="config.periodicChangedUsersSync"
+            defaultValue={false}
+            control={form.control}
+            render={({ onChange, value }) => (
+              <Switch
+                id={"kc-periodic-changed-users-sync"}
+                isDisabled={false}
+                onChange={(value) => onChange(value)}
+                isChecked={value === true}
+                label={t("common:on")}
+                labelOff={t("common:off")}
+                ref={form.register}
+              />
+            )}
+          ></Controller>
+        </FormGroup>
+        {watchChangedSync && (
+          <FormGroup
+            label={t("changedUsersSyncPeriod")}
+            labelIcon={
+              <HelpItem
+                helpText={helpText("changedUsersSyncHelp")}
+                forLabel={t("changedUsersSyncPeriod")}
+                forID="kc-changed-users-sync-period"
+              />
+            }
+            fieldId="kc-changed-users-sync-period"
+            hasNoPaddingTop
+          >
+            <TextInput
+              type="number"
+              min={-1}
+              defaultValue={86400}
+              id="kc-changed-users-sync-period"
+              name="config.changedSyncPeriod[0]"
+              ref={form.register}
+            />
+          </FormGroup>
+        )}
       </FormAccess>
     </>
   );

--- a/src/user-federation/messages.json
+++ b/src/user-federation/messages.json
@@ -81,9 +81,9 @@
     "subtree": "Subtree",
 
     "saveSuccess": "User federation provider successfully saved",
-    "saveError": "User federation provider could not be saved: {error}",
+    "saveError": "User federation provider could not be saved: {{error}}",
     "createSuccess": "User federation provider successfully created",
-    "createError": "User federation provider could not be created: {error}",
+    "createError": "User federation provider could not be created: {{error}}",
     "testSuccess": "Successfully connected to LDAP",
     "testError": "Error when trying to connect to LDAP. See server.log for details.",
 

--- a/src/user-federation/messages.json
+++ b/src/user-federation/messages.json
@@ -84,6 +84,8 @@
     "saveError": "User federation provider could not be saved: {error}",
     "createSuccess": "User federation provider successfully created",
     "createError": "User federation provider could not be created: {error}",
+    "testSuccess": "Successfully connected to LDAP",
+    "testError": "Error when trying to connect to LDAP. See server.log for details.",
 
     "learnMore": "Learn more",
     "addNewProvider": "Add new provider",


### PR DESCRIPTION
## Motivation
Partially fixes https://github.com/keycloak/keycloak-admin-ui/issues/436.

## Brief Description
When creating an LDAP provider, in the Connection and authentication settings section, the "Bind DN" and "Bind credentials" fields should only display when 'simple' is selected from the "Bind type" dropdown, and should be hidden when the Bind type is 'none'.

## Verification Steps
1. Create a User Federation LDAP provider and verify that the two fields above are shown/hidden correctly.
**Update**: Currently having an issue in which the DN and Credentials fields are no longer populating with the correct data when the form is loaded or when simple is chosen.

## Checklist:
- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [x] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [x] Unit tests have been created/updated
- [x] Formatting has been performed via prettier/eslint
- [x] Type checking has been performed via 'yarn check-types'

## Additional Notes
This should not be pushed until the issue in verification steps is fixed.