### PR TITLE
add `/` after baseUrl

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -87,9 +87,11 @@ export const upperCaseFormatter = (): IFormatter => (
 };
 
 export const getBaseUrl = (adminClient: KeycloakAdminClient) => {
-  return adminClient.keycloak
-    ? adminClient.keycloak.authServerUrl!
-    : adminClient.baseUrl + "/";
+  return (
+    (adminClient.keycloak
+      ? adminClient.keycloak.authServerUrl!
+      : adminClient.baseUrl) + "/"
+  );
 };
 
 export const emailRegexPattern = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;


### PR DESCRIPTION
## Motivation
Base url is now invalid because it doesn't have a slash at the end resulting in Urls with `authreamls`

## Brief Description
<!-- Add a short answer for: 
What was done in this PR? (e.g Fix to prevent users from accessing feature X.)
Why it was done? (e.g Feature X was deprecated.)
-->

## Verification Steps
<!--
Add the steps required to verify this change. Keep in mind that these steps should be written so groups unfamiliar with the 
new functionality can follow them, such as QE or documentation.

1. Go to `XX >> YY >> SS`.
2. Create a new item `N` with info `X`.
3. Right-click the item and select Delete.
4. Verify that the item is no longer present in the left navigation menu.
-->
go to the clients section and see that the urls are valid or the realm settings