### PR TITLE
Increase cypress default command timeout to 10 seconds

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -8,5 +8,6 @@
     "retries": {
         "runMode": 2,
         "openMode": 0
-      }
+      },
+    "defaultCommandTimeout": 10000
 }


### PR DESCRIPTION
## Motivation
Increases the cypress default command timeout from 4 secs to 10 secs.

## Brief Description
Simple cypress configuration change. Should help automatically eliminate cases in which slow load times are interfering with test step completion.

## Verification Steps
Run the tests locally and verify that wait times for any commands getting errors are now waiting 10000ms instead of 4000ms.

## Additional Notes
When I ran the tests locally, there were two errors and on each of those errors the default wait was 10000ms. 

I watched the tests execute in real-time and during both of those timeouts, the errors were not due to page loads. The pages were loaded and waiting for a command, but certain data-helpids were not found. It seemed both were related to button clicks and could probably be fixed by forcing the clicks of those buttons, but that is tangential to this PR.