### PR TITLE
Fix additional UX issues with User Federation

### DIFF
--- a/src/route-config.ts
+++ b/src/route-config.ts
@@ -243,7 +243,7 @@ export const routes: RoutesFn = (t: TFunction) => [
   {
     path: "/:realm/user-federation/ldap/new",
     component: UserFederationLdapSettings,
-    breadcrumb: t("common:settings"),
+    breadcrumb: t("user-federation:addOneLdap"),
     access: "view-realm",
   },
   {

--- a/src/user-federation/UserFederationLdapSettings.tsx
+++ b/src/user-federation/UserFederationLdapSettings.tsx
@@ -131,7 +131,7 @@ const LdapSettingsHeader = ({
     <>
       <DisableConfirm />
       {!id ? (
-        <ViewHeader titleKey="LDAP" />
+        <ViewHeader titleKey={t("addOneLdap")} />
       ) : (
         <ViewHeader
           titleKey="LDAP"

--- a/src/user-federation/UserFederationLdapSettings.tsx
+++ b/src/user-federation/UserFederationLdapSettings.tsx
@@ -286,6 +286,51 @@ export const UserFederationLdapSettings = () => {
     },
   });
 
+  const addLdapFormContent = () => {
+    return (
+      <>
+        <ScrollForm
+          sections={[
+            t("generalOptions"),
+            t("connectionAndAuthenticationSettings"),
+            t("ldapSearchingAndUpdatingSettings"),
+            t("synchronizationSettings"),
+            t("kerberosIntegration"),
+            t("cacheSettings"),
+            t("advancedSettings"),
+          ]}
+        >
+          <LdapSettingsGeneral form={form} />
+          <LdapSettingsConnection form={form} />
+          <LdapSettingsSearching form={form} />
+          <LdapSettingsSynchronization form={form} />
+          <LdapSettingsKerberosIntegration form={form} />
+          <SettingsCache form={form} />
+          <LdapSettingsAdvanced form={form} />
+        </ScrollForm>
+        <Form onSubmit={form.handleSubmit(save)}>
+          <ActionGroup className="keycloak__form_actions">
+            <Button
+              isDisabled={!form.formState.isDirty}
+              variant="primary"
+              type="submit"
+              data-testid="ldap-save"
+            >
+              {t("common:save")}
+            </Button>
+            <Button
+              variant="link"
+              onClick={() => history.push(`/${realm}/user-federation`)}
+              data-testid="ldap-cancel"
+            >
+              {t("common:cancel")}
+            </Button>
+          </ActionGroup>
+        </Form>
+      </>
+    );
+  };
+
   return (
     <>
       <DeleteConfirm />
@@ -305,52 +350,15 @@ export const UserFederationLdapSettings = () => {
         )}
       />
       <PageSection variant="light" isFilled>
-        <KeycloakTabs isBox>
-          <Tab
-            id="settings"
-            eventKey="settings"
-            title={<TabTitleText>{t("common:settings")}</TabTitleText>}
-          >
-            <ScrollForm
-              sections={[
-                t("generalOptions"),
-                t("connectionAndAuthenticationSettings"),
-                t("ldapSearchingAndUpdatingSettings"),
-                t("synchronizationSettings"),
-                t("kerberosIntegration"),
-                t("cacheSettings"),
-                t("advancedSettings"),
-              ]}
+        {id ? (
+          <KeycloakTabs isBox>
+            <Tab
+              id="settings"
+              eventKey="settings"
+              title={<TabTitleText>{t("common:settings")}</TabTitleText>}
             >
-              <LdapSettingsGeneral form={form} />
-              <LdapSettingsConnection form={form} />
-              <LdapSettingsSearching form={form} />
-              <LdapSettingsSynchronization form={form} />
-              <LdapSettingsKerberosIntegration form={form} />
-              <SettingsCache form={form} />
-              <LdapSettingsAdvanced form={form} />
-            </ScrollForm>
-            <Form onSubmit={form.handleSubmit(save)}>
-              <ActionGroup className="keycloak__form_actions">
-                <Button
-                  isDisabled={!form.formState.isDirty}
-                  variant="primary"
-                  type="submit"
-                  data-testid="ldap-save"
-                >
-                  {t("common:save")}
-                </Button>
-                <Button
-                  variant="link"
-                  onClick={() => history.push(`/${realm}/user-federation`)}
-                  data-testid="ldap-cancel"
-                >
-                  {t("common:cancel")}
-                </Button>
-              </ActionGroup>
-            </Form>
-          </Tab>
-          {id && (
+              {addLdapFormContent()}
+            </Tab>
             <Tab
               id="mappers"
               eventKey="mappers"
@@ -359,8 +367,10 @@ export const UserFederationLdapSettings = () => {
             >
               <LdapMapperList />
             </Tab>
-          )}
-        </KeycloakTabs>
+          </KeycloakTabs>
+        ) : (
+          addLdapFormContent()
+        )}
       </PageSection>
     </>
   );

--- a/src/user-federation/messages.json
+++ b/src/user-federation/messages.json
@@ -7,6 +7,7 @@
     "providers": "Add providers",
     "addKerberos": "Add Kerberos providers",
     "addLdap": "Add LDAP providers",
+    "addOneLdap": "Add LDAP provider",
     "addKerberosWizardTitle": "Add Kerberos user federation provider",
     "addLdapWizardTitle": "Add LDAP user federation provider",
 


### PR DESCRIPTION
## Motivation
Additional items recently added to the User Fed UX review:
https://github.com/keycloak/keycloak-admin-ui/issues/436 (see bottom)

## Brief Description
Fixes 3 UX issues:
- Should not be a tab bar and tabs on the LDAP provider creation page, just when editing an existing LDAP provider.
- When creating an LDAP provider, the breadcrumb should be **User federation > Add LDAP provider** instead of **User Federation > Settings**.
- When creating an LDAP provider, the page title should be **Add LDAP provider** instead of **LDAP**.

## Verification Steps
1. Create a new LDAP provider and verify that the same configuration and scroll appear without tabs.
2. Verify that the breadcrumb and title on the create LDAP provider page are correct as noted above.
3. Edit an existing LDAP provider and verify that the Settings and Mapper configurations appear within tabs.

## Checklist:
- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [x] Help has been implemented
- [x] Unit tests have been created/updated
- [x] Formatting has been performed via prettier/eslint
- [x] Type checking has been performed via 'yarn check-types'

## Additional Notes
All existing user federation cypress tests passed.