### PR TITLE
Consents UI fixes

### DIFF
--- a/src/user/UserConsents.tsx
+++ b/src/user/UserConsents.tsx
@@ -1,7 +1,7 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import { PageSection } from "@patternfly/react-core";
+import { Button, Label, PageSection } from "@patternfly/react-core";
 import { ListEmptyState } from "../components/list-empty-state/ListEmptyState";
 import { KeycloakDataTable } from "../components/table-toolbar/KeycloakDataTable";
 import { emptyFormatter } from "../util";
@@ -27,10 +27,31 @@ export const UserConsents = () => {
     return alphabetize(consents);
   };
 
+  const [labelClicked, setLabelClicked] = useState(false);
+
+   useEffect(() => {
+    console.log(labelClicked)
+  }, [labelClicked])
+
   const clientScopesRenderer = ({
     grantedClientScopes,
   }: UserConsentRepresentation) => {
-    return <>{grantedClientScopes!.join(", ")}</>;
+    if (grantedClientScopes!.length <= 5 && labelClicked) {
+      return <>{grantedClientScopes!.join(", ")}</>;
+    } else
+      return (
+        <>
+          {grantedClientScopes!.slice(1, 6).join(", ")}{" "}
+          <Label
+            color="blue"
+            style={{ cursor: "pointer" }}
+            variant="outline"
+            onClick={() => setLabelClicked(true)}
+          >
+            {grantedClientScopes!.length - 5 + " more"}
+          </Label>
+        </>
+      );
   };
 
   const createdRenderer = ({ createDate }: UserConsentRepresentation) => {
@@ -45,50 +66,49 @@ export const UserConsents = () => {
 
   return (
     <>
-      <PageSection variant="light">
-        <KeycloakDataTable
-          loader={loader}
-          ariaLabelKey="roles:roleList"
-          columns={[
-            {
-              name: "clientId",
-              displayKey: "clients:Client",
-              cellFormatters: [emptyFormatter()],
-              transforms: [cellWidth(20)],
-            },
-            {
-              name: "grantedClientScopes",
-              displayKey: "client-scopes:grantedClientScopes",
-              cellFormatters: [emptyFormatter()],
-              cellRenderer: clientScopesRenderer,
-              transforms: [cellWidth(30)],
-            },
-            {
-              name: "createdDate",
-              displayKey: "clients:created",
-              cellFormatters: [emptyFormatter()],
-              cellRenderer: createdRenderer,
-              transforms: [cellWidth(20)],
-            },
-            {
-              name: "lastUpdatedDate",
-              displayKey: "clients:lastUpdated",
-              cellFormatters: [emptyFormatter()],
-              cellRenderer: lastUpdatedRenderer,
-              transforms: [cellWidth(20)],
-            },
-          ]}
-          emptyState={
-            <ListEmptyState
-              hasIcon={true}
-              icon={CubesIcon}
-              message={t("users:noConsents")}
-              instructions={t("users:noConsentsText")}
-              onPrimaryAction={() => {}}
-            />
-          }
-        />
-      </PageSection>
+      <KeycloakDataTable
+        loader={loader}
+        ariaLabelKey="roles:roleList"
+        searchPlaceholderKey=" "
+        columns={[
+          {
+            name: "clientId",
+            displayKey: "clients:Client",
+            cellFormatters: [emptyFormatter()],
+            transforms: [cellWidth(20)],
+          },
+          {
+            name: "grantedClientScopes",
+            displayKey: "client-scopes:grantedClientScopes",
+            cellFormatters: [emptyFormatter()],
+            cellRenderer: clientScopesRenderer,
+            transforms: [cellWidth(30)],
+          },
+          {
+            name: "createdDate",
+            displayKey: "clients:created",
+            cellFormatters: [emptyFormatter()],
+            cellRenderer: createdRenderer,
+            transforms: [cellWidth(20)],
+          },
+          {
+            name: "lastUpdatedDate",
+            displayKey: "clients:lastUpdated",
+            cellFormatters: [emptyFormatter()],
+            cellRenderer: lastUpdatedRenderer,
+            transforms: [cellWidth(20)],
+          },
+        ]}
+        emptyState={
+          <ListEmptyState
+            hasIcon={true}
+            icon={CubesIcon}
+            message={t("users:noConsents")}
+            instructions={t("users:noConsentsText")}
+            onPrimaryAction={() => {}}
+          />
+        }
+      />
     </>
   );
 };

--- a/src/user/UserConsents.tsx
+++ b/src/user/UserConsents.tsx
@@ -72,7 +72,9 @@ export const UserConsents = () => {
 
   const [toggleDeleteDialog, DeleteConfirm] = useConfirmDialog({
     titleKey: "users:revokeClientScopesTitle",
-    messageKey: t("users:revokeClientScopes") + selectedClient?.clientId + "?",
+    messageKey: t("users:revokeClientScopes", {
+      clientId: selectedClient?.clientId,
+    }),
     continueButtonLabel: "common:delete",
     continueButtonVariant: ButtonVariant.danger,
     onConfirm: async () => {

--- a/src/user/UserConsents.tsx
+++ b/src/user/UserConsents.tsx
@@ -79,7 +79,6 @@ export const UserConsents = () => {
       try {
         await adminClient.users.revokeConsent({
           id,
-          // realm: realm,
           clientId: selectedClient!.clientId!,
         });
 

--- a/src/user/UserConsents.tsx
+++ b/src/user/UserConsents.tsx
@@ -1,7 +1,7 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { useParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import { Button, Label, PageSection } from "@patternfly/react-core";
+import { Label } from "@patternfly/react-core";
 import { ListEmptyState } from "../components/list-empty-state/ListEmptyState";
 import { KeycloakDataTable } from "../components/table-toolbar/KeycloakDataTable";
 import { emptyFormatter } from "../util";
@@ -29,9 +29,11 @@ export const UserConsents = () => {
 
   const [labelClicked, setLabelClicked] = useState(false);
 
-   useEffect(() => {
-    console.log(labelClicked)
-  }, [labelClicked])
+  //  useEffect(() => {
+  //   console.log(labelClicked)
+  // }, [key])
+
+  const [key, setKey] = useState(0);
 
   const clientScopesRenderer = ({
     grantedClientScopes,
@@ -68,6 +70,7 @@ export const UserConsents = () => {
     <>
       <KeycloakDataTable
         loader={loader}
+        key={key}
         ariaLabelKey="roles:roleList"
         searchPlaceholderKey=" "
         columns={[

--- a/src/user/UserConsents.tsx
+++ b/src/user/UserConsents.tsx
@@ -1,7 +1,7 @@
-import React, { useState } from "react";
+import React from "react";
 import { useParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import { Label } from "@patternfly/react-core";
+import { Chip, ChipGroup } from "@patternfly/react-core";
 import { ListEmptyState } from "../components/list-empty-state/ListEmptyState";
 import { KeycloakDataTable } from "../components/table-toolbar/KeycloakDataTable";
 import { emptyFormatter } from "../util";
@@ -22,38 +22,28 @@ export const UserConsents = () => {
   };
 
   const loader = async () => {
-    const consents = await adminClient.users.listConsents({ id });
+    const getConsents = await adminClient.users.listConsents({ id });
 
-    return alphabetize(consents);
+    return alphabetize(getConsents);
   };
-
-  const [labelClicked, setLabelClicked] = useState(false);
-
-  //  useEffect(() => {
-  //   console.log(labelClicked)
-  // }, [key])
-
-  const [key, setKey] = useState(0);
 
   const clientScopesRenderer = ({
     grantedClientScopes,
   }: UserConsentRepresentation) => {
-    if (grantedClientScopes!.length <= 5 && labelClicked) {
-      return <>{grantedClientScopes!.join(", ")}</>;
-    } else
-      return (
-        <>
-          {grantedClientScopes!.slice(1, 6).join(", ")}{" "}
-          <Label
-            color="blue"
-            style={{ cursor: "pointer" }}
-            variant="outline"
-            onClick={() => setLabelClicked(true)}
+    return (
+      <ChipGroup className="kc-consents-chip-group">
+        {grantedClientScopes!.map((currentChip) => (
+          <Chip
+            key={currentChip}
+            isReadOnly
+            className="kc-consents-chip"
+            id="consents-chip-text"
           >
-            {grantedClientScopes!.length - 5 + " more"}
-          </Label>
-        </>
-      );
+            {currentChip}
+          </Chip>
+        ))}
+      </ChipGroup>
+    );
   };
 
   const createdRenderer = ({ createDate }: UserConsentRepresentation) => {
@@ -70,7 +60,6 @@ export const UserConsents = () => {
     <>
       <KeycloakDataTable
         loader={loader}
-        key={key}
         ariaLabelKey="roles:roleList"
         searchPlaceholderKey=" "
         columns={[

--- a/src/user/UsersTabs.tsx
+++ b/src/user/UsersTabs.tsx
@@ -108,9 +108,7 @@ export const UsersTabs = () => {
               data-testid="user-consents-tab"
               title={<TabTitleText>{t("users:consents")}</TabTitleText>}
             >
-              <PageSection variant="light">
-                <UserConsents />
-              </PageSection>
+              <UserConsents />
             </Tab>
           </KeycloakTabs>
         )}

--- a/src/user/messages.json
+++ b/src/user/messages.json
@@ -60,6 +60,11 @@
     "noConsents": "No consents",
     "noConsentsText": "The consents will only be recorded when users try to access a client that is configured to require consent. In that case, users will get a consent page which asks them to grant access to the client.",
     "whoWillAppearLinkText": "Who will appear in this group list?",
-    "whoWillAppearPopoverText": "Groups are hierarchical. When you select Direct Membership, you see only the child group that the user joined. Ancestor groups are not included."
+    "whoWillAppearPopoverText": "Groups are hierarchical. When you select Direct Membership, you see only the child group that the user joined. Ancestor groups are not included.",
+    "revoke": "Revoke",
+    "revokeClientScopesTitle": "Revoke all granted client scopes?",
+    "revokeClientScopes": "Are you sure you want to revoke all granted client scopes for ",
+    "deleteGrantsSuccess": "Grants successfully revoked.",
+    "deleteGrantsError": "Error deleting grants."
   }
 }

--- a/src/user/messages.json
+++ b/src/user/messages.json
@@ -63,7 +63,7 @@
     "whoWillAppearPopoverText": "Groups are hierarchical. When you select Direct Membership, you see only the child group that the user joined. Ancestor groups are not included.",
     "revoke": "Revoke",
     "revokeClientScopesTitle": "Revoke all granted client scopes?",
-    "revokeClientScopes": "Are you sure you want to revoke all granted client scopes for ",
+    "revokeClientScopes": "Are you sure you want to revoke all granted client scopes for {{clientId}}?",
     "deleteGrantsSuccess": "Grants successfully revoked.",
     "deleteGrantsError": "Error deleting grants."
   }

--- a/src/user/user-section.css
+++ b/src/user/user-section.css
@@ -49,3 +49,50 @@ td.pf-c-table__check > input {
 .pf-c-toolbar__content-section {
   margin-bottom: calc(var(--pf-global--spacer--lg) * -1);
 }
+
+.pf-c-chip.kc-consents-chip::before {
+  padding: 0px;
+  border: 0;
+}
+
+.pf-c-chip.kc-consents-chip {
+  padding: 0px;
+}
+
+.pf-c-chip-group__list-item {
+  margin-right: 0px;
+}
+
+#consents-chip-text.pf-c-chip-text {
+  font-size: var(--pf-c-table--cell--FontSize);
+}
+
+.kc-consents-chip > .pf-c-chip__text {
+  font-size: var(--pf-c-table--cell--FontSize);
+  display: inline-block;
+}
+
+.pf-c-chip-group.kc-consents-chip-group
+  > div.pf-c-chip-group__main
+  > ul.pf-c-chip-group__list
+  li:first-child
+  .pf-c-chip__text::before {
+  content: "";
+}
+
+.pf-c-chip-group.kc-consents-chip-group
+  > div.pf-c-chip-group__main
+  > ul.pf-c-chip-group__list
+  .pf-c-chip__text::before {
+  content: ", ";
+}
+
+.pf-c-chip-group.kc-consents-chip-group
+  > div.pf-c-chip-group__main
+  > ul.pf-c-chip-group__list
+  .pf-m-overflow
+  .pf-c-chip__text::before {
+  content: "";
+  margin-left: var(--pf-global--spacer--sm);
+  padding-left: 0px;
+}

--- a/src/user/user-section.css
+++ b/src/user/user-section.css
@@ -45,3 +45,7 @@ td.pf-c-table__check > input {
   width: 20px;
   vertical-align: text-top;
 }
+
+.pf-c-toolbar__content-section {
+  margin-bottom: calc(var(--pf-global--spacer--lg) * -1);
+}

--- a/src/user/user-section.css
+++ b/src/user/user-section.css
@@ -87,12 +87,21 @@ td.pf-c-table__check > input {
   content: ", ";
 }
 
-.pf-c-chip-group.kc-consents-chip-group
+div.pf-c-chip-group.kc-consents-chip-group
   > div.pf-c-chip-group__main
   > ul.pf-c-chip-group__list
-  .pf-m-overflow
-  .pf-c-chip__text::before {
+  > li.pf-c-chip-group__list-item:last-child
+  > button.pf-c-chip.pf-m-overflow::before {
   content: "";
   margin-left: var(--pf-global--spacer--sm);
-  padding-left: 0px;
+}
+
+div.pf-c-chip-group.kc-consents-chip-group
+  > div.pf-c-chip-group__main
+  > ul.pf-c-chip-group__list
+  > li.pf-c-chip-group__list-item:last-child
+  > button.pf-c-chip.pf-m-overflow
+  > span::before {
+  content: "";
+  margin-left: var(--pf-global--spacer--sm);
 }


### PR DESCRIPTION
## Motivation
<!-- Add references to relevant tickets, issues, design specs and/or a short description of what motivated you to do it. -->
Closes #668 

## Verification Steps
<!--
Add the steps required to verify this change. Keep in mind that these steps should be written so groups unfamiliar with the 
new functionality can follow them, such as QE or documentation. -->

1. Go to client scopes -> create a new client scope.
2. Set the “Type” to “default” and make sure “Display on consent screen” is enabled.
3. Repeat for however many client scopes you want to create/grant.
4. Go to Clients and make sure both security-admin-console and security-admin-console-v2 have “Consent required” set to “on” under Login Settings
5. Go to Clients -> Client Scopes and then add the new client scopes as “Default”
6. Log out of both the new admin console and the old one
7. Log back into both
8. It should ask you to verify the new consents -> click accept/yes
9. Go to Users -> admin -> consents and you should see them listed there

## Checklist:

- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [x] Help has been implemented
- [x] axe report has been run and resulting a11y issues have been resolved
- [x] Unit tests have been created/updated
- [x] Formatting has been performed via prettier/eslint
- [x] Type checking has been performed via 'yarn check-types'

## Additional Notes
<!-- 
Add images and/or screen caps to illustrate what was changed if this pull request adds to or modifies existing user-visible appearance/output. 
-->
