### PR TITLE
Update to Patternfly 4.108.2 (latest release)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
     "start:cypress-tests": "cypress run"
   },
   "dependencies": {
-    "@patternfly/patternfly": "^4.103.6",
-    "@patternfly/react-core": "4.121.1",
-    "@patternfly/react-icons": "4.10.7",
-    "@patternfly/react-table": "4.27.7",
+    "@patternfly/patternfly": "^4.108.1",
+    "@patternfly/react-core": "4.128.1",
+    "@patternfly/react-icons": "4.10.10",
+    "@patternfly/react-table": "4.27.23",
     "file-saver": "^2.0.5",
     "i18next": "^20.3.1",
     "keycloak-admin": "1.14.16",
@@ -43,7 +43,7 @@
     "@babel/preset-typescript": "^7.13.0",
     "@jest/types": "^26.6.2",
     "@snowpack/app-scripts-react": "^1.10.0",
-    "@snowpack/plugin-postcss": "1.4.0",
+    "@snowpack/plugin-postcss": "1.0.4",
     "@snowpack/plugin-webpack": "2.3.1",
     "@storybook/addon-actions": "^6.2.9",
     "@storybook/addon-essentials": "^6.1.7",

--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
     "start:cypress-tests": "cypress run"
   },
   "dependencies": {
-    "@patternfly/patternfly": "^4.108.1",
-    "@patternfly/react-core": "4.128.1",
-    "@patternfly/react-icons": "4.10.10",
-    "@patternfly/react-table": "4.27.23",
+    "@patternfly/patternfly": "^4.108.2",
+    "@patternfly/react-core": "4.128.2",
+    "@patternfly/react-icons": "4.10.11",
+    "@patternfly/react-table": "4.27.24",
     "file-saver": "^2.0.5",
     "i18next": "^20.3.1",
     "keycloak-admin": "1.14.16",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@babel/preset-typescript": "^7.13.0",
     "@jest/types": "^26.6.2",
     "@snowpack/app-scripts-react": "^1.10.0",
-    "@snowpack/plugin-postcss": "1.0.4",
+    "@snowpack/plugin-postcss": "1.4.0",
     "@snowpack/plugin-webpack": "2.3.1",
     "@storybook/addon-actions": "^6.2.9",
     "@storybook/addon-essentials": "^6.1.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3026,50 +3026,50 @@
   dependencies:
     mkdirp "^1.0.4"
 
-"@patternfly/patternfly@^4.108.1":
+"@patternfly/patternfly@^4.108.2":
   version "4.108.2"
   resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-4.108.2.tgz#b6686b9865fd5d4233a15bdf04cc53bded5a8ccc"
   integrity sha512-z0VB+1CXcH+eoClYQABwapX5FURSvm1nPr6asLWwg/Z4Wuxs0RjZpC6Gb+KRm8nGQwSAcMKZY1jLfPqVnznQnw==
 
-"@patternfly/react-core@4.128.1", "@patternfly/react-core@^4.128.1":
-  version "4.128.1"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.128.1.tgz#37ce3f459eadaaa72f8784900efb1f1bf89f9b19"
-  integrity sha512-fc5icLIBxBGMCUeofh9RKCUdAMWWovKEtR23ZFGUwzquE5H2T9OhOE4RSZ2Jt3BGaWw0yZdv3/f0Zdq8KHDA5g==
+"@patternfly/react-core@4.128.2", "@patternfly/react-core@^4.128.2":
+  version "4.128.2"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.128.2.tgz#dd0c218bc75a32ee41c69e3d51bead6b157c4aae"
+  integrity sha512-EhrxE3+V7AYVhbERrcRVH7oY6TeVRqqzaRx8HXWnyn/hxE2rTzhhaLHyjotxk9mGYmIYtMuMebBHFbX0g+6Ymg==
   dependencies:
-    "@patternfly/react-icons" "^4.10.10"
-    "@patternfly/react-styles" "^4.10.10"
-    "@patternfly/react-tokens" "^4.11.11"
+    "@patternfly/react-icons" "^4.10.11"
+    "@patternfly/react-styles" "^4.10.11"
+    "@patternfly/react-tokens" "^4.11.12"
     focus-trap "6.2.2"
     react-dropzone "9.0.0"
     tippy.js "5.1.2"
     tslib "1.13.0"
 
-"@patternfly/react-icons@4.10.10", "@patternfly/react-icons@^4.10.10":
-  version "4.10.10"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.10.10.tgz#d6e7df8d16e6162a076778a486bb18fe6c6dc505"
-  integrity sha512-7A6fZut7ERTbOQJnbaTXbEjNCqjK1zOSIJdPg3VeV0hrsKfugn5MOkXVeMFYspzvHcMgRtfyBio4Wx4XPYAncA==
+"@patternfly/react-icons@4.10.11", "@patternfly/react-icons@^4.10.11":
+  version "4.10.11"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.10.11.tgz#9bed483fc37c8b795b3fb98c17ede00eef775857"
+  integrity sha512-Qyxwvghb9HZB2do3UVw4EzJSvqWaw/AEw6mFzqshZiIm2oPrL4NkvavwDt5WRicz5sbyWTZluB4grOj33PEpww==
 
-"@patternfly/react-styles@^4.10.10":
-  version "4.10.10"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-4.10.10.tgz#3f17aaf8c490d32edf36a83949fc71195269fe69"
-  integrity sha512-nrjyQLIGHOYjt1ImeA58enpIPdt4eaVqkUVIUI+urLv/e8A7YxWXoylrpOeqAh4trmE7u6muhhvDIXC+Mr96/A==
+"@patternfly/react-styles@^4.10.11":
+  version "4.10.11"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-4.10.11.tgz#6bda5673a71037c0fb9be7e11a117ed8cfea6ce0"
+  integrity sha512-M+NhTtAXreJzMAV2Z1P2pbnKpRYnWbB5iZ6mxB0tkxxG+KyZ0/se8M5rUepLOE/n7BMq8IiOjPJ9zu/vpWj0gA==
 
-"@patternfly/react-table@4.27.23":
-  version "4.27.23"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-table/-/react-table-4.27.23.tgz#2f5026db54e43f3fbcc6765916c1aa8c79cadf49"
-  integrity sha512-P+tT/4eo1mjVzBlT63umcUgyBGgAPUBmMP3EMK9eeXs8f1vFsbD3i/l/edRmw/RaamPtxwYRtzkZg103+xet9Q==
+"@patternfly/react-table@4.27.24":
+  version "4.27.24"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-table/-/react-table-4.27.24.tgz#c61947800d9c82fae3d46a03a1e9989ec49f5f61"
+  integrity sha512-LXKWtCeEJ4KR8ZnyeAPHdDQFJC9KQe/2Z7yJxBHy8gWciLAPcrLvnTtAb+d1O2lFXKMpUKFNUIwzVvuAffjDSA==
   dependencies:
-    "@patternfly/react-core" "^4.128.1"
-    "@patternfly/react-icons" "^4.10.10"
-    "@patternfly/react-styles" "^4.10.10"
-    "@patternfly/react-tokens" "^4.11.11"
+    "@patternfly/react-core" "^4.128.2"
+    "@patternfly/react-icons" "^4.10.11"
+    "@patternfly/react-styles" "^4.10.11"
+    "@patternfly/react-tokens" "^4.11.12"
     lodash "^4.17.19"
     tslib "1.13.0"
 
-"@patternfly/react-tokens@^4.11.11":
-  version "4.11.11"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.11.11.tgz#ce3ad4d7ee696cb21099402d945261edaf4ebd21"
-  integrity sha512-nxrTI3ikKoeOKzwTDCXsSWBz6GfsFfq6Na+5+v80J8TgSbb9WmsF+OZdWuBRNd17/fugx4Iz8qWoM/tujRMFkA==
+"@patternfly/react-tokens@^4.11.12":
+  version "4.11.12"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.11.12.tgz#0d4d88ec768cbf5c4b46e75dc8673ba97448823c"
+  integrity sha512-PTEc2CQa/BqcDcUwT0V02l+ZoJa+bheLlh9R5g1+JQ6vlqH31gk0dpHmj6goEcSDLkbvMJgr3kNZdJsP1VdBMg==
 
 "@pmmmwh/react-refresh-webpack-plugin@^0.4.3":
   version "0.4.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3026,50 +3026,50 @@
   dependencies:
     mkdirp "^1.0.4"
 
-"@patternfly/patternfly@^4.103.6":
-  version "4.103.6"
-  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-4.103.6.tgz#a01b1dced931eb4971a6c7366901fdde81a52284"
-  integrity sha512-veWpHv/Dlk0P7tu96QUjLzD2Aq4IysUSGOjGPXlbb/KOUfnIrErLRmQnljY01ykXLJ7kxQSnC3yaJqCU+4fDPQ==
+"@patternfly/patternfly@^4.108.1":
+  version "4.108.2"
+  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-4.108.2.tgz#b6686b9865fd5d4233a15bdf04cc53bded5a8ccc"
+  integrity sha512-z0VB+1CXcH+eoClYQABwapX5FURSvm1nPr6asLWwg/Z4Wuxs0RjZpC6Gb+KRm8nGQwSAcMKZY1jLfPqVnznQnw==
 
-"@patternfly/react-core@4.121.1", "@patternfly/react-core@^4.121.1":
-  version "4.121.1"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.121.1.tgz#25ce945c54366a202e1f581e48ff167df4d3f7fc"
-  integrity sha512-WIlh7Wd4o4r0PA2+9/fPcOxMAnc2H/InPx8rulJzD9a8KdUevl7+XDtKok6p6grKRUriV5wKPQyfZrxcb5VVHw==
+"@patternfly/react-core@4.128.1", "@patternfly/react-core@^4.128.1":
+  version "4.128.1"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.128.1.tgz#37ce3f459eadaaa72f8784900efb1f1bf89f9b19"
+  integrity sha512-fc5icLIBxBGMCUeofh9RKCUdAMWWovKEtR23ZFGUwzquE5H2T9OhOE4RSZ2Jt3BGaWw0yZdv3/f0Zdq8KHDA5g==
   dependencies:
-    "@patternfly/react-icons" "^4.10.7"
-    "@patternfly/react-styles" "^4.10.7"
-    "@patternfly/react-tokens" "^4.11.8"
+    "@patternfly/react-icons" "^4.10.10"
+    "@patternfly/react-styles" "^4.10.10"
+    "@patternfly/react-tokens" "^4.11.11"
     focus-trap "6.2.2"
     react-dropzone "9.0.0"
     tippy.js "5.1.2"
     tslib "1.13.0"
 
-"@patternfly/react-icons@4.10.7", "@patternfly/react-icons@^4.10.7":
-  version "4.10.7"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.10.7.tgz#fe2eabf88512afe7dab0c0e7c71142ec6e594664"
-  integrity sha512-CiHYDOS8jrxNiy/KIxv9vPqg3cie4SzsbQKh+eW8lj41x68IrgILiw3VvjcJeVXXJDRW36T7u3IPKjMI6zuoyA==
+"@patternfly/react-icons@4.10.10", "@patternfly/react-icons@^4.10.10":
+  version "4.10.10"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.10.10.tgz#d6e7df8d16e6162a076778a486bb18fe6c6dc505"
+  integrity sha512-7A6fZut7ERTbOQJnbaTXbEjNCqjK1zOSIJdPg3VeV0hrsKfugn5MOkXVeMFYspzvHcMgRtfyBio4Wx4XPYAncA==
 
-"@patternfly/react-styles@^4.10.7":
-  version "4.10.7"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-4.10.7.tgz#3b0ce38f3e12a69cdcbaf1ada163a5b114b919bd"
-  integrity sha512-oA9R1dXAJaKhj0/1z/uf2Z1wzsQ4jGQw2F8alPBagbDLyZD+pvUmElBr7o2Ucz/fm+/pLcphekCkGEVtyV3jOA==
+"@patternfly/react-styles@^4.10.10":
+  version "4.10.10"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-4.10.10.tgz#3f17aaf8c490d32edf36a83949fc71195269fe69"
+  integrity sha512-nrjyQLIGHOYjt1ImeA58enpIPdt4eaVqkUVIUI+urLv/e8A7YxWXoylrpOeqAh4trmE7u6muhhvDIXC+Mr96/A==
 
-"@patternfly/react-table@4.27.7":
-  version "4.27.7"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-table/-/react-table-4.27.7.tgz#f3159c703b4e5119d3f45dff7f4e9853b0b646a5"
-  integrity sha512-5lQBkXeBC5qtvum7HWPyd6PxpfO2j/UaIdy8ZeN7X0AVI96p3Zb4hH5WSTla2EAOUEmN0g16Nmxg57ZZREp+kg==
+"@patternfly/react-table@4.27.23":
+  version "4.27.23"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-table/-/react-table-4.27.23.tgz#2f5026db54e43f3fbcc6765916c1aa8c79cadf49"
+  integrity sha512-P+tT/4eo1mjVzBlT63umcUgyBGgAPUBmMP3EMK9eeXs8f1vFsbD3i/l/edRmw/RaamPtxwYRtzkZg103+xet9Q==
   dependencies:
-    "@patternfly/react-core" "^4.121.1"
-    "@patternfly/react-icons" "^4.10.7"
-    "@patternfly/react-styles" "^4.10.7"
-    "@patternfly/react-tokens" "^4.11.8"
+    "@patternfly/react-core" "^4.128.1"
+    "@patternfly/react-icons" "^4.10.10"
+    "@patternfly/react-styles" "^4.10.10"
+    "@patternfly/react-tokens" "^4.11.11"
     lodash "^4.17.19"
     tslib "1.13.0"
 
-"@patternfly/react-tokens@^4.11.8":
-  version "4.11.8"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.11.8.tgz#ea0c9ca036f6b0506cda43e899c3248971920337"
-  integrity sha512-k3UwsnWRoHHYbFbiqmUHtkrAPtw6D8BZLB1tPGzdXBlqQXRX1t8xukgDcTSUWo6wOPVdk8WrOgmWMy0u0Tk+sw==
+"@patternfly/react-tokens@^4.11.11":
+  version "4.11.11"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.11.11.tgz#ce3ad4d7ee696cb21099402d945261edaf4ebd21"
+  integrity sha512-nxrTI3ikKoeOKzwTDCXsSWBz6GfsFfq6Na+5+v80J8TgSbb9WmsF+OZdWuBRNd17/fugx4Iz8qWoM/tujRMFkA==
 
 "@pmmmwh/react-refresh-webpack-plugin@^0.4.3":
   version "0.4.3"
@@ -3243,13 +3243,10 @@
     dotenv "^8.2.0"
     dotenv-expand "^5.1.0"
 
-"@snowpack/plugin-postcss@1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@snowpack/plugin-postcss/-/plugin-postcss-1.4.0.tgz#af95fca31ac9663ad41b89d58c7473776fb6c415"
-  integrity sha512-IKJefynh4Bnpy2bXFxGFdwu9uAHvcL2jmpuiR6qZADbd1Pi6dUnRI6Ip84nYoGUMeIaGrbbHPMeAKuSlVv2GTQ==
-  dependencies:
-    postcss-load-config "^3.0.1"
-    workerpool "^6.1.2"
+"@snowpack/plugin-postcss@1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@snowpack/plugin-postcss/-/plugin-postcss-1.0.4.tgz#59a7e40bfb225525b4894d06d20d1205f476af0c"
+  integrity sha512-7znEgujAa1IECR63tx50PPjZkH3DlxIECLZVMngi1/RgRZlKAqWxkORH0y8RtrxLmszHb/TnCwRY0dK5/zJGGQ==
 
 "@snowpack/plugin-react-refresh@^2.1.0":
   version "2.1.0"
@@ -10769,13 +10766,6 @@ import-cwd@^2.0.0:
   dependencies:
     import-from "^2.1.0"
 
-import-cwd@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/import-cwd/-/import-cwd-3.0.0.tgz#20845547718015126ea9b3676b7592fb8bd4cf92"
-  integrity sha512-4pnzH16plW+hgvRECbDWpQl3cqtvSofHWh44met7ESfZ8UZOWWddm8hEyDTqREJ9RbYHY8gi8DqmaelApoOGMg==
-  dependencies:
-    import-from "^3.0.0"
-
 import-fresh@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-2.0.0.tgz#d81355c15612d386c61f9ddd3922d4304822a546"
@@ -10798,13 +10788,6 @@ import-from@^2.1.0:
   integrity sha1-M1238qev/VOqpHHUuAId7ja387E=
   dependencies:
     resolve-from "^3.0.0"
-
-import-from@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/import-from/-/import-from-3.0.0.tgz#055cfec38cd5a27d8057ca51376d7d3bf0891966"
-  integrity sha512-CiuXOFFSzkU5x/CR0+z7T91Iht4CXgfCxVOFRhh2Zyhg5wOpWvvDLQUsWl+gcN+QscYBjez8hDCt85O7RLDttQ==
-  dependencies:
-    resolve-from "^5.0.0"
 
 import-local@^3.0.2:
   version "3.0.2"
@@ -14257,14 +14240,6 @@ postcss-load-config@^2.0.0:
   dependencies:
     cosmiconfig "^5.0.0"
     import-cwd "^2.0.0"
-
-postcss-load-config@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/postcss-load-config/-/postcss-load-config-3.0.1.tgz#d214bf9cfec1608ffaf0f4161b3ba20664ab64b9"
-  integrity sha512-/pDHe30UYZUD11IeG8GWx9lNtu1ToyTsZHnyy45B4Mrwr/Kb6NgYl7k753+05CJNKnjbwh4975amoPJ+TEjHNQ==
-  dependencies:
-    cosmiconfig "^7.0.0"
-    import-cwd "^3.0.0"
 
 postcss-loader@^3.0.0:
   version "3.0.0"
@@ -18290,7 +18265,7 @@ worker-rpc@^0.1.0:
   dependencies:
     microevent.ts "~0.1.1"
 
-workerpool@^6.0.0, workerpool@^6.1.2:
+workerpool@^6.0.0:
   version "6.1.4"
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.1.4.tgz#6a972b6df82e38d50248ee2820aa98e2d0ad3090"
   integrity sha512-jGWPzsUqzkow8HoAvqaPWTUPCrlPJaJ5tY8Iz7n1uCz3tTp6s3CDG0FF1NsX42WNlkRSW6Mr+CDZGnNoSsKa7g==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3243,10 +3243,13 @@
     dotenv "^8.2.0"
     dotenv-expand "^5.1.0"
 
-"@snowpack/plugin-postcss@1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@snowpack/plugin-postcss/-/plugin-postcss-1.0.4.tgz#59a7e40bfb225525b4894d06d20d1205f476af0c"
-  integrity sha512-7znEgujAa1IECR63tx50PPjZkH3DlxIECLZVMngi1/RgRZlKAqWxkORH0y8RtrxLmszHb/TnCwRY0dK5/zJGGQ==
+"@snowpack/plugin-postcss@1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@snowpack/plugin-postcss/-/plugin-postcss-1.4.0.tgz#af95fca31ac9663ad41b89d58c7473776fb6c415"
+  integrity sha512-IKJefynh4Bnpy2bXFxGFdwu9uAHvcL2jmpuiR6qZADbd1Pi6dUnRI6Ip84nYoGUMeIaGrbbHPMeAKuSlVv2GTQ==
+  dependencies:
+    postcss-load-config "^3.0.1"
+    workerpool "^6.1.2"
 
 "@snowpack/plugin-react-refresh@^2.1.0":
   version "2.1.0"
@@ -10766,6 +10769,13 @@ import-cwd@^2.0.0:
   dependencies:
     import-from "^2.1.0"
 
+import-cwd@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/import-cwd/-/import-cwd-3.0.0.tgz#20845547718015126ea9b3676b7592fb8bd4cf92"
+  integrity sha512-4pnzH16plW+hgvRECbDWpQl3cqtvSofHWh44met7ESfZ8UZOWWddm8hEyDTqREJ9RbYHY8gi8DqmaelApoOGMg==
+  dependencies:
+    import-from "^3.0.0"
+
 import-fresh@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-2.0.0.tgz#d81355c15612d386c61f9ddd3922d4304822a546"
@@ -10788,6 +10798,13 @@ import-from@^2.1.0:
   integrity sha1-M1238qev/VOqpHHUuAId7ja387E=
   dependencies:
     resolve-from "^3.0.0"
+
+import-from@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/import-from/-/import-from-3.0.0.tgz#055cfec38cd5a27d8057ca51376d7d3bf0891966"
+  integrity sha512-CiuXOFFSzkU5x/CR0+z7T91Iht4CXgfCxVOFRhh2Zyhg5wOpWvvDLQUsWl+gcN+QscYBjez8hDCt85O7RLDttQ==
+  dependencies:
+    resolve-from "^5.0.0"
 
 import-local@^3.0.2:
   version "3.0.2"
@@ -14240,6 +14257,14 @@ postcss-load-config@^2.0.0:
   dependencies:
     cosmiconfig "^5.0.0"
     import-cwd "^2.0.0"
+
+postcss-load-config@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-load-config/-/postcss-load-config-3.0.1.tgz#d214bf9cfec1608ffaf0f4161b3ba20664ab64b9"
+  integrity sha512-/pDHe30UYZUD11IeG8GWx9lNtu1ToyTsZHnyy45B4Mrwr/Kb6NgYl7k753+05CJNKnjbwh4975amoPJ+TEjHNQ==
+  dependencies:
+    cosmiconfig "^7.0.0"
+    import-cwd "^3.0.0"
 
 postcss-loader@^3.0.0:
   version "3.0.0"
@@ -18265,7 +18290,7 @@ worker-rpc@^0.1.0:
   dependencies:
     microevent.ts "~0.1.1"
 
-workerpool@^6.0.0:
+workerpool@^6.0.0, workerpool@^6.1.2:
   version "6.1.4"
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.1.4.tgz#6a972b6df82e38d50248ee2820aa98e2d0ad3090"
   integrity sha512-jGWPzsUqzkow8HoAvqaPWTUPCrlPJaJ5tY8Iz7n1uCz3tTp6s3CDG0FF1NsX42WNlkRSW6Mr+CDZGnNoSsKa7g==


### PR DESCRIPTION
## Motivation
Update Patternfly to the latest releases so we stay current with the latest changes.

## Brief Description
As part of the Patternfly release process, I perform sanity tests of the new proposed versions on the keycloak admin UI and file issues as needed. This occurs about every 3 weeks. As part of that process, we should update keycloak to the latest versions on a regular cadence.

Note that this PR also reverts snowpack/plugin-postcss from 1.4.0 to 1.0.4 in order to fix font issues introduced with the dependabot PR.

## Verification Steps
Use the keycloak admin UI and verify that no visual or behavioral issues have been introduced, and that there are no new console warnings/errors. Also, rebuild node_modules and verify that the font 404 issues are now fixed.

## Checklist:
- [x] Code has been tested locally by PR requester
