### PR TITLE
Adds User Fed Group and Role mappers

### DIFF
--- a/cypress/integration/user_fed_ldap_mapper_test.spec.ts
+++ b/cypress/integration/user_fed_ldap_mapper_test.spec.ts
@@ -3,6 +3,7 @@ import SidebarPage from "../support/pages/admin_console/SidebarPage";
 import ListingPage from "../support/pages/admin_console/ListingPage";
 import GroupModal from "../support/pages/admin_console/manage/groups/GroupModal";
 import ProviderPage from "../support/pages/admin_console/manage/providers/ProviderPage";
+import CreateClientPage from "../support/pages/admin_console/manage/clients/CreateClientPage";
 import Masthead from "../support/pages/admin_console/Masthead";
 import ModalUtils from "../support/util/ModalUtils";
 import { keycloakBefore } from "../support/util/keycloak_before";
@@ -12,6 +13,7 @@ const masthead = new Masthead();
 const sidebarPage = new SidebarPage();
 const listingPage = new ListingPage();
 const groupModal = new GroupModal();
+const createClientPage = new CreateClientPage();
 
 const providersPage = new ProviderPage();
 const modalUtils = new ModalUtils();
@@ -41,8 +43,12 @@ const providerDeleteSuccess = "The user federation provider has been deleted.";
 const providerDeleteTitle = "Delete user federation provider?";
 const mapperDeletedSuccess = "Mapping successfully deleted";
 const mapperDeleteTitle = "Delete mapping?";
-
-const groupName = "my-mappers-group";
+const groupCreatedSuccess = "Group created";
+const groupDeletedSuccess = "Group deleted";
+const clientCreatedSuccess = "Client created successfully";
+const clientDeletedSuccess = "The client has been deleted";
+const groupName = "aa-uf-mappers-group";
+const clientName = "aa-uf-mappers-client";
 
 // mapperType variables
 const msadUserAcctMapper = "msad-user-account-control-mapper";
@@ -53,9 +59,12 @@ const certLdapMapper = "certificate-ldap-mapper";
 const fullNameLdapMapper = "full-name-ldap-mapper";
 const hcLdapGroupMapper = "hardcoded-ldap-group-mapper";
 const hcLdapAttMapper = "hardcoded-ldap-attribute-mapper";
-// const groupLdapMapper = "group-ldap-mapper";
-// const roleMapper = "role-ldap-mapper";
-// const hcLdapRoleMapper = "hardcoded-ldap-role-mapper";
+
+const groupLdapMapper = "group-ldap-mapper";
+/* 
+const roleMapper = "role-ldap-mapper";
+const hcLdapRoleMapper = "hardcoded-ldap-role-mapper";
+*/
 
 const creationDateMapper = "creation date";
 const emailMapper = "email";
@@ -111,7 +120,22 @@ describe("User Fed LDAP mapper tests", () => {
       .fillGroupForm(groupName)
       .clickCreate();
 
-    masthead.checkNotificationMessage("Group created");
+    masthead.checkNotificationMessage(groupCreatedSuccess);
+  });
+
+  // create a new client
+  it("Create client", () => {
+    sidebarPage.goToClients();
+    listingPage.goToCreateItem();
+    createClientPage
+      .selectClientType("openid-connect")
+      .fillClientData(clientName)
+      .continue()
+      .continue();
+
+    masthead.checkNotificationMessage(clientCreatedSuccess);
+    sidebarPage.goToClients();
+    listingPage.searchItem(clientName).itemExist(clientName);
   });
 
   // delete default mappers
@@ -156,6 +180,7 @@ describe("User Fed LDAP mapper tests", () => {
     masthead.checkNotificationMessage(mapperDeletedSuccess);
   });
 
+  // mapper CRUD tests
   // create mapper
   it("Create certificate ldap mapper", () => {
     providersPage.clickExistingCard(ldapName);
@@ -188,7 +213,7 @@ describe("User Fed LDAP mapper tests", () => {
     masthead.checkNotificationMessage(mapperDeletedSuccess);
   });
 
-  // create one of every kind of non-group/role mapper (8)
+  // create one of each mapper type
   it("Create user account control mapper", () => {
     providersPage.clickExistingCard(ldapName);
     providersPage.goToMappers();
@@ -261,17 +286,52 @@ describe("User Fed LDAP mapper tests", () => {
     listingPage.itemExist(hcLdapAttMapper, true);
   });
 
-  // *** test cleanup ***
-  it("Cleanup - delete group", () => {
-    sidebarPage.goToGroups();
-    listingPage.deleteItem(groupName);
-    modalUtils.confirmModal();
-    masthead.checkNotificationMessage("Group deleted");
+/*  COMING SOON
+  it("Create hardcoded ldap role mapper", () => {
+    providersPage.clickExistingCard(ldapName);
+    providersPage.goToMappers();
+    providersPage.createNewMapper(hcLdapRoleMapper);
+    providersPage.save("ldap-mapper");
+    masthead.checkNotificationMessage(mapperCreatedSuccess);
+    listingPage.itemExist(hcLdapRoleMapper, true);
   });
 
+  it("Create role ldap mapper", () => {
+    providersPage.clickExistingCard(ldapName);
+    providersPage.goToMappers();
+    providersPage.createNewMapper(roleMapper);
+    providersPage.save("ldap-mapper");
+    masthead.checkNotificationMessage(mapperCreatedSuccess);
+    listingPage.itemExist(roleMapper, true);
+  });
+*/
+
+  it("Create group ldap mapper", () => {
+    providersPage.clickExistingCard(ldapName);
+    providersPage.goToMappers();
+    providersPage.createNewMapper(groupLdapMapper);
+    providersPage.save("ldap-mapper");
+    masthead.checkNotificationMessage(mapperCreatedSuccess);
+    listingPage.itemExist(groupLdapMapper, true);
+  });
+
+  // *** test cleanup ***
   it("Cleanup - delete LDAP provider", () => {
     providersPage.deleteCardFromMenu(provider, ldapName);
     modalUtils.checkModalTitle(providerDeleteTitle).confirmModal();
     masthead.checkNotificationMessage(providerDeleteSuccess);
+  });
+
+  it("Cleanup - delete group", () => {
+    sidebarPage.goToGroups();
+    listingPage.deleteItem(groupName);
+    masthead.checkNotificationMessage(groupDeletedSuccess);
+  });
+
+  it("Cleanup - delete client", () => {
+    sidebarPage.goToClients();
+    listingPage.deleteItem(clientName);
+    modalUtils.checkModalTitle(`Delete ${clientName} ?`).confirmModal();
+    masthead.checkNotificationMessage(clientDeletedSuccess);
   });
 });

--- a/cypress/integration/user_fed_ldap_mapper_test.spec.ts
+++ b/cypress/integration/user_fed_ldap_mapper_test.spec.ts
@@ -47,8 +47,10 @@ const groupCreatedSuccess = "Group created";
 const groupDeletedSuccess = "Group deleted";
 const clientCreatedSuccess = "Client created successfully";
 const clientDeletedSuccess = "The client has been deleted";
+const roleCreatedSuccess = "Role created";
 const groupName = "aa-uf-mappers-group";
 const clientName = "aa-uf-mappers-client";
+const roleName = "aa-uf-mappers-role";
 
 // mapperType variables
 const msadUserAcctMapper = "msad-user-account-control-mapper";
@@ -61,10 +63,8 @@ const hcLdapGroupMapper = "hardcoded-ldap-group-mapper";
 const hcLdapAttMapper = "hardcoded-ldap-attribute-mapper";
 
 const groupLdapMapper = "group-ldap-mapper";
-/* 
-const roleMapper = "role-ldap-mapper";
+const roleLdapMapper = "role-ldap-mapper";
 const hcLdapRoleMapper = "hardcoded-ldap-role-mapper";
-*/
 
 const creationDateMapper = "creation date";
 const emailMapper = "email";
@@ -105,9 +105,7 @@ describe("User Fed LDAP mapper tests", () => {
       firstUuidLdapAtt,
       firstUserObjClasses
     );
-
     providersPage.save(provider);
-
     masthead.checkNotificationMessage(providerCreatedSuccess);
     sidebarPage.goToUserFederation();
   });
@@ -123,8 +121,8 @@ describe("User Fed LDAP mapper tests", () => {
     masthead.checkNotificationMessage(groupCreatedSuccess);
   });
 
-  // create a new client
-  it("Create client", () => {
+  // create a new client and then new role for that client
+  it("Create client and role", () => {
     sidebarPage.goToClients();
     listingPage.goToCreateItem();
     createClientPage
@@ -134,6 +132,10 @@ describe("User Fed LDAP mapper tests", () => {
       .continue();
 
     masthead.checkNotificationMessage(clientCreatedSuccess);
+
+    providersPage.createRole(roleName);
+    masthead.checkNotificationMessage(roleCreatedSuccess);
+
     sidebarPage.goToClients();
     listingPage.searchItem(clientName).itemExist(clientName);
   });
@@ -286,26 +288,6 @@ describe("User Fed LDAP mapper tests", () => {
     listingPage.itemExist(hcLdapAttMapper, true);
   });
 
-/*  COMING SOON
-  it("Create hardcoded ldap role mapper", () => {
-    providersPage.clickExistingCard(ldapName);
-    providersPage.goToMappers();
-    providersPage.createNewMapper(hcLdapRoleMapper);
-    providersPage.save("ldap-mapper");
-    masthead.checkNotificationMessage(mapperCreatedSuccess);
-    listingPage.itemExist(hcLdapRoleMapper, true);
-  });
-
-  it("Create role ldap mapper", () => {
-    providersPage.clickExistingCard(ldapName);
-    providersPage.goToMappers();
-    providersPage.createNewMapper(roleMapper);
-    providersPage.save("ldap-mapper");
-    masthead.checkNotificationMessage(mapperCreatedSuccess);
-    listingPage.itemExist(roleMapper, true);
-  });
-*/
-
   it("Create group ldap mapper", () => {
     providersPage.clickExistingCard(ldapName);
     providersPage.goToMappers();
@@ -313,6 +295,24 @@ describe("User Fed LDAP mapper tests", () => {
     providersPage.save("ldap-mapper");
     masthead.checkNotificationMessage(mapperCreatedSuccess);
     listingPage.itemExist(groupLdapMapper, true);
+
+    it("Create hardcoded ldap role mapper", () => {
+      providersPage.clickExistingCard(ldapName);
+      providersPage.goToMappers();
+      providersPage.createNewMapper(hcLdapRoleMapper);
+      providersPage.save("ldap-mapper");
+      masthead.checkNotificationMessage(mapperCreatedSuccess);
+      listingPage.itemExist(hcLdapRoleMapper, true);
+    });
+
+    it("Create role ldap mapper", () => {
+      providersPage.clickExistingCard(ldapName);
+      providersPage.goToMappers();
+      providersPage.createNewMapper(roleLdapMapper);
+      providersPage.save("ldap-mapper");
+      masthead.checkNotificationMessage(mapperCreatedSuccess);
+      listingPage.itemExist(roleLdapMapper, true);
+    });
   });
 
   // *** test cleanup ***

--- a/cypress/integration/user_fed_ldap_mapper_test.spec.ts
+++ b/cypress/integration/user_fed_ldap_mapper_test.spec.ts
@@ -43,6 +43,7 @@ const providerDeleteSuccess = "The user federation provider has been deleted.";
 const providerDeleteTitle = "Delete user federation provider?";
 const mapperDeletedSuccess = "Mapping successfully deleted";
 const mapperDeleteTitle = "Delete mapping?";
+const groupDeleteTitle = "Delete group?";
 const groupCreatedSuccess = "Group created";
 const groupDeletedSuccess = "Group deleted";
 const clientCreatedSuccess = "Client created successfully";
@@ -325,6 +326,7 @@ describe("User Fed LDAP mapper tests", () => {
   it("Cleanup - delete group", () => {
     sidebarPage.goToGroups();
     listingPage.deleteItem(groupName);
+    modalUtils.checkModalTitle(groupDeleteTitle).confirmModal();
     masthead.checkNotificationMessage(groupDeletedSuccess);
   });
 

--- a/cypress/support/pages/admin_console/manage/providers/ProviderPage.ts
+++ b/cypress/support/pages/admin_console/manage/providers/ProviderPage.ts
@@ -56,10 +56,27 @@ export default class ProviderPage {
   private hcLdapAttMapper = "hardcoded-ldap-attribute-mapper";
   private hcLdapGroupMapper = "hardcoded-ldap-group-mapper";
   private groupLdapMapper = "group-ldap-mapper";
-  // this.roleMapper = "role-ldap-mapper";
-  // this.hcLdapRoleMapper = "hardcoded-ldap-role-mapper";
+  private roleLdapMapper = "role-ldap-mapper";
+  private hcLdapRoleMapper = "hardcoded-ldap-role-mapper";
+
+  private tab = "#pf-tab-serviceAccount-serviceAccount";
+  private scopeTab = "scopeTab";
+  private assignRole = "assignRole";
+  private unAssign = "unAssignRole";
+  private assign = "assign";
+  private hide = "#hideInheritedRoles";
+  private assignedRolesTable = "assigned-roles";
+  private namesColumn = 'td[data-label="Name"]:visible';
+
+  private rolesTab = "#pf-tab-roles-roles";
+  private createRoleBtn = "data-testid=empty-primary-action";
+  private realmRolesSaveBtn = "data-testid=realm-roles-save-button";
+  private roleNameField = "#kc-name";
+  private clientIdSelect = "#kc-client-id";
 
   private groupName = "aa-uf-mappers-group";
+  private clientName = "aa-uf-mappers-client";
+  private roleName = "aa-uf-mappers-role";
 
   changeCacheTime(unit: string, time: string) {
     switch (unit) {
@@ -184,10 +201,21 @@ export default class ProviderPage {
     cy.get(`[data-testid="ldap-mappers-tab"]`).click();
   }
 
+  createRole(roleName: string) {
+    cy.get(this.rolesTab).click();
+    cy.wait(1000);
+    cy.get(`[${this.createRoleBtn}]`).click();
+    cy.wait(1000);
+    cy.get(this.roleNameField).type(roleName);
+    cy.wait(1000);
+    cy.get(`[${this.realmRolesSaveBtn}]`).click();
+    cy.wait(1000);
+  }
+
   createNewMapper(mapperType: string) {
     const userModelAttValue = "firstName";
     const ldapAttValue = "cn";
-    const ldapDnValue = "ou=groups"
+    const ldapDnValue = "ou=groups";
 
     cy.get(`[data-testid="add-mapper-btn"]`).click();
     cy.wait(1000);
@@ -223,10 +251,26 @@ export default class ProviderPage {
       case this.groupLdapMapper:
         cy.get(`[${this.ldapDnInput}]`).type(ldapDnValue);
         break;
-      // case this.roleMapper:
-      //   break;
-      // case this.hcLdapRoleMapper:
-      //   break;
+
+      case this.roleLdapMapper:
+        cy.get(`[${this.ldapDnInput}]`).type(ldapDnValue);
+        // cy select clientID dropdown and choose clientName (var)
+        cy.get(this.clientIdSelect).click();
+        cy.get("button").contains(this.clientName).click({ force: true });
+        break;
+
+      case this.hcLdapRoleMapper:
+        cy.get(`[data-testid="selectRole"]`).click();
+        cy.wait(2000);
+        cy.get(this.namesColumn)
+          .contains(this.clientName)
+          .parent()
+          .parent()
+          .within(() => {
+            cy.get('input[name="radioGroup"]').click();
+          });
+        cy.getId(this.assign).click();
+        break;
       default:
         console.log("Invalid mapper type.");
         break;
@@ -264,14 +308,6 @@ export default class ProviderPage {
         cy.get(`[${this.ldapAttValueInput}]`).clear;
         cy.get(`[${this.ldapAttValueInput}]`).type(ldapAttValue);
         break;
-      // case this.hcLdapGroupMapper:
-      //   break;
-      // case this.groupLdapMapper:
-      //   break;
-      // case this.roleMapper:
-      //   break;
-      // case this.hcLdapRoleMapper:
-      //   break;
       default:
         console.log("Invalid mapper name.");
         break;

--- a/cypress/support/pages/admin_console/manage/providers/ProviderPage.ts
+++ b/cypress/support/pages/admin_console/manage/providers/ProviderPage.ts
@@ -44,6 +44,7 @@ export default class ProviderPage {
   private ldapAttNameInput = "data-testid=mapper-ldapAttributeName-fld";
   private ldapAttValueInput = "data-testid=mapper-ldapAttributeValue-fld";
   private groupInput = "data-testid=mapper-group-fld";
+  private ldapDnInput = "data-testid=ldap-dn";
 
   // mapper types
   private msadUserAcctMapper = "msad-user-account-control-mapper";
@@ -54,11 +55,11 @@ export default class ProviderPage {
   private fullNameLdapMapper = "full-name-ldap-mapper";
   private hcLdapAttMapper = "hardcoded-ldap-attribute-mapper";
   private hcLdapGroupMapper = "hardcoded-ldap-group-mapper";
-  // this.groupLdapMapper = "group-ldap-mapper";
+  private groupLdapMapper = "group-ldap-mapper";
   // this.roleMapper = "role-ldap-mapper";
   // this.hcLdapRoleMapper = "hardcoded-ldap-role-mapper";
 
-  private groupName = "my-mappers-group";
+  private groupName = "aa-uf-mappers-group";
 
   changeCacheTime(unit: string, time: string) {
     switch (unit) {
@@ -186,6 +187,7 @@ export default class ProviderPage {
   createNewMapper(mapperType: string) {
     const userModelAttValue = "firstName";
     const ldapAttValue = "cn";
+    const ldapDnValue = "ou=groups"
 
     cy.get(`[data-testid="add-mapper-btn"]`).click();
     cy.wait(1000);
@@ -218,8 +220,9 @@ export default class ProviderPage {
       case this.hcLdapGroupMapper:
         cy.get(`[${this.groupInput}]`).type(this.groupName);
         break;
-      // case this.groupLdapMapper:
-      //   break;
+      case this.groupLdapMapper:
+        cy.get(`[${this.ldapDnInput}]`).type(ldapDnValue);
+        break;
       // case this.roleMapper:
       //   break;
       // case this.hcLdapRoleMapper:

--- a/src/components/role-mapping/AddRoleMappingModal.tsx
+++ b/src/components/role-mapping/AddRoleMappingModal.tsx
@@ -23,12 +23,12 @@ import { FilterIcon } from "@patternfly/react-icons";
 import { Row, ServiceRole } from "./RoleMapping";
 import type RoleRepresentation from "keycloak-admin/lib/defs/roleRepresentation";
 
-export type MappingType = "service-account" | "client-scope";
+export type MappingType = "service-account" | "client-scope" | "user-fed";
 
 type AddRoleMappingModalProps = {
   id: string;
   type: MappingType;
-  name: string;
+  name?: string;
   isRadio?: boolean;
   onAssign: (rows: Row[]) => void;
   onClose: () => void;
@@ -69,32 +69,29 @@ export const AddRoleMappingModal = ({
         await Promise.all(
           clients.map(async (client) => {
             let roles: RoleRepresentation[] = [];
-            if (type === "service-account") {
-              roles = await adminClient.users.listAvailableClientRoleMappings({
-                id: id,
-                clientUniqueId: client.id!,
-              });
-            } else if (type === "client-scope") {
-              roles = await adminClient.clientScopes.listAvailableClientScopeMappings(
-                {
-                  id,
-                  client: client.id!,
-                }
-              );
+
+            switch (type) {
+              case "service-account":
+                roles = await adminClient.users.listAvailableClientRoleMappings(
+                  {
+                    id: id,
+                    clientUniqueId: client.id!,
+                  }
+                );
+                break;
+
+              case "client-scope":
+                roles = await adminClient.clientScopes.listAvailableClientScopeMappings(
+                  {
+                    id,
+                    client: client.id!,
+                  }
+                );
+                break;
+              case "user-fed":
+                roles = await adminClient.roles.find();
+                break;
             }
-            // MF 052021 TODOs:
-            // change if/elses to switches
-            // add a type for user-federation that pulls in all roles
-            // make id optional
-
-            // adminClient.roles.find
-
-            // roles = await adminClient.clients.listRoles(
-            //   {
-            //
-            //     id: client.id!
-            //   }
-
             return {
               roles,
               client,
@@ -133,15 +130,25 @@ export const AddRoleMappingModal = ({
     }
 
     let availableRoles: RoleRepresentation[] = [];
-    if (type === "service-account") {
-      availableRoles = await adminClient.users.listAvailableRealmRoleMappings({
-        id,
-      });
-    } else if (type === "client-scope") {
-      availableRoles = await adminClient.clientScopes.listAvailableRealmScopeMappings(
-        { id }
-      );
+
+    switch (type) {
+      case "service-account":
+        availableRoles = await adminClient.users.listAvailableRealmRoleMappings(
+          {
+            id,
+          }
+        );
+        break;
+      case "client-scope":
+        availableRoles = await adminClient.clientScopes.listAvailableRealmScopeMappings(
+          { id }
+        );
+        break;
+      case "user-fed":
+        availableRoles = await adminClient.roles.find();
+        break;
     }
+
     const realmRoles = availableRoles.map((role) => {
       return {
         role,
@@ -158,18 +165,28 @@ export const AddRoleMappingModal = ({
       await Promise.all(
         allClients.map(async (client) => {
           let clientAvailableRoles: RoleRepresentation[] = [];
-          if (type === "service-account") {
-            clientAvailableRoles = await adminClient.users.listAvailableClientRoleMappings(
-              {
-                id,
-                clientUniqueId: client.id!,
-              }
-            );
-          } else if (type === "client-scope") {
-            clientAvailableRoles = await adminClient.clientScopes.listAvailableClientScopeMappings(
-              { id, client: client.id! }
-            );
+
+          switch (type) {
+            case "service-account":
+              clientAvailableRoles = await adminClient.users.listAvailableClientRoleMappings(
+                {
+                  id,
+                  clientUniqueId: client.id!,
+                }
+              );
+              break;
+            case "client-scope":
+              clientAvailableRoles = await adminClient.clientScopes.listAvailableClientScopeMappings(
+                { id, client: client.id! }
+              );
+              break;
+            case "user-fed":
+              clientAvailableRoles = await adminClient.clients.listRoles({
+                id: client.id!,
+              });
+              break;
           }
+
           return clientAvailableRoles.map((role) => {
             return {
               role,

--- a/src/components/role-mapping/AddRoleMappingModal.tsx
+++ b/src/components/role-mapping/AddRoleMappingModal.tsx
@@ -29,6 +29,7 @@ type AddRoleMappingModalProps = {
   id: string;
   type: MappingType;
   name: string;
+  isRadio?: boolean;
   onAssign: (rows: Row[]) => void;
   onClose: () => void;
 };
@@ -45,6 +46,7 @@ export const AddRoleMappingModal = ({
   id,
   name,
   type,
+  isRadio = false,
   onAssign,
   onClose,
 }: AddRoleMappingModalProps) => {
@@ -233,7 +235,7 @@ export const AddRoleMappingModal = ({
         toggleId="role"
         onToggle={() => setSearchToggle(!searchToggle)}
         isOpen={searchToggle}
-        variant={SelectVariant.checkbox}
+        variant={isRadio ? SelectVariant.single : SelectVariant.checkbox}
         hasInlineFilter
         menuAppendTo="parent"
         placeholderText={
@@ -283,6 +285,7 @@ export const AddRoleMappingModal = ({
         onSelect={(rows) => setSelectedRows([...rows])}
         searchPlaceholderKey="clients:searchByRoleName"
         canSelectAll={false}
+        isRadio={isRadio}
         loader={loader}
         ariaLabelKey="clients:roles"
         columns={[

--- a/src/components/role-mapping/AddRoleMappingModal.tsx
+++ b/src/components/role-mapping/AddRoleMappingModal.tsx
@@ -81,17 +81,17 @@ export const AddRoleMappingModal = ({
                   client: client.id!,
                 }
               );
-            } 
-            // MF 052021 TODOs: 
+            }
+            // MF 052021 TODOs:
             // change if/elses to switches
             // add a type for user-federation that pulls in all roles
             // make id optional
-            
+
             // adminClient.roles.find
 
             // roles = await adminClient.clients.listRoles(
             //   {
-            //     
+            //
             //     id: client.id!
             //   }
 

--- a/src/components/role-mapping/AddRoleMappingModal.tsx
+++ b/src/components/role-mapping/AddRoleMappingModal.tsx
@@ -79,7 +79,20 @@ export const AddRoleMappingModal = ({
                   client: client.id!,
                 }
               );
-            }
+            } 
+            // MF 052021 TODOs: 
+            // change if/elses to switches
+            // add a type for user-federation that pulls in all roles
+            // make id optional
+            
+            // adminClient.roles.find
+
+            // roles = await adminClient.clients.listRoles(
+            //   {
+            //     
+            //     id: client.id!
+            //   }
+
             return {
               roles,
               client,

--- a/src/components/role-mapping/RoleMapping.tsx
+++ b/src/components/role-mapping/RoleMapping.tsx
@@ -19,7 +19,6 @@ import "./role-mapping.css";
 import { useConfirmDialog } from "../confirm-dialog/ConfirmDialog";
 import { useAdminClient } from "../../context/auth/AdminClient";
 import { useAlerts } from "../alert/Alerts";
-import _ from "lodash";
 
 export type CompositeRole = RoleRepresentation & {
   parent: RoleRepresentation;
@@ -85,46 +84,49 @@ export const RoleMapping = ({
     continueButtonVariant: ButtonVariant.danger,
     onConfirm: async () => {
       try {
-        if (type === "service-account") {
-          await Promise.all(
-            selected.map((row) => {
-              const role = { id: row.role.id!, name: row.role.name! };
-              if (row.client) {
-                return adminClient.users.delClientRoleMappings({
-                  id,
-                  clientUniqueId: row.client!.id!,
-                  roles: [role],
-                });
-              } else {
-                return adminClient.users.delRealmRoleMappings({
-                  id,
-                  roles: [role],
-                });
-              }
-            })
-          );
-        } else if (type === "client-scope") {
-          await Promise.all(
-            selected.map((row) => {
-              const role = { id: row.role.id!, name: row.role.name! };
-              if (row.client) {
-                return adminClient.clientScopes.delClientScopeMappings(
-                  {
+        switch (type) {
+          case "service-account":
+            await Promise.all(
+              selected.map((row) => {
+                const role = { id: row.role.id!, name: row.role.name! };
+                if (row.client) {
+                  return adminClient.users.delClientRoleMappings({
                     id,
-                    client: row.client!.id!,
-                  },
-                  [role]
-                );
-              } else {
-                return adminClient.clientScopes.delRealmScopeMappings(
-                  {
+                    clientUniqueId: row.client!.id!,
+                    roles: [role],
+                  });
+                } else {
+                  return adminClient.users.delRealmRoleMappings({
                     id,
-                  },
-                  [role]
-                );
-              }
-            })
-          );
+                    roles: [role],
+                  });
+                }
+              })
+            );
+            break;
+          case "client-scope":
+            await Promise.all(
+              selected.map((row) => {
+                const role = { id: row.role.id!, name: row.role.name! };
+                if (row.client) {
+                  return adminClient.clientScopes.delClientScopeMappings(
+                    {
+                      id,
+                      client: row.client!.id!,
+                    },
+                    [role]
+                  );
+                } else {
+                  return adminClient.clientScopes.delRealmScopeMappings(
+                    {
+                      id,
+                    },
+                    [role]
+                  );
+                }
+              })
+            );
+            break;
         }
         addAlert(t("clientScopeRemoveSuccess"), AlertVariant.success);
         refresh();

--- a/src/components/table-toolbar/KeycloakDataTable.tsx
+++ b/src/components/table-toolbar/KeycloakDataTable.tsx
@@ -54,6 +54,7 @@ type DataTableProps<T> = {
   onCollapse?: (isOpen: boolean, rowIndex: number) => void;
   canSelectAll: boolean;
   isNotCompact?: boolean;
+  isRadio?: boolean;
 };
 
 function DataTable<T>({
@@ -66,6 +67,7 @@ function DataTable<T>({
   onCollapse,
   canSelectAll,
   isNotCompact,
+  isRadio,
   ...props
 }: DataTableProps<T>) {
   const { t } = useTranslation();
@@ -83,6 +85,7 @@ function DataTable<T>({
           ? (_, rowIndex, isOpen) => onCollapse(isOpen, rowIndex)
           : undefined
       }
+      selectVariant={isRadio ? 'radio' : 'checkbox'}
       canSelectAll={canSelectAll}
       cells={columns.map((column) => {
         return { ...column, title: t(column.displayKey || column.name) };
@@ -133,6 +136,7 @@ export type DataListProps<T> = {
   emptyState?: ReactNode;
   icon?: React.ComponentClass<SVGIconProps>;
   isNotCompact?: boolean;
+  isRadio?: boolean;
 };
 
 /**
@@ -165,6 +169,7 @@ export function KeycloakDataTable<T>({
   onSelect,
   canSelectAll = false,
   isNotCompact,
+  isRadio,
   detailColumns,
   isRowDisabled,
   loader,
@@ -394,6 +399,7 @@ export function KeycloakDataTable<T>({
               rows={filteredData || rows}
               columns={columns}
               isNotCompact={isNotCompact}
+              isRadio={isRadio}
               ariaLabelKey={ariaLabelKey}
             />
           )}

--- a/src/components/table-toolbar/KeycloakDataTable.tsx
+++ b/src/components/table-toolbar/KeycloakDataTable.tsx
@@ -85,7 +85,7 @@ function DataTable<T>({
           ? (_, rowIndex, isOpen) => onCollapse(isOpen, rowIndex)
           : undefined
       }
-      selectVariant={isRadio ? 'radio' : 'checkbox'}
+      selectVariant={isRadio ? "radio" : "checkbox"}
       canSelectAll={canSelectAll}
       cells={columns.map((column) => {
         return { ...column, title: t(column.displayKey || column.name) };

--- a/src/user-federation/ldap/mappers/LdapMapperDetails.tsx
+++ b/src/user-federation/ldap/mappers/LdapMapperDetails.tsx
@@ -10,6 +10,7 @@ import {
   SelectOption,
   SelectVariant,
   TextInput,
+  ValidatedOptions
 } from "@patternfly/react-core";
 import { convertFormValuesToObject, convertToFormValues } from "../../../util";
 import type ComponentRepresentation from "keycloak-admin/lib/defs/componentRepresentation";
@@ -158,7 +159,10 @@ export const LdapMapperDetails = () => {
               id="kc-ldap-mapper-name"
               data-testid="ldap-mapper-name"
               name="name"
-              ref={form.register}
+              ref={form.register({ required: true})}
+              validated={ 
+                form.errors.name ? ValidatedOptions.error : ValidatedOptions.default
+              }
             />
             <TextInput
               hidden

--- a/src/user-federation/ldap/mappers/LdapMapperDetails.tsx
+++ b/src/user-federation/ldap/mappers/LdapMapperDetails.tsx
@@ -10,7 +10,7 @@ import {
   SelectOption,
   SelectVariant,
   TextInput,
-  ValidatedOptions
+  ValidatedOptions,
 } from "@patternfly/react-core";
 import { convertFormValuesToObject, convertToFormValues } from "../../../util";
 import type ComponentRepresentation from "keycloak-admin/lib/defs/componentRepresentation";
@@ -159,9 +159,11 @@ export const LdapMapperDetails = () => {
               id="kc-ldap-mapper-name"
               data-testid="ldap-mapper-name"
               name="name"
-              ref={form.register({ required: true})}
-              validated={ 
-                form.errors.name ? ValidatedOptions.error : ValidatedOptions.default
+              ref={form.register({ required: true })}
+              validated={
+                form.errors.name
+                  ? ValidatedOptions.error
+                  : ValidatedOptions.default
               }
             />
             <TextInput

--- a/src/user-federation/ldap/mappers/LdapMapperHardcodedLdapGroup.tsx
+++ b/src/user-federation/ldap/mappers/LdapMapperHardcodedLdapGroup.tsx
@@ -1,4 +1,4 @@
-import { FormGroup, TextInput } from "@patternfly/react-core";
+import { FormGroup, TextInput, ValidatedOptions } from "@patternfly/react-core";
 import React from "react";
 import { HelpItem } from "../../../components/help-enabler/HelpItem";
 import type { UseFormMethods } from "react-hook-form";
@@ -34,7 +34,10 @@ export const LdapMapperHardcodedLdapGroup = ({
           id="kc-group"
           data-testid="mapper-group-fld"
           name="config.group[0]"
-          ref={form.register}
+          ref={form.register({ required: true })}
+          validated={ 
+            form.errors.config && form.errors.config.group ? ValidatedOptions.error : ValidatedOptions.default
+          }
         />
       </FormGroup>
     </>

--- a/src/user-federation/ldap/mappers/LdapMapperHardcodedLdapGroup.tsx
+++ b/src/user-federation/ldap/mappers/LdapMapperHardcodedLdapGroup.tsx
@@ -35,8 +35,10 @@ export const LdapMapperHardcodedLdapGroup = ({
           data-testid="mapper-group-fld"
           name="config.group[0]"
           ref={form.register({ required: true })}
-          validated={ 
-            form.errors.config && form.errors.config.group ? ValidatedOptions.error : ValidatedOptions.default
+          validated={
+            form.errors.config && form.errors.config.group
+              ? ValidatedOptions.error
+              : ValidatedOptions.default
           }
         />
       </FormGroup>

--- a/src/user-federation/ldap/mappers/LdapMapperHardcodedLdapRole.tsx
+++ b/src/user-federation/ldap/mappers/LdapMapperHardcodedLdapRole.tsx
@@ -1,4 +1,9 @@
-import { Button, FormGroup, TextInput } from "@patternfly/react-core";
+import {
+  Button,
+  FormGroup,
+  TextInput,
+  ValidatedOptions,
+} from "@patternfly/react-core";
 import React, { useState } from "react";
 import { HelpItem } from "../../../components/help-enabler/HelpItem";
 import type { UseFormMethods } from "react-hook-form";
@@ -71,7 +76,12 @@ export const LdapMapperHardcodedLdapRole = ({
             id="kc-role"
             data-testid="role"
             name="config.role[0]"
-            ref={form.register}
+            ref={form.register({ required: true })}
+            validated={
+              form.errors.config && form.errors.config.role
+                ? ValidatedOptions.error
+                : ValidatedOptions.default
+            }
           />
           <Button
             className="keycloak__user-federation__assign-role-btn"

--- a/src/user-federation/ldap/mappers/LdapMapperHardcodedLdapRole.tsx
+++ b/src/user-federation/ldap/mappers/LdapMapperHardcodedLdapRole.tsx
@@ -45,7 +45,7 @@ export const LdapMapperHardcodedLdapRole = ({
       {showAssign && (
         // MF 042921 hardcoded for now, to see modal displayed
         <AddRoleMappingModal
-          id="1a85c63a-99bd-4d16-9924-b38b8f7cceaf"  // this is the ID for client-scopes > marks-client-scope
+          id="1a85c63a-99bd-4d16-9924-b38b8f7cceaf" // this is the ID for client-scopes > marks-client-scope
           type="client-scope"
           name="name"
           // id={id}

--- a/src/user-federation/ldap/mappers/LdapMapperHardcodedLdapRole.tsx
+++ b/src/user-federation/ldap/mappers/LdapMapperHardcodedLdapRole.tsx
@@ -52,6 +52,7 @@ export const LdapMapperHardcodedLdapRole = ({
           // type={type}
           // name={name}
           onAssign={selectRoles}
+          isRadio={true}
           onClose={() => setShowAssign(false)}
         />
       )}

--- a/src/user-federation/ldap/mappers/LdapMapperHardcodedLdapRole.tsx
+++ b/src/user-federation/ldap/mappers/LdapMapperHardcodedLdapRole.tsx
@@ -1,8 +1,15 @@
-import { FormGroup, TextInput } from "@patternfly/react-core";
-import React from "react";
+import { AlertVariant, Button, FormGroup, TextInput } from "@patternfly/react-core";
+import React, { useState } from "react";
 import { HelpItem } from "../../../components/help-enabler/HelpItem";
 import type { UseFormMethods } from "react-hook-form";
 import { useTranslation } from "react-i18next";
+
+import { useAdminClient } from "../../../context/auth/AdminClient";
+import { useAlerts } from "../../../components/alert/Alerts";
+import { RoleMappingPayload } from "keycloak-admin/lib/defs/roleRepresentation";
+
+
+import { AddRoleMappingModal, MappingType } from "../../../components/role-mapping/AddRoleMappingModal";
 
 export type LdapMapperHardcodedLdapRoleProps = {
   form: UseFormMethods;
@@ -14,8 +21,64 @@ export const LdapMapperHardcodedLdapRole = ({
   const { t } = useTranslation("user-federation");
   const helpText = useTranslation("user-federation-help").t;
 
+  const adminClient = useAdminClient();
+
+  const [showAssign, setShowAssign] = useState(false);
+
+  const { addAlert } = useAlerts();
+
+
+  const assignRoles = async (rows: Row[]) => {
+    try {
+      const realmRoles = rows
+        .filter((row) => row.client === undefined)
+        .map((row) => row.role as RoleMappingPayload)
+        .flat();
+      await adminClient.clientScopes.addRealmScopeMappings(
+        {
+          id,
+        },
+        realmRoles
+      );
+      await Promise.all(
+        rows
+          .filter((row) => row.client !== undefined)
+          .map((row) =>
+            adminClient.clientScopes.addClientScopeMappings(
+              {
+                id,
+                client: row.client!.id!,
+              },
+              [row.role as RoleMappingPayload]
+            )
+          )
+      );
+      addAlert(t("roleMappingUpdatedSuccess"), AlertVariant.success);
+    } catch (error) {
+      addAlert(
+        t("roleMappingUpdatedError", {
+          error: error.response?.data?.errorMessage || error,
+        }),
+        AlertVariant.danger
+      );
+    }
+  };
+
   return (
     <>
+          {showAssign && (
+        // MF 042921 hardcoded for now, to see modal displayed
+        <AddRoleMappingModal
+        id="e2d7fe7c-f7bc-4903-9562-3d079ae8667c"
+        type="client-scope"
+        name="name"
+          // id={id}
+          // type={type}
+          // name={name}
+        onAssign={assignRoles}
+        onClose={() => setShowAssign(false)}
+        />)}
+
       <FormGroup
         label={t("common:role")}
         labelIcon={
@@ -36,6 +99,12 @@ export const LdapMapperHardcodedLdapRole = ({
           name="config.role[0]"
           ref={form.register}
         />
+              <Button
+                data-testid="assignRole"
+                onClick={() => setShowAssign(true)}
+              >
+                {t("assignRole")}
+              </Button>
       </FormGroup>
     </>
   );

--- a/src/user-federation/ldap/mappers/LdapMapperHardcodedLdapRole.tsx
+++ b/src/user-federation/ldap/mappers/LdapMapperHardcodedLdapRole.tsx
@@ -43,14 +43,9 @@ export const LdapMapperHardcodedLdapRole = ({
   return (
     <>
       {showAssign && (
-        // MF 042921 hardcoded for now, to see modal displayed
         <AddRoleMappingModal
-          id="1a85c63a-99bd-4d16-9924-b38b8f7cceaf" // this is the ID for client-scopes > marks-client-scope
-          type="client-scope"
-          name="name"
-          // id={id}
-          // type={type}
-          // name={name}
+          id=""
+          type="user-fed"
           onAssign={selectRoles}
           isRadio={true}
           onClose={() => setShowAssign(false)}

--- a/src/user-federation/ldap/mappers/LdapMapperRoleGroup.tsx
+++ b/src/user-federation/ldap/mappers/LdapMapperRoleGroup.tsx
@@ -90,6 +90,7 @@ export const LdapMapperRoleGroup = ({
           type="text"
           id="kc-name-attribute"
           data-testid="name-attribute"
+          defaultValue="cn"
           name={
             isRole
               ? "config.role-name-ldap-attribute[0]"
@@ -119,6 +120,7 @@ export const LdapMapperRoleGroup = ({
           type="text"
           id="kc-object-classes"
           data-testid="object-classes"
+          defaultValue="group"
           name={
             isRole
               ? "config.role-object-classes[0]"
@@ -143,7 +145,7 @@ export const LdapMapperRoleGroup = ({
           >
             <Controller
               name="config.preserve-group-inheritance"
-              defaultValue={["false"]}
+              defaultValue={["true"]}
               control={form.control}
               render={({ onChange, value }) => (
                 <Switch
@@ -202,6 +204,7 @@ export const LdapMapperRoleGroup = ({
         <TextInput
           isRequired
           type="text"
+          defaultValue="member"
           id="kc-membership-ldap-attribute"
           data-testid="membership-ldap-attribute"
           name="config.membership-ldap-attribute[0]"
@@ -264,6 +267,7 @@ export const LdapMapperRoleGroup = ({
           type="text"
           id="kc-membership-user-ldap-attribute"
           data-testid="membership-user-ldap-attribute"
+          defaultValue="cn"
           name="config.membership-user-ldap-attribute[0]"
           ref={form.register}
         />
@@ -413,6 +417,7 @@ export const LdapMapperRoleGroup = ({
           isRequired
           type="text"
           id="kc-member-of-attribute"
+          defaultValue="memberOf"
           data-testid="member-of-attribute"
           name="config.memberof-ldap-attribute[0]"
           ref={form.register}
@@ -434,7 +439,7 @@ export const LdapMapperRoleGroup = ({
           >
             <Controller
               name="config.use-realm-roles-mapping"
-              defaultValue={["false"]}
+              defaultValue={["true"]}
               control={form.control}
               render={({ onChange, value }) => (
                 <Switch
@@ -557,6 +562,7 @@ export const LdapMapperRoleGroup = ({
               type="text"
               id="kc-path"
               data-testid="path"
+              defaultValue="/"
               name="config.groups-path[0]"
               ref={form.register}
             />

--- a/src/user-federation/ldap/mappers/LdapMapperRoleGroup.tsx
+++ b/src/user-federation/ldap/mappers/LdapMapperRoleGroup.tsx
@@ -5,6 +5,7 @@ import {
   SelectVariant,
   Switch,
   TextInput,
+  ValidatedOptions,
 } from "@patternfly/react-core";
 import React, { useState } from "react";
 import { HelpItem } from "../../../components/help-enabler/HelpItem";
@@ -77,7 +78,16 @@ export const LdapMapperRoleGroup = ({
           id="kc-ldap-dn"
           data-testid="ldap-dn"
           name={isRole ? "config.roles-dn[0]" : "config.groups-dn[0]"}
-          ref={form.register}
+          ref={form.register({ required: true })}
+          validated={
+            isRole
+              ? form.errors.config && form.errors.config["roles-dn"]
+                ? ValidatedOptions.error
+                : ValidatedOptions.default
+              : form.errors.config && form.errors.config["groups-dn"]
+              ? ValidatedOptions.error
+              : ValidatedOptions.default
+          }
         />
       </FormGroup>
       <FormGroup
@@ -297,10 +307,8 @@ export const LdapMapperRoleGroup = ({
           />
         }
         fieldId="kc-ldap-filter"
-        isRequired
       >
         <TextInput
-          isRequired
           type="text"
           id="kc-ldap-filter"
           data-testid="ldap-filter"
@@ -519,10 +527,8 @@ export const LdapMapperRoleGroup = ({
               />
             }
             fieldId="kc-mapped-attributes"
-            isRequired
           >
             <TextInput
-              isRequired
               type="text"
               id="kc-mapped-attributes"
               data-testid="mapped-attributes"
@@ -577,7 +583,12 @@ export const LdapMapperRoleGroup = ({
               data-testid="path"
               defaultValue="/"
               name="config.groups-path[0]"
-              ref={form.register}
+              ref={form.register({ required: true })}
+              validated={
+                form.errors.config && form.errors.config["groups-path"]
+                  ? ValidatedOptions.error
+                  : ValidatedOptions.default
+              }
             />
           </FormGroup>
         </>

--- a/src/user-federation/user-federation.css
+++ b/src/user-federation/user-federation.css
@@ -9,3 +9,13 @@
 .error {
   color: red;
 }
+
+.keycloak__user-federation__assign-role {
+  display: flex;
+  flex-direction: row;
+  align-items: right;
+}
+
+.keycloak__user-federation__assign-role-btn {
+  margin-left: 10px;
+}


### PR DESCRIPTION
## Motivation
https://issues.redhat.com/browse/APPDUX-929 and https://issues.redhat.com/browse/APPDUX-940

## Brief Description
Adds the 3 remaining mapper types to user federation ldap providers (group-ldap-mapper, role-ldap-mapper, and hardcoded-ldap-role-mapper). These required extra functionality than the others e.g. a modal to select from existing roles/clients. Also includes cypress tests for all 3 of the new mappers.

## Verification Steps
1. Go to User Fed and create a new LDAP provider if one doesn't already exist.
2. Go to the LDAP provider settings and click the Mappers tab.
3. Click Add mapper and choose group-ldap-mapper and verify that you can create a new one successfully.
4. Repeat for role-ldap-mapper and hardcoded-ldap-role-mapper. 
5. When configuring the role mappers, verify that you can select a role via the "Select role" button (hardcoded-ldap-role-mapper) or a client from the Client ID dropdown (role-ldap-mapper).
6. Bonus points - verify that the tests for user fed mappers all complete without errors.

## Checklist:
- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [x] Help has been implemented
- [x] Unit tests have been created/updated
- [x] Formatting has been performed via prettier/eslint
- [x] Type checking has been performed via 'yarn check-types'

## Additional Notes
None