### PR TITLE
UX review: Fixes for test button and import users

### DIFF
--- a/src/user-federation/ldap/LdapSettingsConnection.tsx
+++ b/src/user-federation/ldap/LdapSettingsConnection.tsx
@@ -339,18 +339,17 @@ export const LdapSettingsConnection = ({
                 })}
               />
             </FormGroup>
-            <FormGroup fieldId="kc-test-button">
-              <Button
-                isDisabled={!form.formState.isValid}
-                variant="secondary"
-                id="kc-test-button"
-                onClick={() => testLdap()}
-              >
-                {t("common:test")}
-              </Button>
-            </FormGroup>
           </>
         )}
+        <FormGroup fieldId="kc-test-button">
+          <Button
+            variant="secondary"
+            id="kc-test-button"
+            onClick={() => testLdap()}
+          >
+            {t("common:test")}
+          </Button>
+        </FormGroup>
       </FormAccess>
     </>
   );

--- a/src/user-federation/ldap/LdapSettingsSynchronization.tsx
+++ b/src/user-federation/ldap/LdapSettingsSynchronization.tsx
@@ -47,7 +47,7 @@ export const LdapSettingsSynchronization = ({
         >
           <Controller
             name="config.importEnabled"
-            defaultValue={["false"]}
+            defaultValue={["true"]}
             control={form.control}
             render={({ onChange, value }) => (
               <Switch


### PR DESCRIPTION
## Motivation
https://github.com/keycloak/keycloak-admin-ui/issues/436

## Brief Description
Requests from UX:
- In the "Connection and authentication settings" section, the Test button should always be enabled, and it should not be hidden regardless of bind type.
- In the "Synchronization settings" section, the Import users toggle should default to On. 

## Verification Steps
Go to User Fed and create a new LDAP provider. Verify that the:
- Import users toggle default to On. 
- Test button can be clicked.
- Test button appears when you select Bind type of none or simple.

## Checklist:
- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [x] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [x] Unit tests have been created/updated
- [x] Formatting has been performed via prettier/eslint
- [x] Type checking has been performed via 'yarn check-types'

## Additional Notes
All user federation cypress tests passed.