### PR TITLE
Localization tab

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -54,3 +54,7 @@ td.pf-c-table__check > input {
   margin-top: var(--pf-c-table__check--input--MarginTop);
   vertical-align: baseline;
 }
+
+.pf-c-pagination.pf-m-bottom.pf-m-compact {
+  padding: 0px;
+}

--- a/src/realm-settings/KeysProvidersTab.tsx
+++ b/src/realm-settings/KeysProvidersTab.tsx
@@ -95,12 +95,15 @@ export const KeysTabInner = ({ components, refresh }: KeysTabInnerProps) => {
     setItemOrder(["data", ...itemIds]);
   }, [components, searchVal]);
 
+  console.log("realm", realm);
+
   const [toggleDeleteDialog, DeleteConfirm] = useConfirmDialog({
     titleKey: "realm-settings:deleteProviderTitle",
     messageKey: t("deleteProviderConfirm") + selectedComponent?.name + "?",
     continueButtonLabel: "common:delete",
     continueButtonVariant: ButtonVariant.danger,
     onConfirm: async () => {
+      console.log(selectedComponent);
       try {
         await adminClient.components.del({
           id: selectedComponent!.id!,

--- a/src/realm-settings/KeysProvidersTab.tsx
+++ b/src/realm-settings/KeysProvidersTab.tsx
@@ -95,15 +95,12 @@ export const KeysTabInner = ({ components, refresh }: KeysTabInnerProps) => {
     setItemOrder(["data", ...itemIds]);
   }, [components, searchVal]);
 
-  console.log("realm", realm);
-
   const [toggleDeleteDialog, DeleteConfirm] = useConfirmDialog({
     titleKey: "realm-settings:deleteProviderTitle",
     messageKey: t("deleteProviderConfirm") + selectedComponent?.name + "?",
     continueButtonLabel: "common:delete",
     continueButtonVariant: ButtonVariant.danger,
     onConfirm: async () => {
-      console.log(selectedComponent);
       try {
         await adminClient.components.del({
           id: selectedComponent!.id!,

--- a/src/realm-settings/LocalizationTab.tsx
+++ b/src/realm-settings/LocalizationTab.tsx
@@ -231,7 +231,7 @@ export const LocalizationTab = ({
           </FormAccess>
         </FormPanel>
 
-        <FormPanel className="kc-login-screen" title="Edit message bundle">
+        <FormPanel className="kc-login-screen" title="Edit message bundles">
           <TextContent className="messageBundleDescription">
             {t("messageBundleDescription")}
           </TextContent>
@@ -244,9 +244,8 @@ export const LocalizationTab = ({
               emptyState={
                 <ListEmptyState
                   hasIcon={true}
-                  icon={SearchIcon}
-                  message={t("common:noSearchResults")}
-                  instructions={t("common:noSearchResultsInstructions")}
+                  message={t("noMessageBundles")}
+                  instructions={t("noMessageBundlesInstructions")}
                   onPrimaryAction={() => {}}
                 />
               }

--- a/src/realm-settings/LocalizationTab.tsx
+++ b/src/realm-settings/LocalizationTab.tsx
@@ -41,8 +41,8 @@ export const LocalizationTab = ({
   const [supportedLocalesOpen, setSupportedLocalesOpen] = useState(false);
   const [defaultLocaleOpen, setDefaultLocaleOpen] = useState(false);
 
-  const { control, handleSubmit } = useFormContext();
-  const [selectedLocale, setSelectedLocale] = useState("en");
+  const { getValues, control, handleSubmit } = useFormContext();
+  // const [selectedLocale, setSelectedLocale] = useState("en");
   const [valueSelected, setValueSelected] = useState(false);
   const themeTypes = useServerInfo().themes!;
 
@@ -61,9 +61,9 @@ export const LocalizationTab = ({
   const loader = async () => {
     if (realm) {
       const response = await fetch(
-        `${getBaseUrl(adminClient)}admin/realms/${
-          realm.realm
-        }/localization/${selectedLocale}`,
+        `${getBaseUrl(adminClient)}admin/realms/${realm.realm}/localization/${
+          getValues("defaultLocale") || "en"
+        }`,
         {
           method: "GET",
           headers: {
@@ -187,7 +187,7 @@ export const LocalizationTab = ({
                         onSelect={(_, value) => {
                           onChange(value as string);
                           setValueSelected(true);
-                          setSelectedLocale(value as string);
+                          // setSelectedLocale(value as string);
                           setKey(new Date().getTime());
                           setDefaultLocaleOpen(false);
                         }}
@@ -195,7 +195,11 @@ export const LocalizationTab = ({
                           valueSelected
                             ? t(`allSupportedLocales.${value}`)
                             : realm.defaultLocale !== ""
-                            ? t(`allSupportedLocales.${realm?.defaultLocale}`)
+                            ? t(
+                                `allSupportedLocales.${
+                                  realm.defaultLocale || "en"
+                                }`
+                              )
                             : t("placeholderText")
                         }
                         variant={SelectVariant.single}

--- a/src/realm-settings/LocalizationTab.tsx
+++ b/src/realm-settings/LocalizationTab.tsx
@@ -60,7 +60,6 @@ export const LocalizationTab = ({
 
   const loader = async () => {
     if (realm) {
-
       const response = await fetch(
         `${getBaseUrl(adminClient)}admin/realms/${
           realm.realm
@@ -100,13 +99,13 @@ export const LocalizationTab = ({
               <Controller
                 name="internationalizationEnabled"
                 control={control}
-                defaultValue={false}
+                defaultValue={realm?.internationalizationEnabled}
                 render={({ onChange, value }) => (
                   <Switch
                     id="kc-l-internationalization"
                     label={t("common:enabled")}
                     labelOff={t("common:disabled")}
-                    isChecked={internationalizationEnabled}
+                    isChecked={value}
                     data-testid={
                       value
                         ? "internationalization-enabled"

--- a/src/realm-settings/LocalizationTab.tsx
+++ b/src/realm-settings/LocalizationTab.tsx
@@ -1,0 +1,269 @@
+import React, { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Controller, useFormContext, useWatch } from "react-hook-form";
+import {
+  ActionGroup,
+  Button,
+  FormGroup,
+  PageSection,
+  Select,
+  SelectOption,
+  SelectVariant,
+  Switch,
+  TextContent,
+} from "@patternfly/react-core";
+
+import type RealmRepresentation from "keycloak-admin/lib/defs/realmRepresentation";
+import { FormAccess } from "../components/form-access/FormAccess";
+import { useServerInfo } from "../context/server-info/ServerInfoProvider";
+import { FormPanel } from "../components/scroll-form/FormPanel";
+import { KeycloakDataTable } from "../components/table-toolbar/KeycloakDataTable";
+import { useAdminClient } from "../context/auth/AdminClient";
+import { getBaseUrl } from "../util";
+import { ListEmptyState } from "../components/list-empty-state/ListEmptyState";
+import { SearchIcon } from "@patternfly/react-icons";
+
+type LocalizationTabProps = {
+  save: (realm: RealmRepresentation) => void;
+  reset: () => void;
+  refresh: () => void;
+  realm: RealmRepresentation;
+};
+
+export const LocalizationTab = ({
+  save,
+  reset,
+  realm,
+}: LocalizationTabProps) => {
+  const { t } = useTranslation("realm-settings");
+  const adminClient = useAdminClient();
+  const [key, setKey] = useState(0);
+
+  const [supportedLocalesOpen, setSupportedLocalesOpen] = useState(false);
+  const [defaultLocaleOpen, setDefaultLocaleOpen] = useState(false);
+
+  const { control, handleSubmit } = useFormContext();
+  const [selectedLocale, setSelectedLocale] = useState("en");
+  const themeTypes = useServerInfo().themes!;
+
+  const watchSupportedLocales = useWatch({
+    control,
+    name: "supportedLocales",
+    defaultValue: themeTypes?.account![0].locales,
+  });
+
+  const internationalizationEnabled = useWatch({
+    control,
+    name: "internationalizationEnabled",
+    defaultValue: false,
+  });
+
+  const loader = async () => {
+    if (realm) {
+
+      const response = await fetch(
+        `${getBaseUrl(adminClient)}admin/realms/${
+          realm.realm
+        }/localization/${selectedLocale}`,
+        {
+          method: "GET",
+          headers: {
+            Authorization: `bearer ${await adminClient.getAccessToken()}`,
+          },
+        }
+      );
+
+      const result = await response.json();
+      const resultTest = Object.keys(result).map((key) => [key, result[key]]);
+      return resultTest;
+    }
+    return [[]];
+  };
+
+  return (
+    <>
+      <PageSection variant="light">
+        <FormPanel
+          className="kc-login-screen"
+          title="Login screen customization"
+        >
+          <FormAccess
+            isHorizontal
+            role="manage-realm"
+            className="pf-u-mt-lg"
+            onSubmit={handleSubmit(save)}
+          >
+            <FormGroup
+              label={t("internationalization")}
+              fieldId="kc-internationalization"
+            >
+              <Controller
+                name="internationalizationEnabled"
+                control={control}
+                defaultValue={false}
+                render={({ onChange, value }) => (
+                  <Switch
+                    id="kc-l-internationalization"
+                    label={t("common:enabled")}
+                    labelOff={t("common:disabled")}
+                    isChecked={internationalizationEnabled}
+                    data-testid={
+                      value
+                        ? "internationalization-enabled"
+                        : "internationalization-disabled"
+                    }
+                    onChange={onChange}
+                  />
+                )}
+              />
+            </FormGroup>
+            {internationalizationEnabled && (
+              <>
+                <FormGroup
+                  label={t("supportedLocales")}
+                  fieldId="kc-l-supported-locales"
+                >
+                  <Controller
+                    name="supportedLocales"
+                    control={control}
+                    defaultValue={themeTypes?.account![0].locales}
+                    render={({ value, onChange }) => (
+                      <Select
+                        toggleId="kc-l-supported-locales"
+                        onToggle={() => {
+                          setSupportedLocalesOpen(!supportedLocalesOpen);
+                        }}
+                        onSelect={(_, v) => {
+                          const option = v as string;
+                          if (!value) {
+                            onChange([option]);
+                          } else if (value!.includes(option)) {
+                            onChange(
+                              value.filter((item: string) => item !== option)
+                            );
+                          } else {
+                            onChange([...value, option]);
+                          }
+                        }}
+                        onClear={() => {
+                          onChange([]);
+                        }}
+                        selections={value}
+                        variant={SelectVariant.typeaheadMulti}
+                        aria-label={t("supportedLocales")}
+                        isOpen={supportedLocalesOpen}
+                        placeholderText={"Select locales"}
+                      >
+                        {themeTypes?.login![0].locales.map(
+                          (locale: string, idx: number) => (
+                            <SelectOption
+                              selected={true}
+                              key={`locale-${idx}`}
+                              value={locale}
+                            >
+                              {t(`allSupportedLocales.${locale}`)}
+                            </SelectOption>
+                          )
+                        )}
+                      </Select>
+                    )}
+                  />
+                </FormGroup>
+                <FormGroup
+                  label={t("defaultLocale")}
+                  fieldId="kc-l-default-locale"
+                >
+                  <Controller
+                    name="defaultLocale"
+                    control={control}
+                    defaultValue={realm?.defaultLocale}
+                    render={({ onChange, value }) => (
+                      <Select
+                        toggleId="kc-default-locale"
+                        onToggle={() =>
+                          setDefaultLocaleOpen(!defaultLocaleOpen)
+                        }
+                        onSelect={(_, value) => {
+                          onChange(value as string);
+                          setSelectedLocale(value as string);
+                          setKey(new Date().getTime());
+                          setDefaultLocaleOpen(false);
+                        }}
+                        selections={
+                          realm?.defaultLocale &&
+                          t(`allSupportedLocales.${value}`)
+                        }
+                        variant={SelectVariant.single}
+                        aria-label={t("defaultLocale")}
+                        isOpen={defaultLocaleOpen}
+                        placeholderText="Select one"
+                        data-testid="select-default-locale"
+                      >
+                        {watchSupportedLocales.map(
+                          (locale: string, idx: number) => (
+                            <SelectOption
+                              key={`default-locale-${idx}`}
+                              value={locale}
+                            >
+                              {t(`allSupportedLocales.${locale}`)}
+                            </SelectOption>
+                          )
+                        )}
+                      </Select>
+                    )}
+                  />
+                </FormGroup>
+              </>
+            )}
+            <ActionGroup>
+              <Button
+                variant="primary"
+                type="submit"
+                data-testid="themes-tab-save"
+              >
+                {t("common:save")}
+              </Button>
+              <Button variant="link" onClick={reset}>
+                {t("common:revert")}
+              </Button>
+            </ActionGroup>
+          </FormAccess>
+        </FormPanel>
+
+        <FormPanel className="kc-login-screen" title="Edit message bundle">
+          <TextContent className="messageBundleDescription">
+            {t("messageBundleDescription")}
+          </TextContent>
+          <div className="tableBorder">
+            <KeycloakDataTable
+              key={key}
+              loader={loader}
+              ariaLabelKey="client-scopes:clientScopeList"
+              searchPlaceholderKey=" "
+              emptyState={
+                <ListEmptyState
+                  hasIcon={true}
+                  icon={SearchIcon}
+                  message={t("common:noSearchResults")}
+                  instructions={t("common:noSearchResultsInstructions")}
+                  onPrimaryAction={() => {}}
+                />
+              }
+              canSelectAll
+              columns={[
+                {
+                  name: "Key",
+                  cellRenderer: (row) => row[0],
+                },
+                {
+                  name: "Value",
+                  cellRenderer: (row) => row[1],
+                },
+              ]}
+            />
+          </div>
+        </FormPanel>
+      </PageSection>
+    </>
+  );
+};

--- a/src/realm-settings/LocalizationTab.tsx
+++ b/src/realm-settings/LocalizationTab.tsx
@@ -205,7 +205,7 @@ export const LocalizationTab = ({
                               key={`default-locale-${idx}`}
                               value={locale}
                             >
-                              {/* {t(`allSupportedLocales.${locale}`)} */}
+                              {t(`allSupportedLocales.${locale}`)}
                             </SelectOption>
                           )
                         )}

--- a/src/realm-settings/LocalizationTab.tsx
+++ b/src/realm-settings/LocalizationTab.tsx
@@ -43,6 +43,7 @@ export const LocalizationTab = ({
 
   const { control, handleSubmit } = useFormContext();
   const [selectedLocale, setSelectedLocale] = useState("en");
+  const [valueSelected, setValueSelected] = useState(false);
   const themeTypes = useServerInfo().themes!;
 
   const watchSupportedLocales = useWatch({
@@ -104,7 +105,7 @@ export const LocalizationTab = ({
                     id="kc-l-internationalization"
                     label={t("common:enabled")}
                     labelOff={t("common:disabled")}
-                    isChecked={value}
+                    isChecked={internationalizationEnabled}
                     data-testid={
                       value
                         ? "internationalization-enabled"
@@ -185,18 +186,22 @@ export const LocalizationTab = ({
                         }
                         onSelect={(_, value) => {
                           onChange(value as string);
+                          setValueSelected(true);
                           setSelectedLocale(value as string);
                           setKey(new Date().getTime());
                           setDefaultLocaleOpen(false);
                         }}
                         selections={
-                          realm?.defaultLocale &&
-                          t(`allSupportedLocales.${value}`)
+                          valueSelected
+                            ? t(`allSupportedLocales.${value}`)
+                            : realm.defaultLocale !== ""
+                            ? t(`allSupportedLocales.${realm?.defaultLocale}`)
+                            : t("placeholderText")
                         }
                         variant={SelectVariant.single}
                         aria-label={t("defaultLocale")}
                         isOpen={defaultLocaleOpen}
-                        placeholderText="Select one"
+                        placeholderText={t("placeholderText")}
                         data-testid="select-default-locale"
                       >
                         {watchSupportedLocales.map(

--- a/src/realm-settings/LocalizationTab.tsx
+++ b/src/realm-settings/LocalizationTab.tsx
@@ -21,7 +21,6 @@ import { KeycloakDataTable } from "../components/table-toolbar/KeycloakDataTable
 import { useAdminClient } from "../context/auth/AdminClient";
 import { getBaseUrl } from "../util";
 import { ListEmptyState } from "../components/list-empty-state/ListEmptyState";
-import { SearchIcon } from "@patternfly/react-icons";
 
 type LocalizationTabProps = {
   save: (realm: RealmRepresentation) => void;
@@ -55,7 +54,7 @@ export const LocalizationTab = ({
   const internationalizationEnabled = useWatch({
     control,
     name: "internationalizationEnabled",
-    defaultValue: false,
+    defaultValue: realm?.internationalizationEnabled,
   });
 
   const loader = async () => {

--- a/src/realm-settings/LocalizationTab.tsx
+++ b/src/realm-settings/LocalizationTab.tsx
@@ -219,7 +219,7 @@ export const LocalizationTab = ({
               <Button
                 variant="primary"
                 type="submit"
-                data-testid="themes-tab-save"
+                data-testid="localization-tab-save"
               >
                 {t("common:save")}
               </Button>

--- a/src/realm-settings/LocalizationTab.tsx
+++ b/src/realm-settings/LocalizationTab.tsx
@@ -126,7 +126,7 @@ export const LocalizationTab = ({
                     name="supportedLocales"
                     control={control}
                     defaultValue={themeTypes?.account![0].locales}
-                    render={({ value, onChange }) => (
+                    render={({ onChange }) => (
                       <Select
                         toggleId="kc-l-supported-locales"
                         onToggle={() => {
@@ -134,20 +134,22 @@ export const LocalizationTab = ({
                         }}
                         onSelect={(_, v) => {
                           const option = v as string;
-                          if (!value) {
+                          if (!watchSupportedLocales) {
                             onChange([option]);
-                          } else if (value!.includes(option)) {
+                          } else if (watchSupportedLocales!.includes(option)) {
                             onChange(
-                              value.filter((item: string) => item !== option)
+                              watchSupportedLocales.filter(
+                                (item: string) => item !== option
+                              )
                             );
                           } else {
-                            onChange([...value, option]);
+                            onChange([...watchSupportedLocales, option]);
                           }
                         }}
                         onClear={() => {
                           onChange([]);
                         }}
-                        selections={value}
+                        selections={watchSupportedLocales}
                         variant={SelectVariant.typeaheadMulti}
                         aria-label={t("supportedLocales")}
                         isOpen={supportedLocalesOpen}
@@ -204,7 +206,7 @@ export const LocalizationTab = ({
                               key={`default-locale-${idx}`}
                               value={locale}
                             >
-                              {t(`allSupportedLocales.${locale}`)}
+                              {/* {t(`allSupportedLocales.${locale}`)} */}
                             </SelectOption>
                           )
                         )}

--- a/src/realm-settings/RSAGeneratedModal.tsx
+++ b/src/realm-settings/RSAGeneratedModal.tsx
@@ -214,8 +214,9 @@ export const RSAGeneratedModal = ({
               }
             >
               <Controller
-                name="algorithm"
-                defaultValue=""
+                name="config.algorithm"
+                control={control}
+                defaultValue={["RS256"]}
                 render={({ onChange, value }) => (
                   <Select
                     toggleId="kc-rsa-algorithm"
@@ -223,7 +224,7 @@ export const RSAGeneratedModal = ({
                       setIsRSAalgDropdownOpen(!isRSAalgDropdownOpen)
                     }
                     onSelect={(_, value) => {
-                      onChange(value as string);
+                      onChange([value + ""]);
                       setIsRSAalgDropdownOpen(false);
                     }}
                     selections={[value + ""]}

--- a/src/realm-settings/RealmSettingsSection.css
+++ b/src/realm-settings/RealmSettingsSection.css
@@ -80,3 +80,15 @@ button.pf-c-button.pf-m-link.add-provider {
 .add-provider-modal > div.pf-c-modal-box__body {
   overflow: visible;
 }
+
+.pf-c-content.messageBundleDescription {
+  max-width: 1024px;
+  padding-bottom: var(--pf-global--spacer--lg);
+}
+
+div.tableBorder {
+  border-style: solid;
+  border-width: 1px;
+  border-color: var(--pf-global--BorderColor--100);
+  max-width: 1024px;
+}

--- a/src/realm-settings/RealmSettingsSection.tsx
+++ b/src/realm-settings/RealmSettingsSection.tsx
@@ -276,6 +276,7 @@ export const RealmSettingsSection = () => {
               <RealmSettingsThemesTab
                 save={save}
                 reset={() => setupForm(realm!)}
+                realm={realm!}
               />
             </Tab>
             <Tab

--- a/src/realm-settings/RealmSettingsSection.tsx
+++ b/src/realm-settings/RealmSettingsSection.tsx
@@ -31,6 +31,7 @@ import { EventsTab } from "./event-config/EventsTab";
 import type ComponentRepresentation from "keycloak-admin/lib/defs/componentRepresentation";
 import { KeysProviderTab } from "./KeysProvidersTab";
 import { useServerInfo } from "../context/server-info/ServerInfoProvider";
+import { LocalizationTab } from "./LocalizationTab";
 
 type RealmSettingsHeaderProps = {
   onChange: (value: boolean) => void;
@@ -129,9 +130,9 @@ export const RealmSettingsSection = () => {
   const { addAlert } = useAlerts();
   const form = useForm();
   const { control, getValues, setValue, reset: resetForm } = form;
+  const [key, setKey] = useState(0);
   const [realm, setRealm] = useState<RealmRepresentation>();
   const [activeTab, setActiveTab] = useState(0);
-  const [key, setKey] = useState(0);
   const [realmComponents, setRealmComponents] = useState<
     ComponentRepresentation[]
   >();
@@ -195,6 +196,17 @@ export const RealmSettingsSection = () => {
   useEffect(() => {
     if (realm) setupForm(realm);
   }, [realm]);
+
+  useEffect(() => {
+    const update = async () => {
+      const realmComponents = await adminClient.components.find({
+        type: "org.keycloak.keys.KeyProvider",
+        realm: realmName,
+      });
+      setRealmComponents(realmComponents);
+    };
+    setTimeout(update, 100);
+  }, [key]);
 
   const setupForm = (realm: RealmRepresentation) => {
     resetForm(realm);
@@ -304,6 +316,20 @@ export const RealmSettingsSection = () => {
               data-testid="rs-realm-events-tab"
             >
               <EventsTab />
+            </Tab>
+
+            <Tab
+              id="localization"
+              eventKey="localization"
+              title={<TabTitleText>{t("localization")}</TabTitleText>}
+            >
+              <LocalizationTab
+                key={key}
+                refresh={refresh}
+                save={save}
+                reset={() => setupForm(realm!)}
+                realm={realm!}
+              />
             </Tab>
           </KeycloakTabs>
         </FormProvider>

--- a/src/realm-settings/RealmSettingsSection.tsx
+++ b/src/realm-settings/RealmSettingsSection.tsx
@@ -319,19 +319,22 @@ export const RealmSettingsSection = () => {
               <EventsTab />
             </Tab>
 
-            <Tab
-              id="localization"
-              eventKey="localization"
-              title={<TabTitleText>{t("localization")}</TabTitleText>}
-            >
-              <LocalizationTab
-                key={key}
-                refresh={refresh}
-                save={save}
-                reset={() => setupForm(realm!)}
-                realm={realm!}
-              />
-            </Tab>
+            {realm && (
+              <Tab
+                id="localization"
+                eventKey="localization"
+                title={<TabTitleText>{t("localization")}</TabTitleText>}
+              >
+                <LocalizationTab
+                  key={key}
+                  refresh={refresh}
+                  save={save}
+                  reset={() => setupForm(realm)}
+                  realm={realm}
+                />
+              </Tab>
+            )}
+
           </KeycloakTabs>
         </FormProvider>
       </PageSection>

--- a/src/realm-settings/RealmSettingsSection.tsx
+++ b/src/realm-settings/RealmSettingsSection.tsx
@@ -150,17 +150,6 @@ export const RealmSettingsSection = () => {
     []
   );
 
-  useEffect(() => {
-    const update = async () => {
-      const realmComponents = await adminClient.components.find({
-        type: "org.keycloak.keys.KeyProvider",
-        realm: realmName,
-      });
-      setRealmComponents(realmComponents);
-    };
-    setTimeout(update, 100);
-  }, [key]);
-
   useFetch(
     async () => {
       const realm = await adminClient.realms.findOne({ realm: realmName });
@@ -175,7 +164,7 @@ export const RealmSettingsSection = () => {
       setRealm(result.realm);
       setRealmComponents(result.realmComponents);
     },
-    []
+    [key]
   );
 
   const refresh = () => {
@@ -183,30 +172,8 @@ export const RealmSettingsSection = () => {
   };
 
   useEffect(() => {
-    const update = async () => {
-      const realmComponents = await adminClient.components.find({
-        type: "org.keycloak.keys.KeyProvider",
-        realm: realmName,
-      });
-      setRealmComponents(realmComponents);
-    };
-    setTimeout(update, 100);
-  }, [key]);
-
-  useEffect(() => {
     if (realm) setupForm(realm);
   }, [realm]);
-
-  useEffect(() => {
-    const update = async () => {
-      const realmComponents = await adminClient.components.find({
-        type: "org.keycloak.keys.KeyProvider",
-        realm: realmName,
-      });
-      setRealmComponents(realmComponents);
-    };
-    setTimeout(update, 100);
-  }, [key]);
 
   const setupForm = (realm: RealmRepresentation) => {
     resetForm(realm);
@@ -334,7 +301,6 @@ export const RealmSettingsSection = () => {
                 />
               </Tab>
             )}
-
           </KeycloakTabs>
         </FormProvider>
       </PageSection>

--- a/src/realm-settings/ThemesTab.tsx
+++ b/src/realm-settings/ThemesTab.tsx
@@ -20,11 +20,13 @@ import { useServerInfo } from "../context/server-info/ServerInfoProvider";
 type RealmSettingsThemesTabProps = {
   save: (realm: RealmRepresentation) => void;
   reset: () => void;
+  realm: RealmRepresentation;
 };
 
 export const RealmSettingsThemesTab = ({
   save,
   reset,
+  realm,
 }: RealmSettingsThemesTabProps) => {
   const { t } = useTranslation("realm-settings");
 
@@ -49,7 +51,7 @@ export const RealmSettingsThemesTab = ({
   const internationalizationEnabled = useWatch({
     control,
     name: "internationalizationEnabled",
-    defaultValue: false,
+    defaultValue: realm?.internationalizationEnabled,
   });
 
   return (
@@ -242,7 +244,7 @@ export const RealmSettingsThemesTab = ({
             <Controller
               name="internationalizationEnabled"
               control={control}
-              defaultValue={false}
+              defaultValue={internationalizationEnabled}
               render={({ onChange, value }) => (
                 <Switch
                   id="kc-t-internationalization"

--- a/src/realm-settings/ThemesTab.tsx
+++ b/src/realm-settings/ThemesTab.tsx
@@ -245,7 +245,7 @@ export const RealmSettingsThemesTab = ({
               defaultValue={false}
               render={({ onChange, value }) => (
                 <Switch
-                  id="kc-internationalization"
+                  id="kc-t-internationalization"
                   label={t("common:enabled")}
                   labelOff={t("common:disabled")}
                   isChecked={value}
@@ -263,7 +263,7 @@ export const RealmSettingsThemesTab = ({
             <>
               <FormGroup
                 label={t("supportedLocales")}
-                fieldId="kc-supported-locales"
+                fieldId="kc-t-supported-locales"
               >
                 <Controller
                   name="supportedLocales"
@@ -271,7 +271,7 @@ export const RealmSettingsThemesTab = ({
                   defaultValue={themeTypes?.account![0].locales}
                   render={({ value, onChange }) => (
                     <Select
-                      toggleId="kc-supported-locales"
+                      toggleId="kc-t-supported-locales"
                       onToggle={() => {
                         setSupportedLocalesOpen(!supportedLocalesOpen);
                       }}
@@ -318,7 +318,7 @@ export const RealmSettingsThemesTab = ({
                   defaultValue=""
                   render={({ onChange, value }) => (
                     <Select
-                      toggleId="kc-default-locale"
+                      toggleId="kc-t-default-locale"
                       onToggle={() => setDefaultLocaleOpen(!defaultLocaleOpen)}
                       onSelect={(_, value) => {
                         onChange(value as string);

--- a/src/realm-settings/messages.json
+++ b/src/realm-settings/messages.json
@@ -490,6 +490,8 @@
     "events-disable-title": "Unsave events?",
     "events-disable-confirm": "If \"Save events\" is disabled, subsequent events will not be displayed in the \"Events\" menu",
     "confirm": "Confirm",
+    "noMessageBundles": "No message bundles",
+    "noMessageBundlesInstructions": "Add a message bundle to get started.",
     "messageBundleDescription": "You can edit the supported locales. If you haven't selected supported locales yet, you can only edit the English locale."
   },
   "partial-import": {

--- a/src/realm-settings/messages.json
+++ b/src/realm-settings/messages.json
@@ -1,4 +1,3 @@
-  
 {
   "realm-settings": {
     "partialImport": "Partial import",
@@ -123,6 +122,7 @@
       "tr": "Türkçe",
       "zh-CN": "中文"
     },
+    "placeholderText": "Select one",
     "userManagedAccess": "User-managed access",
     "endpoints": "Endpoints",
     "openIDEndpointConfiguration": "OpenID Endpoint Configuration",
@@ -475,7 +475,6 @@
         "name": "Refresh token error",
         "description": "Refresh token error"
       }
-
     },
     "emptyEvents": "Nothing to add",
     "emptyEventsInstructions": "There are no more events types left to add",

--- a/src/realm-settings/messages.json
+++ b/src/realm-settings/messages.json
@@ -490,7 +490,7 @@
     "events-disable-title": "Unsave events?",
     "events-disable-confirm": "If \"Save events\" is disabled, subsequent events will not be displayed in the \"Events\" menu",
     "confirm": "Confirm",
-    "messageBundleDescription": "You can edit the supported locales.If you haven't selected supported locales yet, you can only edit the English locale."
+    "messageBundleDescription": "You can edit the supported locales. If you haven't selected supported locales yet, you can only edit the English locale."
   },
   "partial-import": {
     "partialImportHeaderText": "Partial import allows you to import users, clients, and resources from a previously exported json file.",

--- a/src/realm-settings/messages.json
+++ b/src/realm-settings/messages.json
@@ -132,6 +132,9 @@
     "adminTheme": "Admin console theme",
     "emailTheme": "Email theme",
     "internationalization": "Internationalization",
+    "localization": "Localization",
+    "key": "Key",
+    "value": "Value",
     "supportedLocales": "Supported locales",
     "defaultLocale": "Default locale",
 
@@ -486,7 +489,8 @@
     "user-events-cleared-error": "Could not clear the user events {{error}}",
     "events-disable-title": "Unsave events?",
     "events-disable-confirm": "If \"Save events\" is disabled, subsequent events will not be displayed in the \"Events\" menu",
-    "confirm": "Confirm"
+    "confirm": "Confirm",
+    "messageBundleDescription": "You can edit the supported locales.If you haven't selected supported locales yet, you can only edit the English locale."
   },
   "partial-import": {
     "partialImportHeaderText": "Partial import allows you to import users, clients, and resources from a previously exported json file.",


### PR DESCRIPTION
## Motivation
<!-- Add references to relevant tickets, issues, design specs and/or a short description of what motivated you to do it. -->
Closes #682 

## Brief Description
<!-- Add a short answer for: 
What was done in this PR? (e.g Fix to prevent users from accessing feature X.)
Why it was done? (e.g Feature X was deprecated.)
-->
Towards https://issues.redhat.com/browse/APPDUX-937

## Verification Steps
<!--
Add the steps required to verify this change. Keep in mind that these steps should be written so groups unfamiliar with the 
new functionality can follow them, such as QE or documentation.-->

1. Go to the old admin console.
2. Navigate to Realm settings -> Localization 
3. Create a locale: you must name it any of the following: ca, cs, da, de, en, es, fr, hu, it, ja, lt, nl, no, pl, pt-BR, ru, sk, sv, tr, zh-CN
4. Add at least one key, value pair and click save.
5. Go to the new console. 
6. Navigate to Realm settings -> localization 
7. Comment out https://github.com/keycloak/keycloak-admin-ui/compare/master...jenny-s51:localizationTab?expand=1#diff-6a013ef3899e308f424b7fd2f79cee59df8f9f2989832ece8ccf14d4081aa2abR207
7. Enable Internationalization and select your new locale as the "default locale". 
8. Verify that the key-value mappings are listed in the table below. 

## Checklist:

- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [x] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [x] Unit tests have been created/updated
- [x] Formatting has been performed via prettier/eslint
- [x] Type checking has been performed via 'yarn check-types'

## Additional Notes
<!-- 
Add images and/or screen caps to illustrate what was changed if this pull request adds to or modifies existing user-visible appearance/output. 
-->
