### PR TITLE
Partial import phase 2

### DIFF
--- a/cypress/integration/partial-import-test-data/client-only.json
+++ b/cypress/integration/partial-import-test-data/client-only.json
@@ -1,0 +1,13 @@
+{
+   "clients": [
+        {
+            "clientId": "customer-portal",
+            "enabled": true,
+            "adminUrl": "/customer-portal",
+            "baseUrl": "/customer-portal",
+            "redirectUris": [
+                "/customer-portal/*"
+            ],
+            "secret": "password"
+        }]
+}

--- a/cypress/integration/partial-import-test-data/kcexport.json
+++ b/cypress/integration/partial-import-test-data/kcexport.json
@@ -1,0 +1,5254 @@
+[ {
+  "id" : "master",
+  "realm" : "master",
+  "notBefore" : 0,
+  "revokeRefreshToken" : false,
+  "accessTokenLifespan" : 60,
+  "ssoSessionIdleTimeout" : 1800,
+  "ssoSessionMaxLifespan" : 36000,
+  "offlineSessionIdleTimeout" : 2592000,
+  "accessCodeLifespan" : 60,
+  "accessCodeLifespanUserAction" : 300,
+  "accessCodeLifespanLogin" : 1800,
+  "enabled" : true,
+  "sslRequired" : "external",
+  "registrationAllowed" : false,
+  "registrationEmailAsUsername" : false,
+  "rememberMe" : false,
+  "verifyEmail" : false,
+  "resetPasswordAllowed" : false,
+  "editUsernameAllowed" : false,
+  "bruteForceProtected" : false,
+  "maxFailureWaitSeconds" : 900,
+  "minimumQuickLoginWaitSeconds" : 60,
+  "waitIncrementSeconds" : 60,
+  "quickLoginCheckMilliSeconds" : 1000,
+  "maxDeltaTimeSeconds" : 43200,
+  "failureFactor" : 30,
+  "privateKey" : "MIIEpAIBAAKCAQEAv5g6gYoRAknG5Ekq2k2WYACyM25mTsaSC3UOUve4Dc8zmfbyUwGShkVsaUmgTy/UiuEHzrJ0U8pWg+xjdXIosyuKR8eEhORtA3kxuMzsSb3F1FFdb8l8vgtVU9waG2Xc0mHUE0P9tRCXUgXp8kCv0zULfmqGvtNkl4oNnbOB6v7w9tYCCxGof5nZXBclSHqOj8H7dy4JxEV0PDNLh70Pc3ey4ZLrXBkeOxetZXwWsnshLghr3XkMNQwSsuMgjeL06E+uoNN9gTdez63Q4UrfRBMKbEepmRq0vmRk1fYVrI6roeqQfi6joZlDgQFE/8bKy1hCe3ZgzU+rF+PyXPU+KwIDAQABAoIBAD7ZNsfrfGzduqqD/dSiguN3Fv2cB19r79hmS46Xx/5vq6OjyBXGfEQjXc6j4jxXmkb8Tk1VaKdbxkl8L5wFGKi9bZziK+xT6harmM3gGtqNr+lXz2iuFYdZvGHH36CBJ5Czmpe/Q+gzSxAS9I0M/yAvVFfhpdXPDj5PgOvsSH/HE+/n7oH/rElWtFuTmby30BLfhTD5QGEtnrLG/Zzblro4XF9wyCgm/ovfl3aBweLYnYKsZOFQu+h8uDylTL/bCyFU5W9zskmFAbTaRZfj3xOYd95LrE+lvu0pvi2L9JowvnDn1lfwPLo5BK6CdaHJLhtsHeWWEV4qmsDApp4lu5ECgYEA5NzEnvREGp3+TLZG62X+1r/t89YnCCK2RtwaoQ/59LGiqGmay6EuKL99BwWLqwYyCuwF5IWYL23tf3HWWh+q+jAK7ZojolXsAMgVCrKQ0aoibaYw8DDJ2m4D5oXeyIlUeyMQwjTE3MxMmevk3x4PRm45qGmkEwSdsmZJiNFdaj0CgYEA1lAuCHIQeWlAsb/847ziBdloPK+AmHpDOpzInXdLmZSdu5FqO2S2oGCYTM0M4FFBDoCTeq0xRmlrTWKQlLx7Jy4cVC6c+RdwrDIuKuxJOXQHrD7FUDg03Kk0CVYXUsfB1ryOIIC7Mj0X5hrfbUkd86Au5nOccbIqWetE63P2mIcCgYEAoVT7ii4ZQEY1+O/ZqKF69vnPjT9evn5xzhvk7bsschEy39OqGnfh6TmrsmJ3ZbV1W3usX77JXE36yQd/moKObdWmLn6lNg+p0Zc6NhNQwWxU3sTz5K4P7Vn2h+/A787XbgJ3EuBOEnQ2X58J9Trke7rCDHWEAyAS5qrylW85keUCgYEAzVcLlCn+IOY5B1ZlbqtGgMY6+pJJi07x5VHdYgqwU9mye8orV/b6iJWkt0lsge04gTWumMcixE0zc3TyBKDG+tZSbFIxMvVDjqmR1KyKyFKlG2MVWPRRqe8xHZTwSe99iUsmfnv5YHxqzp2G38ZDvW8IIOQ6zDEiJP+oDFUSvDcCgYBlo+X4gou44GjeIWSKX0agVa6gi588tp4FALFQ55SomtJKbX1OozeEN+e9zVsL/25c4NDrp61WoaJGixPKhSMGJ0u+snsWaM+2wtGjVoxCUpMLcSXTHzT4YkUK21sU6+Yzdg8PnNVA1JaI4XKtxuKtaMA+VlXlqfQ3ImGZdn6YDw==",
+  "publicKey" : "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAv5g6gYoRAknG5Ekq2k2WYACyM25mTsaSC3UOUve4Dc8zmfbyUwGShkVsaUmgTy/UiuEHzrJ0U8pWg+xjdXIosyuKR8eEhORtA3kxuMzsSb3F1FFdb8l8vgtVU9waG2Xc0mHUE0P9tRCXUgXp8kCv0zULfmqGvtNkl4oNnbOB6v7w9tYCCxGof5nZXBclSHqOj8H7dy4JxEV0PDNLh70Pc3ey4ZLrXBkeOxetZXwWsnshLghr3XkMNQwSsuMgjeL06E+uoNN9gTdez63Q4UrfRBMKbEepmRq0vmRk1fYVrI6roeqQfi6joZlDgQFE/8bKy1hCe3ZgzU+rF+PyXPU+KwIDAQAB",
+  "certificate" : "MIICmzCCAYMCBgFQ9+hyuzANBgkqhkiG9w0BAQsFADARMQ8wDQYDVQQDDAZtYXN0ZXIwHhcNMTUxMTExMTg1NTE3WhcNMjUxMTExMTg1NjU3WjARMQ8wDQYDVQQDDAZtYXN0ZXIwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC/mDqBihECScbkSSraTZZgALIzbmZOxpILdQ5S97gNzzOZ9vJTAZKGRWxpSaBPL9SK4QfOsnRTylaD7GN1ciizK4pHx4SE5G0DeTG4zOxJvcXUUV1vyXy+C1VT3BobZdzSYdQTQ/21EJdSBenyQK/TNQt+aoa+02SXig2ds4Hq/vD21gILEah/mdlcFyVIeo6Pwft3LgnERXQ8M0uHvQ9zd7LhkutcGR47F61lfBayeyEuCGvdeQw1DBKy4yCN4vToT66g032BN17PrdDhSt9EEwpsR6mZGrS+ZGTV9hWsjquh6pB+LqOhmUOBAUT/xsrLWEJ7dmDNT6sX4/Jc9T4rAgMBAAEwDQYJKoZIhvcNAQELBQADggEBABi3/VA3jKTNNdIfe/Il56Xfdgp/upBjw0er5nb2Jq/JuR4zZWAB3B+1wCO2ofBJZM9psXLd9HL3zvXct3eytisGp9gfRvZ+aL6kanhLdj3pF06NA2lIFkx292alYEDKF56GnCZlnCtF88j1kreXaOdkeUSjWlatVvEikRJUNTijiHLcX9XSBQ8qiDcdLu+DBrEWLmSnDNwWPKnWAz/w4ypVE4RxH3v0KYCDesv887fdWuLZmEyvFcc8sEwH4K7wj1vWUjSqSz+9uv7sqV/adPBMPkUeGeqsHkGu6Wn5JhaYHvrXsza5ZQ9H/X3BNmnp5JZCk17jWwjfiTRx0VtX7rM=",
+  "codeSecret" : "bc4719b1-5c6f-4b55-abe7-11a32dae080c",
+  "roles" : {
+    "realm" : [ {
+      "id" : "9d2638c8-4c62-4c42-90ea-5f3c836d0cc8",
+      "name" : "user",
+      "scopeParamRequired" : false,
+      "composite" : false
+    }, {
+      "id" : "e927db37-b0cc-4f84-be22-faa799666d26",
+      "name" : "offline_access",
+      "description" : "${role_offline-access}",
+      "scopeParamRequired" : true,
+      "composite" : false
+    }, {
+      "id" : "f02fcbcc-5c75-4cab-afc8-157c372a0d76",
+      "name" : "admin",
+      "description" : "${role_admin}",
+      "scopeParamRequired" : false,
+      "composite" : true,
+      "composites" : {
+        "realm" : [ "create-realm" ],
+        "client" : {
+          "mynewrealm-realm" : [ "create-client", "view-events", "manage-events", "view-realm", "view-identity-providers", "view-clients", "manage-realm", "manage-clients", "impersonation", "view-users", "manage-identity-providers", "manage-users" ],
+          "demo-realm" : [ "view-clients", "view-users", "manage-realm", "manage-clients", "impersonation", "view-identity-providers", "manage-events", "manage-identity-providers", "view-realm", "manage-users", "create-client", "view-events" ],
+          "master-realm" : [ "view-clients", "impersonation", "manage-users", "manage-clients", "view-identity-providers", "manage-identity-providers", "view-realm", "manage-realm", "create-client", "view-users", "manage-events", "view-events" ]
+        }
+      }
+    }, {
+      "id" : "2a800219-13dd-4c97-bdee-997bd07969c2",
+      "name" : "noncomposite",
+      "description" : "Non-composite role",
+      "scopeParamRequired" : true,
+      "composite" : false
+    }, {
+      "id" : "08eb0d05-9f8e-4958-822c-1083a90ff52f",
+      "name" : "create-realm",
+      "description" : "${role_create-realm}",
+      "scopeParamRequired" : false,
+      "composite" : false
+    } ],
+    "client" : {
+      "database-service" : [ ],
+      "admin-client" : [ ],
+      "customer-portal-js" : [ ],
+      "security-admin-console" : [ ],
+      "product-sa-client-jwt-auth" : [ ],
+      "demo-realm" : [ {
+        "id" : "4802ec90-93d9-4d5b-b3e9-9185f69e4c49",
+        "name" : "manage-realm",
+        "description" : "${role_manage-realm}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      }, {
+        "id" : "85b2e5a2-f67a-43fa-a353-8fb899ac91b7",
+        "name" : "manage-identity-providers",
+        "description" : "${role_manage-identity-providers}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      }, {
+        "id" : "29bf4122-efdd-473b-9282-c2936c649443",
+        "name" : "view-clients",
+        "description" : "${role_view-clients}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      }, {
+        "id" : "c2f2b7b5-1105-4a53-94fe-b72dc652a2c1",
+        "name" : "view-users",
+        "description" : "${role_view-users}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      }, {
+        "id" : "37758fcd-0aed-4a96-81fb-22d4ab99a8a6",
+        "name" : "view-realm",
+        "description" : "${role_view-realm}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      }, {
+        "id" : "a54fb635-b965-4fe6-87de-c80908146021",
+        "name" : "impersonation",
+        "description" : "${role_impersonation}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      }, {
+        "id" : "fd5e3cc1-78ba-4006-b716-c79adf103bcd",
+        "name" : "manage-clients",
+        "description" : "${role_manage-clients}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      }, {
+        "id" : "7186dd05-7ac6-4ad6-9e53-06f0833912d0",
+        "name" : "view-identity-providers",
+        "description" : "${role_view-identity-providers}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      }, {
+        "id" : "059a454c-955a-4d05-93b3-93f3131889e3",
+        "name" : "manage-users",
+        "description" : "${role_manage-users}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      }, {
+        "id" : "afc291f4-eb9a-4e16-9da9-37925f17192e",
+        "name" : "create-client",
+        "description" : "${role_create-client}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      }, {
+        "id" : "b6a26d5c-0ee9-4852-b81f-24ccdf157efa",
+        "name" : "view-events",
+        "description" : "${role_view-events}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      }, {
+        "id" : "2315217d-3266-462f-b02f-6b17778a5b75",
+        "name" : "manage-events",
+        "description" : "${role_manage-events}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      } ],
+      "angular-product" : [ ],
+      "product-sa-client" : [ ],
+      "master-realm" : [ {
+        "id" : "9bee5e34-444f-49d2-a772-7865bead3515",
+        "name" : "view-realm",
+        "description" : "${role_view-realm}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      }, {
+        "id" : "20154625-4f8a-4787-b050-d8f1ba75950e",
+        "name" : "view-users",
+        "description" : "${role_view-users}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      }, {
+        "id" : "18cbc727-544a-479d-9f09-c6f17c8c6b70",
+        "name" : "manage-events",
+        "description" : "${role_manage-events}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      }, {
+        "id" : "70e573e9-d1e3-48e2-92f4-e1471303b81a",
+        "name" : "manage-users",
+        "description" : "${role_manage-users}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      }, {
+        "id" : "5de4c4ff-bd14-4e02-9407-b719b082b04e",
+        "name" : "view-clients",
+        "description" : "${role_view-clients}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      }, {
+        "id" : "720bb2f3-a88d-428e-93c8-9b8233caa8e5",
+        "name" : "impersonation",
+        "description" : "${role_impersonation}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      }, {
+        "id" : "acfc02b9-e18e-4931-ba2b-eb865b6373dc",
+        "name" : "manage-realm",
+        "description" : "${role_manage-realm}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      }, {
+        "id" : "97d19f5a-382b-4c8e-b67e-f5d396371f87",
+        "name" : "manage-clients",
+        "description" : "${role_manage-clients}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      }, {
+        "id" : "64649e1a-1d96-4610-a8f0-fbb0f091ca8f",
+        "name" : "view-events",
+        "description" : "${role_view-events}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      }, {
+        "id" : "fc732649-6dda-435c-9fae-1fe2f9ad2176",
+        "name" : "view-identity-providers",
+        "description" : "${role_view-identity-providers}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      }, {
+        "id" : "63ad6d6f-99fc-4048-ade9-06d837655c39",
+        "name" : "create-client",
+        "description" : "${role_create-client}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      }, {
+        "id" : "5246c662-e043-4a4e-8db8-b9d62a8e7b5b",
+        "name" : "manage-identity-providers",
+        "description" : "${role_manage-identity-providers}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      } ],
+      "broker" : [ {
+        "id" : "b80f960c-c4db-4d3d-a76d-bf6de7462909",
+        "name" : "read-token",
+        "description" : "${role_read-token}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      } ],
+      "customer-portal-cli" : [ ],
+      "customer-portal" : [ ],
+      "mynewrealm-realm" : [ {
+        "id" : "d6147a85-57ea-4664-ae4c-eca82aa4033b",
+        "name" : "impersonation",
+        "description" : "${role_impersonation}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      }, {
+        "id" : "b20e77e6-1163-4833-a637-7794244d4f15",
+        "name" : "view-clients",
+        "description" : "${role_view-clients}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      }, {
+        "id" : "cd1dd572-6bd5-4409-81a8-f4dce75e7600",
+        "name" : "view-events",
+        "description" : "${role_view-events}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      }, {
+        "id" : "4d5cd5db-51ae-4d18-86a3-1987222607ee",
+        "name" : "view-users",
+        "description" : "${role_view-users}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      }, {
+        "id" : "bf693edd-8a74-45a0-9775-b65357e5398f",
+        "name" : "manage-identity-providers",
+        "description" : "${role_manage-identity-providers}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      }, {
+        "id" : "eba019b2-14c5-4951-9fd0-4801dbd74cba",
+        "name" : "manage-events",
+        "description" : "${role_manage-events}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      }, {
+        "id" : "98d2be44-ebd2-4d93-b348-2aa197ce3538",
+        "name" : "create-client",
+        "description" : "${role_create-client}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      }, {
+        "id" : "9ce9c2f4-872d-476e-9bf3-975eb0220593",
+        "name" : "manage-realm",
+        "description" : "${role_manage-realm}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      }, {
+        "id" : "474ce253-d224-443f-b5b2-ad80a226b91a",
+        "name" : "view-realm",
+        "description" : "${role_view-realm}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      }, {
+        "id" : "7fa87f28-ad3e-4372-b262-f023726d6a5a",
+        "name" : "view-identity-providers",
+        "description" : "${role_view-identity-providers}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      }, {
+        "id" : "5e289465-611c-4ecc-9256-c88b4e4f61fa",
+        "name" : "manage-users",
+        "description" : "${role_manage-users}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      }, {
+        "id" : "cfc28d0b-78b6-49d3-aa01-b0f2f6cea71e",
+        "name" : "manage-clients",
+        "description" : "${role_manage-clients}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      } ],
+      "product-portal" : [ ],
+      "account" : [ {
+        "id" : "8dfe4967-259f-453f-9193-a60f845e3396",
+        "name" : "manage-account",
+        "description" : "${role_manage-account}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      }, {
+        "id" : "e494be2d-f5a7-43e1-924b-97fb75e07a1a",
+        "name" : "view-profile",
+        "description" : "${role_view-profile}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      } ],
+      "third-party" : [ ],
+      "offline-access-portal" : [ ]
+    }
+  },
+  "defaultRoles" : [ "offline_access" ],
+  "requiredCredentials" : [ "password" ],
+  "otpPolicyType" : "totp",
+  "otpPolicyAlgorithm" : "HmacSHA1",
+  "otpPolicyInitialCounter" : 0,
+  "otpPolicyDigits" : 6,
+  "otpPolicyLookAheadWindow" : 1,
+  "otpPolicyPeriod" : 30,
+  "users" : [ {
+    "id" : "ccee8213-15b0-4d38-bcb3-209cd563c743",
+    "createdTimestamp" : 1447268217566,
+    "username" : "admin",
+    "enabled" : true,
+    "totp" : false,
+    "emailVerified" : false,
+    "credentials" : [ {
+      "type" : "password",
+      "hashedSaltedValue" : "CFazI0ssShxu8szLm2bwLP+N8Dk+5PEspbpwtSgtkFrS7Lvq1XBTusbgJZg8LycST/fhUy7v0TAqPqPFBBU0Sw==",
+      "salt" : "97EXNDYXHkKehzFzXG/Fkg==",
+      "hashIterations" : 1,
+      "counter" : 0,
+      "digits" : 0,
+      "temporary" : false
+    } ],
+    "requiredActions" : [ ],
+    "realmRoles" : [ "offline_access", "admin" ],
+    "clientRoles" : {
+      "account" : [ "manage-account", "view-profile" ]
+    }
+  }, {
+    "id" : "beb49335-bf91-4712-b93b-f338cad7468d",
+    "username" : "bburke@redhat.com",
+    "enabled" : true,
+    "totp" : false,
+    "emailVerified" : false,
+    "firstName" : "Bill",
+    "lastName" : "Burke",
+    "email" : "bburke@redhat.com",
+    "credentials" : [ {
+      "type" : "password",
+      "hashedSaltedValue" : "30gHSyQ9IMLJc9vrwJA12OjbisrWPvmiveCzqovMucz4fcE6I10Djzqfec88w0FhEnpps4RVr4vh9mGpIYgiAg==",
+      "salt" : "L3hlszVvFI7lqRCe36aqbQ==",
+      "hashIterations" : 1,
+      "counter" : 0,
+      "digits" : 0,
+      "temporary" : false
+    } ],
+    "requiredActions" : [ ],
+    "realmRoles" : [ "user", "offline_access" ],
+    "clientRoles" : {
+      "account" : [ "manage-account" ]
+    }
+  }, {
+    "id" : "79d481e3-6aab-412b-b6aa-00db7954dc89",
+    "username" : "mposolda@redhat.com",
+    "enabled" : true,
+    "totp" : false,
+    "emailVerified" : false,
+    "firstName" : "Marek",
+    "lastName" : "Posolda",
+    "email" : "mposolda@redhat.com",
+    "credentials" : [ {
+      "type" : "password",
+      "hashedSaltedValue" : "jzbNz54Ir/XrzcDNoHuySKRCrr7hFXs916jVzKlyIMvg5Cirzt1vP3F88nDkBe3QM2OEV/jvOAZeKFK6XPHcFg==",
+      "salt" : "V66xxpnBgW8mL96W5wkaOg==",
+      "hashIterations" : 1,
+      "counter" : 0,
+      "digits" : 0,
+      "temporary" : false
+    } ],
+    "requiredActions" : [ ],
+    "realmRoles" : [ "user", "offline_access" ],
+    "clientRoles" : {
+      "account" : [ "manage-account" ]
+    }
+  }, {
+    "id" : "5af5b260-17f0-42e2-8f26-fa4e009354cf",
+    "username" : "stian",
+    "enabled" : true,
+    "totp" : false,
+    "emailVerified" : false,
+    "firstName" : "Stian",
+    "lastName" : "Thorgersen",
+    "email" : "stian@redhat.com",
+    "credentials" : [ {
+      "type" : "password",
+      "hashedSaltedValue" : "v4oc+B7t/743QGFLH+Y3dnSRfjBDJEN7xS/komuwSDC5YKxHPw+V8SoM5OTIQjXAf2fbXr50evNvrPIW9RPg+g==",
+      "salt" : "y9//kWaEfX0dvLwQ6uOBdg==",
+      "hashIterations" : 1,
+      "counter" : 0,
+      "digits" : 0,
+      "temporary" : false
+    } ],
+    "requiredActions" : [ ],
+    "realmRoles" : [ "user", "offline_access" ],
+    "clientRoles" : {
+      "account" : [ "manage-account" ]
+    }
+  } ],
+  "scopeMappings" : [ {
+    "client" : "security-admin-console",
+    "roles" : [ "admin" ]
+  } ],
+  "clients" : [ {
+    "id" : "8e05994e-72a2-4c9a-b6c7-56f644a43a4f",
+    "clientId" : "database-service",
+    "adminUrl" : "/database",
+    "baseUrl" : "/database",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "8b62ff99-85b3-4e4e-ad35-5223ca0c0a85",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : true,
+    "consentRequired" : false,
+    "serviceAccountsEnabled" : false,
+    "directGrantsOnly" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "attributes" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : -1,
+    "protocolMappers" : [ {
+      "id" : "a2431032-7607-4a9e-a0c8-94627434eb4d",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${username}",
+      "config" : {
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "ab49a828-f2a3-4d24-8e9b-a54cc762b368",
+      "name" : "given name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${givenName}",
+      "config" : {
+        "user.attribute" : "firstName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "given_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "cdb61022-c6ca-4bba-baef-5026ecf0a57f",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${email}",
+      "config" : {
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "6a5f83b9-65b8-44cb-bdc8-72b650aa0b0f",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : true,
+      "consentText" : "${fullName}",
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    }, {
+      "id" : "38df05fb-c4e2-45d0-bab5-b36b6dafb18c",
+      "name" : "family name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${familyName}",
+      "config" : {
+        "user.attribute" : "lastName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "38f98204-fced-4a04-bcef-3a41e35ee7f4",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    } ]
+  }, {
+    "id" : "3f15550f-f7cd-4bf9-a40a-801472b0d9b7",
+    "clientId" : "admin-client",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "29e8215e-786b-4e59-913f-5acfe2cecf9f",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "serviceAccountsEnabled" : false,
+    "directGrantsOnly" : true,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "attributes" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : -1,
+    "protocolMappers" : [ {
+      "id" : "6c0d2ecd-72d5-41ef-b376-0e6312f27a05",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${username}",
+      "config" : {
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "3dc86deb-5316-45fc-9d2f-1cbe15e87492",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${email}",
+      "config" : {
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "e3e0b3ab-fd1f-466c-b409-f880a005b2f7",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    }, {
+      "id" : "4fd81299-d1fd-4234-a245-60d9c68b1532",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : true,
+      "consentText" : "${fullName}",
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    }, {
+      "id" : "1a311b3e-8556-4d47-b537-35352ed62506",
+      "name" : "given name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${givenName}",
+      "config" : {
+        "user.attribute" : "firstName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "given_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "8aa953e8-9f79-4f24-b293-1a0fe6a04442",
+      "name" : "family name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${familyName}",
+      "config" : {
+        "user.attribute" : "lastName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "bc403281-e651-479e-8130-84ccd37ad4a6",
+    "clientId" : "customer-portal-js",
+    "baseUrl" : "/customer-portal-js",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "77638937-f511-4b72-ae21-4382dfcfd1c2",
+    "redirectUris" : [ "/customer-portal-js/*" ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "serviceAccountsEnabled" : false,
+    "directGrantsOnly" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "attributes" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : -1,
+    "protocolMappers" : [ {
+      "id" : "d89257ef-2883-4c0b-ab91-7b8b34a186ba",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${username}",
+      "config" : {
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "ceb1fd0c-cf62-435e-bc51-05d4dfa2bc83",
+      "name" : "given name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${givenName}",
+      "config" : {
+        "user.attribute" : "firstName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "given_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "e0d0b086-b9c8-42a0-baf3-58135bc07374",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${email}",
+      "config" : {
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "3d38e1e2-1218-4fb6-8811-20d420195b48",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    }, {
+      "id" : "1550b89e-103e-429e-8c94-4fa37ca190a7",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : true,
+      "consentText" : "${fullName}",
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    }, {
+      "id" : "bda0c751-4647-4311-b941-f7bdc2853e95",
+      "name" : "family name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${familyName}",
+      "config" : {
+        "user.attribute" : "lastName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "5cbaa3f5-6b80-42b1-820e-3230e087060b",
+    "clientId" : "security-admin-console",
+    "name" : "${client_security-admin-console}",
+    "baseUrl" : "/auth/admin/master/console/index.html",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "a030f7d0-1d5d-4d4b-b3b0-8a62c95b8de1",
+    "redirectUris" : [ "/auth/admin/master/console/*" ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "serviceAccountsEnabled" : false,
+    "directGrantsOnly" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "attributes" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "protocolMappers" : [ {
+      "id" : "fd943e23-e057-4e3f-a42a-d8eabcec48ce",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${email}",
+      "config" : {
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "8c6bace2-dae6-4420-a3e8-e279c91befcc",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    }, {
+      "id" : "2d95bda0-9d7a-4595-bb31-a15b0599f362",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${username}",
+      "config" : {
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "bf6ef571-6383-42ac-bbb2-5df1eac7c560",
+      "name" : "family name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${familyName}",
+      "config" : {
+        "user.attribute" : "lastName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "0b051624-dc37-4452-88a6-937ea748f797",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : true,
+      "consentText" : "${fullName}",
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    }, {
+      "id" : "14f935dc-0c92-496d-a911-d8f0036e69a3",
+      "name" : "locale",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "consentText" : "${locale}",
+      "config" : {
+        "user.attribute" : "locale",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "locale",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "2a1b96b1-ee51-467a-8c41-c36386aabbec",
+      "name" : "given name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${givenName}",
+      "config" : {
+        "user.attribute" : "firstName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "given_name",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "8ad378b0-4641-4407-a6f6-b6d68f420335",
+    "clientId" : "product-sa-client-jwt-auth",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "clientAuthenticatorType" : "client-jwt",
+    "secret" : "b8fd08bd-fa1e-44fd-a90d-403c81949ef2",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "serviceAccountsEnabled" : true,
+    "directGrantsOnly" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "attributes" : {
+      "jwt.credential.certificate" : "MIICnTCCAYUCBgFPPLDaTzANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdjbGllbnQxMB4XDTE1MDgxNzE3MjI0N1oXDTI1MDgxNzE3MjQyN1owEjEQMA4GA1UEAwwHY2xpZW50MTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAIUjjgv+V3s96O+Za9002Lp/trtGuHBeaeVL9dFKMKzO2MPqdRmHB4PqNlDdd28Rwf5Xn6iWdFpyUKOnI/yXDLhdcuFpR0sMNK/C9Lt+hSpPFLuzDqgtPgDotlMxiHIWDOZ7g9/gPYNXbNvjv8nSiyqoguoCQiiafW90bPHsiVLdP7ZIUwCcfi1qQm7FhxRJ1NiW5dvUkuCnnWEf0XR+Wzc5eC9EgB0taLFiPsSEIlWMm5xlahYyXkPdNOqZjiRnrTWm5Y4uk8ZcsD/KbPTf/7t7cQXipVaswgjdYi1kK2/zRwOhg1QwWFX/qmvdd+fLxV0R6VqRDhn7Qep2cxwMxLsCAwEAATANBgkqhkiG9w0BAQsFAAOCAQEAKE6OA46sf20bz8LZPoiNsqRwBUDkaMGXfnob7s/hJZIIwDEx0IAQ3uKsG7q9wb+aA6s+v7S340zb2k3IxuhFaHaZpAd4CyR5cn1FHylbzoZ7rI/3ASqHDqpljdJaFqPH+m7nZWtyDvtZf+gkZ8OjsndwsSBK1d/jMZPp29qYbl1+XfO7RCp/jDqro/R3saYFaIFiEZPeKn1hUJn6BO48vxH1xspSu9FmlvDOEAOz4AuM58z4zRMP49GcFdCWr1wkonJUHaSptJaQwmBwLFUkCbE5I1ixGMb7mjEud6Y5jhfzJiZMo2U8RfcjNbrN0diZl3jB6LQIwESnhYSghaTjNQ=="
+    },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : -1,
+    "protocolMappers" : [ {
+      "id" : "aa8d820a-aee2-416f-a224-760622c5a40b",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${username}",
+      "config" : {
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "0a7b32fe-b70e-4c04-8818-b3aa98b5ed09",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    }, {
+      "id" : "b897d187-147b-4d89-93b5-7990757df443",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${email}",
+      "config" : {
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "6e08a310-1ba7-407c-9d40-bd9c76575c8b",
+      "name" : "family name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${familyName}",
+      "config" : {
+        "user.attribute" : "lastName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "5b862d4f-bb7a-46dd-a504-91a3481d963f",
+      "name" : "given name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${givenName}",
+      "config" : {
+        "user.attribute" : "firstName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "given_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "c446d029-6865-464a-8cfa-77f4965f8507",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : true,
+      "consentText" : "${fullName}",
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    } ]
+  }, {
+    "id" : "bafaa6ac-6744-43db-96f7-dc1017d501d2",
+    "clientId" : "demo-realm",
+    "name" : "demo Realm",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "aad11539-ab30-4055-86b4-6e013c47a798",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : true,
+    "consentRequired" : false,
+    "serviceAccountsEnabled" : false,
+    "directGrantsOnly" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "attributes" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : 0,
+    "protocolMappers" : [ {
+      "id" : "fdf2c87a-0f41-4309-bcbc-5b56f5afedcb",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    }, {
+      "id" : "dcce2cdc-91e7-4f68-8d28-edd254cc519e",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${email}",
+      "config" : {
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "60900478-3bc6-449a-af97-7f1f06be3fde",
+      "name" : "family name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${familyName}",
+      "config" : {
+        "user.attribute" : "lastName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "5f6e2e63-dd59-44bb-aaa3-908125b1e364",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${username}",
+      "config" : {
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "8c82272b-6995-4dca-a63d-2cad8c8aa40d",
+      "name" : "given name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${givenName}",
+      "config" : {
+        "user.attribute" : "firstName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "given_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "8492bd07-2e76-41d7-b0b8-eca7e66f7e5e",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : true,
+      "consentText" : "${fullName}",
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    } ]
+  }, {
+    "id" : "a1b3689c-53d2-4964-bc51-395afbd6be74",
+    "clientId" : "angular-product",
+    "baseUrl" : "/angular-product/index.html",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "d169d88a-ee90-4c3f-bd71-cb39a4163bed",
+    "redirectUris" : [ "/angular-product/*" ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "serviceAccountsEnabled" : false,
+    "directGrantsOnly" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "attributes" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : -1,
+    "protocolMappers" : [ {
+      "id" : "5ae72e66-1840-411e-9b5f-a9567377944b",
+      "name" : "family name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${familyName}",
+      "config" : {
+        "user.attribute" : "lastName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "ab973b0f-084c-424b-a1f6-bb4a434a3196",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : true,
+      "consentText" : "${fullName}",
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    }, {
+      "id" : "13085615-0774-4048-a618-6646a17ff0ea",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${username}",
+      "config" : {
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "d83166f3-6247-4fb8-81e1-8dce9563ed18",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${email}",
+      "config" : {
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "67f079b8-8f75-4e95-9fca-1e5d6259147a",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    }, {
+      "id" : "96b9c867-7b8a-4675-be15-a441a695692f",
+      "name" : "given name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${givenName}",
+      "config" : {
+        "user.attribute" : "firstName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "given_name",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "0d1c1818-cf28-4e5d-96b6-457a594122b9",
+    "clientId" : "product-sa-client",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "password",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "serviceAccountsEnabled" : true,
+    "directGrantsOnly" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "attributes" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : -1,
+    "protocolMappers" : [ {
+      "id" : "3d797492-d90b-4b3e-a325-f23605cb577b",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : true,
+      "consentText" : "${fullName}",
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    }, {
+      "id" : "09331df8-260e-4581-b922-3a8c8c3ded0e",
+      "name" : "given name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${givenName}",
+      "config" : {
+        "user.attribute" : "firstName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "given_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "e90089b9-a831-45cd-bd7e-c923ca7e2cec",
+      "name" : "family name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${familyName}",
+      "config" : {
+        "user.attribute" : "lastName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "7a0bc75a-4890-4a04-9b1f-07032d75b223",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    }, {
+      "id" : "001ec6cc-7a59-4a04-8e77-5d61092009e1",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${username}",
+      "config" : {
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "14eaf865-36e9-492f-98aa-ca76f52b6e25",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${email}",
+      "config" : {
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "737c1d02-5b04-4caa-96ac-12f82b55e3a1",
+    "clientId" : "master-realm",
+    "name" : "master Realm",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "c9e38b12-57cf-47bd-8116-3b69ef3a2110",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : true,
+    "consentRequired" : false,
+    "serviceAccountsEnabled" : false,
+    "directGrantsOnly" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "attributes" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : 0,
+    "protocolMappers" : [ {
+      "id" : "0285f882-61a2-4b98-8f51-2b0f4d230edc",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${email}",
+      "config" : {
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "b3216963-f3b5-4b1b-b5a1-c291ab15d835",
+      "name" : "family name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${familyName}",
+      "config" : {
+        "user.attribute" : "lastName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "4632dca4-a334-4353-826a-3ac8eb517fe5",
+      "name" : "given name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${givenName}",
+      "config" : {
+        "user.attribute" : "firstName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "given_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "14ade32e-ca83-4c4f-9fd1-8ced257eecf6",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    }, {
+      "id" : "bf76011c-5d36-4c84-b981-7fcfa3eee76e",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : true,
+      "consentText" : "${fullName}",
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    }, {
+      "id" : "ea3d84dc-ed8c-4b77-a974-5bdf4c7591fc",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${username}",
+      "config" : {
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "de89d8d5-e526-457f-a83f-a05a32d2b3c4",
+    "clientId" : "broker",
+    "name" : "${client_broker}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "64bb4575-8bc4-41f8-95fe-37ccdc7e58b8",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "serviceAccountsEnabled" : false,
+    "directGrantsOnly" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "attributes" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "protocolMappers" : [ {
+      "id" : "2315624c-5a12-48c0-92c2-987eaec0a7f1",
+      "name" : "family name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${familyName}",
+      "config" : {
+        "user.attribute" : "lastName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "6b7b79a6-e852-4008-85b9-6514422a5f73",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    }, {
+      "id" : "3de1364e-b896-444e-8e67-8c143f9f5af9",
+      "name" : "given name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${givenName}",
+      "config" : {
+        "user.attribute" : "firstName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "given_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "1ff705e3-1dea-49c6-8671-48bb23599762",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${email}",
+      "config" : {
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "4f896934-ecc5-491a-876e-1ec8f123dd4b",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : true,
+      "consentText" : "${fullName}",
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    }, {
+      "id" : "c7f079d7-093d-4ff0-91ec-2eb433a24bc7",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${username}",
+      "config" : {
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "d38fc352-f9bd-4ee8-a4b1-b1d49121d8de",
+    "clientId" : "customer-portal-cli",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "6f7a911c-46cc-47a4-a475-67584f387556",
+    "redirectUris" : [ "urn:ietf:wg:oauth:2.0:oob", "http://localhost" ],
+    "webOrigins" : [ "http://localhost" ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "serviceAccountsEnabled" : false,
+    "directGrantsOnly" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "attributes" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : -1,
+    "protocolMappers" : [ {
+      "id" : "77032cf9-8c5e-4c9a-8aa2-c1612586f70d",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    }, {
+      "id" : "b4f97a2f-bef6-4b28-bd07-376ea4b196ec",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${username}",
+      "config" : {
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "675fff85-b373-45d4-8465-d76cbf860562",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${email}",
+      "config" : {
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "bcb3716f-29d2-4904-97a5-6f460026da47",
+      "name" : "family name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${familyName}",
+      "config" : {
+        "user.attribute" : "lastName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "2ee67514-cfc1-4002-8e2d-894d208c93a9",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : true,
+      "consentText" : "${fullName}",
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    }, {
+      "id" : "a36d453e-fee5-4407-b7a8-515509f86e7d",
+      "name" : "given name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${givenName}",
+      "config" : {
+        "user.attribute" : "firstName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "given_name",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "a8ad2322-3bfd-4d3d-b555-5d2927b3b43c",
+    "clientId" : "customer-portal",
+    "adminUrl" : "/customer-portal",
+    "baseUrl" : "/customer-portal",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "password",
+    "redirectUris" : [ "/customer-portal/*" ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "serviceAccountsEnabled" : false,
+    "directGrantsOnly" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "attributes" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : -1,
+    "protocolMappers" : [ {
+      "id" : "6edd6df4-f175-43d7-a961-981a8517a8b5",
+      "name" : "given name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${givenName}",
+      "config" : {
+        "user.attribute" : "firstName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "given_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "a2a5df10-3b62-44ea-b7de-71974f4c54d6",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    }, {
+      "id" : "092682ff-d347-4386-b97b-e91cd469db94",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${email}",
+      "config" : {
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "a23b0c07-6b27-4118-8efa-9ab29fbdc75a",
+      "name" : "family name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${familyName}",
+      "config" : {
+        "user.attribute" : "lastName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "0834e677-ee6b-40b4-aace-9720e0933b1e",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : true,
+      "consentText" : "${fullName}",
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    }, {
+      "id" : "1c25b331-f020-4786-8786-549ff57ce3b3",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${username}",
+      "config" : {
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "d2a382cb-fd72-4643-a3b6-f9dbc0da80f4",
+    "clientId" : "mynewrealm-realm",
+    "name" : "mynewrealm Realm",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "50cbe999-4c6f-4424-96cb-fd03919cce1e",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : true,
+    "consentRequired" : false,
+    "serviceAccountsEnabled" : false,
+    "directGrantsOnly" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "attributes" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : 0,
+    "protocolMappers" : [ {
+      "id" : "fd60f8ee-faf7-4d42-b3ee-a1e9b571b195",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${email}",
+      "config" : {
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "68264dfd-75db-4dd8-8aae-0e470bf851f7",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    }, {
+      "id" : "960d419d-f616-40f1-ae78-ee10bab1ca00",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${username}",
+      "config" : {
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "bc703891-d4d9-44de-b909-e168320a1650",
+      "name" : "family name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${familyName}",
+      "config" : {
+        "user.attribute" : "lastName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "ab9b12a2-fba8-4bd3-93c4-853081b61d7b",
+      "name" : "given name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${givenName}",
+      "config" : {
+        "user.attribute" : "firstName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "given_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "ba4a9642-0a04-49ff-9e82-370c50be52b1",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : true,
+      "consentText" : "${fullName}",
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    } ]
+  }, {
+    "id" : "c8507822-3793-4f7c-a328-dfe45c125e02",
+    "clientId" : "product-portal",
+    "adminUrl" : "/product-portal",
+    "baseUrl" : "/product-portal",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "password",
+    "redirectUris" : [ "/product-portal/*" ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "serviceAccountsEnabled" : false,
+    "directGrantsOnly" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "attributes" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : -1,
+    "protocolMappers" : [ {
+      "id" : "62613797-4231-4c0a-b3ca-c4128cb96922",
+      "name" : "family name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${familyName}",
+      "config" : {
+        "user.attribute" : "lastName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "f47d226f-ff60-408d-8eca-2241594b08a0",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${email}",
+      "config" : {
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "e165f967-4267-485d-ae9c-065e35a36246",
+      "name" : "given name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${givenName}",
+      "config" : {
+        "user.attribute" : "firstName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "given_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "c1711314-d68d-4f0f-bb79-0ba3f88b9a70",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${username}",
+      "config" : {
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "b204b8d1-f944-4fa7-a436-ff1d7923145e",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : true,
+      "consentText" : "${fullName}",
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    }, {
+      "id" : "4c996673-4fdd-4d48-91d4-05d584fd7f12",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    } ]
+  }, {
+    "id" : "bdbdfb4a-64aa-49a7-89bb-d67ec85f272a",
+    "clientId" : "account",
+    "name" : "${client_account}",
+    "baseUrl" : "/auth/realms/master/account",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "5879d256-6b50-4233-85cf-379c699c26a0",
+    "defaultRoles" : [ "view-profile", "manage-account" ],
+    "redirectUris" : [ "/auth/realms/master/account/*" ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "serviceAccountsEnabled" : false,
+    "directGrantsOnly" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "attributes" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "protocolMappers" : [ {
+      "id" : "14d427a2-ceff-4b50-a94a-a4474fc4fdb2",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${email}",
+      "config" : {
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "83a17f83-d98f-4e2e-91b4-b73e4e53186d",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${username}",
+      "config" : {
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "5fba4099-df00-4982-9585-5af1759602ef",
+      "name" : "family name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${familyName}",
+      "config" : {
+        "user.attribute" : "lastName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "fc7586dd-8ed3-4656-9be7-c247bba69b85",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    }, {
+      "id" : "6e9d15d7-1da8-43d4-84e5-725c479edad7",
+      "name" : "given name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${givenName}",
+      "config" : {
+        "user.attribute" : "firstName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "given_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "a890ac50-4553-4238-8356-c22e37d1fa4e",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : true,
+      "consentText" : "${fullName}",
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    } ]
+  }, {
+    "id" : "826c609d-d32e-4305-832c-2c847222c7c3",
+    "clientId" : "third-party",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "password",
+    "redirectUris" : [ "/oauth-client/*", "/oauth-client-cdi/*" ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : true,
+    "serviceAccountsEnabled" : false,
+    "directGrantsOnly" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "attributes" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : -1,
+    "protocolMappers" : [ {
+      "id" : "a0c8b770-23ef-4d79-b8e9-6b76ff2a6e01",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : true,
+      "consentText" : "${fullName}",
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    }, {
+      "id" : "eaff4d98-33c5-450f-bbe7-450bfd2ab117",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${email}",
+      "config" : {
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "594e7a02-4241-434a-9b69-9f2d93d87656",
+      "name" : "family name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${familyName}",
+      "config" : {
+        "user.attribute" : "lastName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "a83ac8f8-7e01-44df-a5fb-24b939ec31ac",
+      "name" : "given name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${givenName}",
+      "config" : {
+        "user.attribute" : "firstName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "given_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "fc84619d-935f-4c75-8c31-44ee12448d1e",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${username}",
+      "config" : {
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "15512f5b-a0c9-4d72-b398-8a5aebec741b",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    } ]
+  }, {
+    "id" : "d32d12db-d80c-457f-b1b4-bc2a3cd95826",
+    "clientId" : "offline-access-portal",
+    "adminUrl" : "/offline-access-portal",
+    "baseUrl" : "/offline-access-portal",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "password",
+    "redirectUris" : [ "/offline-access-portal/*" ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : true,
+    "serviceAccountsEnabled" : false,
+    "directGrantsOnly" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "attributes" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : -1,
+    "protocolMappers" : [ {
+      "id" : "7787685f-67c8-43b1-b332-48ec497e1d44",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : true,
+      "consentText" : "${fullName}",
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    }, {
+      "id" : "2f4b623a-d263-4b4a-ae0c-10648791981c",
+      "name" : "family name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${familyName}",
+      "config" : {
+        "user.attribute" : "lastName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "6b5193e7-06c5-4293-89c0-13c90c3fb7ed",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    }, {
+      "id" : "41c96cee-e661-4a06-922d-123016085265",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${email}",
+      "config" : {
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "1d8d553e-dc33-4065-9598-b5decaf0d11c",
+      "name" : "given name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${givenName}",
+      "config" : {
+        "user.attribute" : "firstName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "given_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "8e689c7c-693f-4001-a267-985e9c42aa6b",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${username}",
+      "config" : {
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    } ]
+  } ],
+  "browserSecurityHeaders" : {
+    "contentSecurityPolicy" : "frame-src 'self'",
+    "xFrameOptions" : "SAMEORIGIN"
+  },
+  "smtpServer" : { },
+  "eventsEnabled" : false,
+  "eventsListeners" : [ "jboss-logging" ],
+  "enabledEventTypes" : [ "SEND_RESET_PASSWORD", "SEND_VERIFY_EMAIL", "EXECUTE_ACTIONS_ERROR", "REMOVE_FEDERATED_IDENTITY", "UPDATE_TOTP", "REMOVE_TOTP", "REVOKE_GRANT", "LOGIN_ERROR", "CLIENT_LOGIN", "RESET_PASSWORD_ERROR", "CODE_TO_TOKEN_ERROR", "CUSTOM_REQUIRED_ACTION", "UPDATE_EMAIL", "REGISTER_ERROR", "LOGOUT_ERROR", "UPDATE_EMAIL_ERROR", "UPDATE_PROFILE_ERROR", "IMPERSONATE", "LOGIN", "UPDATE_PASSWORD_ERROR", "CLIENT_UPDATE_ERROR", "UPDATE_PROFILE", "REGISTER", "LOGOUT", "FEDERATED_IDENTITY_LINK", "CLIENT_REGISTER_ERROR", "CLIENT_REGISTER", "SEND_VERIFY_EMAIL_ERROR", "UPDATE_PASSWORD", "RESET_PASSWORD", "FEDERATED_IDENTITY_LINK_ERROR", "CLIENT_DELETE", "REMOVE_TOTP_ERROR", "VERIFY_EMAIL_ERROR", "VERIFY_EMAIL", "SEND_RESET_PASSWORD_ERROR", "CLIENT_DELETE_ERROR", "CLIENT_LOGIN_ERROR", "CLIENT_UPDATE", "REMOVE_FEDERATED_IDENTITY_ERROR", "EXECUTE_ACTIONS", "CUSTOM_REQUIRED_ACTION_ERROR", "UPDATE_TOTP_ERROR", "CODE_TO_TOKEN" ],
+  "adminEventsEnabled" : true,
+  "adminEventsDetailsEnabled" : true,
+  "identityProviders" : [ {
+    "alias" : "keycloak-oidc",
+    "internalId" : "721b5dae-5b98-4284-bcd1-f872ce2ac174",
+    "providerId" : "keycloak-oidc",
+    "enabled" : true,
+    "updateProfileFirstLoginMode" : "on",
+    "trustEmail" : false,
+    "storeToken" : false,
+    "addReadTokenRoleOnCreate" : false,
+    "authenticateByDefault" : false,
+    "config" : {
+      "clientSecret" : "foo",
+      "clientId" : "foo",
+      "tokenUrl" : "foo",
+      "authorizationUrl" : "foo"
+    }
+  }, {
+    "alias" : "oidc",
+    "internalId" : "7c8070e6-87d7-42b0-97df-b4cb87bc0c98",
+    "providerId" : "oidc",
+    "enabled" : true,
+    "updateProfileFirstLoginMode" : "on",
+    "trustEmail" : false,
+    "storeToken" : false,
+    "addReadTokenRoleOnCreate" : false,
+    "authenticateByDefault" : false,
+    "config" : {
+      "clientSecret" : "asdf",
+      "clientId" : "asdf",
+      "tokenUrl" : "asdf",
+      "authorizationUrl" : "asdf"
+    }
+  } ],
+  "identityProviderMappers" : [ {
+    "id" : "2bee0286-db3b-4051-ae59-3d56bf8d9f4d",
+    "name" : "asdf",
+    "identityProviderAlias" : "oidc",
+    "identityProviderMapper" : "oidc-user-attribute-idp-mapper",
+    "config" : {
+      "claim" : "fasdf",
+      "user.attribute" : "asdf"
+    }
+  } ],
+  "identityFederationEnabled" : true,
+  "internationalizationEnabled" : false,
+  "supportedLocales" : [ ],
+  "authenticationFlows" : [ {
+    "alias" : "direct grant",
+    "description" : "OpenID Connect Resource Owner Grant",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "direct-grant-validate-username",
+      "autheticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "userSetupAllowed" : false,
+      "priority" : 10
+    }, {
+      "authenticator" : "direct-grant-validate-password",
+      "autheticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "userSetupAllowed" : false,
+      "priority" : 20
+    }, {
+      "authenticator" : "direct-grant-validate-otp",
+      "autheticatorFlow" : false,
+      "requirement" : "OPTIONAL",
+      "userSetupAllowed" : false,
+      "priority" : 30
+    } ]
+  }, {
+    "alias" : "registration",
+    "description" : "registration flow",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "registration-page-form",
+      "flowAlias" : "registration form",
+      "autheticatorFlow" : true,
+      "requirement" : "REQUIRED",
+      "userSetupAllowed" : false,
+      "priority" : 10
+    } ]
+  }, {
+    "alias" : "reset credentials",
+    "description" : "Reset credentials for a user if they forgot their password or something",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "reset-credentials-choose-user",
+      "autheticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "userSetupAllowed" : false,
+      "priority" : 10
+    }, {
+      "authenticator" : "reset-credential-email",
+      "autheticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "userSetupAllowed" : false,
+      "priority" : 20
+    }, {
+      "authenticator" : "reset-password",
+      "autheticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "userSetupAllowed" : false,
+      "priority" : 30
+    }, {
+      "authenticator" : "reset-otp",
+      "autheticatorFlow" : false,
+      "requirement" : "OPTIONAL",
+      "userSetupAllowed" : false,
+      "priority" : 40
+    } ]
+  }, {
+    "alias" : "browser",
+    "description" : "browser based authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "auth-cookie",
+      "autheticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "userSetupAllowed" : false,
+      "priority" : 10
+    }, {
+      "authenticator" : "auth-spnego",
+      "autheticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "userSetupAllowed" : false,
+      "priority" : 20
+    }, {
+      "flowAlias" : "forms",
+      "autheticatorFlow" : true,
+      "requirement" : "ALTERNATIVE",
+      "userSetupAllowed" : false,
+      "priority" : 30
+    } ]
+  }, {
+    "alias" : "forms",
+    "description" : "Username, password, otp and other auth forms.",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "auth-username-password-form",
+      "autheticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "userSetupAllowed" : false,
+      "priority" : 10
+    }, {
+      "authenticator" : "auth-otp-form",
+      "autheticatorFlow" : false,
+      "requirement" : "OPTIONAL",
+      "userSetupAllowed" : false,
+      "priority" : 20
+    } ]
+  }, {
+    "alias" : "clients",
+    "description" : "Base authentication for clients",
+    "providerId" : "client-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "client-secret",
+      "autheticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "userSetupAllowed" : false,
+      "priority" : 10
+    }, {
+      "authenticator" : "client-jwt",
+      "autheticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "userSetupAllowed" : false,
+      "priority" : 20
+    } ]
+  }, {
+    "alias" : "registration form",
+    "description" : "registration form",
+    "providerId" : "form-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "registration-user-creation",
+      "autheticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "userSetupAllowed" : false,
+      "priority" : 20
+    }, {
+      "authenticator" : "registration-profile-action",
+      "autheticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "userSetupAllowed" : false,
+      "priority" : 40
+    }, {
+      "authenticator" : "registration-password-action",
+      "autheticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "userSetupAllowed" : false,
+      "priority" : 50
+    }, {
+      "authenticator" : "registration-recaptcha-action",
+      "autheticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "userSetupAllowed" : false,
+      "priority" : 60
+    } ]
+  } ],
+  "authenticatorConfig" : [ ],
+  "requiredActions" : [ {
+    "alias" : "VERIFY_EMAIL",
+    "name" : "Verify Email",
+    "providerId" : "VERIFY_EMAIL",
+    "enabled" : true,
+    "defaultAction" : false,
+    "config" : { }
+  }, {
+    "alias" : "CONFIGURE_TOTP",
+    "name" : "Configure Totp",
+    "providerId" : "CONFIGURE_TOTP",
+    "enabled" : true,
+    "defaultAction" : false,
+    "config" : { }
+  }, {
+    "alias" : "UPDATE_PROFILE",
+    "name" : "Update Profile",
+    "providerId" : "UPDATE_PROFILE",
+    "enabled" : true,
+    "defaultAction" : false,
+    "config" : { }
+  }, {
+    "alias" : "terms_and_conditions",
+    "name" : "Terms and Conditions",
+    "providerId" : "terms_and_conditions",
+    "enabled" : false,
+    "defaultAction" : false,
+    "config" : { }
+  }, {
+    "alias" : "UPDATE_PASSWORD",
+    "name" : "Update Password",
+    "providerId" : "UPDATE_PASSWORD",
+    "enabled" : true,
+    "defaultAction" : false,
+    "config" : { }
+  } ],
+  "browserFlow" : "browser",
+  "registrationFlow" : "registration",
+  "directGrantFlow" : "direct grant",
+  "resetCredentialsFlow" : "reset credentials",
+  "clientAuthenticationFlow" : "clients"
+}, {
+  "id" : "demo",
+  "realm" : "demo",
+  "notBefore" : 0,
+  "revokeRefreshToken" : false,
+  "accessTokenLifespan" : 60,
+  "ssoSessionIdleTimeout" : 600,
+  "ssoSessionMaxLifespan" : 36000,
+  "offlineSessionIdleTimeout" : 2592000,
+  "accessCodeLifespan" : 60,
+  "accessCodeLifespanUserAction" : 300,
+  "accessCodeLifespanLogin" : 1800,
+  "enabled" : true,
+  "sslRequired" : "external",
+  "registrationAllowed" : false,
+  "registrationEmailAsUsername" : false,
+  "rememberMe" : false,
+  "verifyEmail" : false,
+  "resetPasswordAllowed" : false,
+  "editUsernameAllowed" : false,
+  "bruteForceProtected" : false,
+  "maxFailureWaitSeconds" : 900,
+  "minimumQuickLoginWaitSeconds" : 60,
+  "waitIncrementSeconds" : 60,
+  "quickLoginCheckMilliSeconds" : 1000,
+  "maxDeltaTimeSeconds" : 43200,
+  "failureFactor" : 30,
+  "privateKey" : "MIICXAIBAAKBgQCrVrCuTtArbgaZzL1hvh0xtL5mc7o0NqPVnYXkLvgcwiC3BjLGw1tGEGoJaXDuSaRllobm53JBhjx33UNv+5z/UMG4kytBWxheNVKnL6GgqlNabMaFfPLPCF8kAgKnsi79NMo+n6KnSY8YeUmec/p2vjO2NjsSAVcWEQMVhJ31LwIDAQABAoGAfmO8gVhyBxdqlxmIuglbz8bcjQbhXJLR2EoS8ngTXmN1bo2L90M0mUKSdc7qF10LgETBzqL8jYlQIbt+e6TH8fcEpKCjUlyq0Mf/vVbfZSNaVycY13nTzo27iPyWQHK5NLuJzn1xvxxrUeXI6A2WFpGEBLbHjwpx5WQG9A+2scECQQDvdn9NE75HPTVPxBqsEd2z10TKkl9CZxu10Qby3iQQmWLEJ9LNmy3acvKrE3gMiYNWb6xHPKiIqOR1as7L24aTAkEAtyvQOlCvr5kAjVqrEKXalj0Tzewjweuxc0pskvArTI2Oo070h65GpoIKLc9jf+UA69cRtquwP93aZKtW06U8dQJAF2Y44ks/mK5+eyDqik3koCI08qaC8HYq2wVl7G2QkJ6sbAaILtcvD92ToOvyGyeE0flvmDZxMYlvaZnaQ0lcSQJBAKZU6umJi3/xeEbkJqMfeLclD27XGEFoPeNrmdx0q10Azp4NfJAY+Z8KRyQCR2BEG+oNitBOZ+YXF9KCpH3cdmECQHEigJhYg+ykOvr1aiZUMFT72HU0jnmQe2FVekuG+LJUt2Tm7GtMjTFoGpf0JwrVuZN39fOYAlo+nTixgeW7X8Y=",
+  "publicKey" : "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCrVrCuTtArbgaZzL1hvh0xtL5mc7o0NqPVnYXkLvgcwiC3BjLGw1tGEGoJaXDuSaRllobm53JBhjx33UNv+5z/UMG4kytBWxheNVKnL6GgqlNabMaFfPLPCF8kAgKnsi79NMo+n6KnSY8YeUmec/p2vjO2NjsSAVcWEQMVhJ31LwIDAQAB",
+  "certificate" : "MIIBkTCB+wIGAVD9HwYqMA0GCSqGSIb3DQEBCwUAMA8xDTALBgNVBAMMBGRlbW8wHhcNMTUxMTEyMTkxMzAwWhcNMjUxMTEyMTkxNDQwWjAPMQ0wCwYDVQQDDARkZW1vMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCrVrCuTtArbgaZzL1hvh0xtL5mc7o0NqPVnYXkLvgcwiC3BjLGw1tGEGoJaXDuSaRllobm53JBhjx33UNv+5z/UMG4kytBWxheNVKnL6GgqlNabMaFfPLPCF8kAgKnsi79NMo+n6KnSY8YeUmec/p2vjO2NjsSAVcWEQMVhJ31LwIDAQABMA0GCSqGSIb3DQEBCwUAA4GBAIPmcZ++qAtAEzdrRMtkmyDAtf41R4MSC3+ljYErbFI9mPqnrY2BAzLpusivqxuORBwYetdhFuqAJAluB8K1a6aRadt2u2+z0eGEgkKVtfYs4tDth23lg8WvubmwyJrGfCY5GtHEAl3RuTCkFTSRqbJ9fzD68rhJQPojNxAhABze",
+  "codeSecret" : "b2e0a1a4-94ae-46d4-8d30-9b8ee47627ae",
+  "roles" : {
+    "realm" : [ {
+      "id" : "4c9c285e-ec83-4294-b629-57c22b3916d9",
+      "name" : "offline_access",
+      "description" : "${role_offline-access}",
+      "scopeParamRequired" : true,
+      "composite" : false
+    }, {
+      "id" : "6f916d2f-3dae-4153-b9c0-fc0987fc18e1",
+      "name" : "create-realm",
+      "description" : "${role_create-realm}",
+      "scopeParamRequired" : false,
+      "composite" : false
+    }, {
+      "id" : "d928d12d-5d3c-48a4-b1dc-510d23001963",
+      "name" : "admin",
+      "description" : "Administrator privileges",
+      "scopeParamRequired" : false,
+      "composite" : false
+    }, {
+      "id" : "0301e5bd-7902-4929-9da1-553de7738044",
+      "name" : "user",
+      "description" : "User privileges",
+      "scopeParamRequired" : false,
+      "composite" : false
+    } ],
+    "client" : {
+      "database-service" : [ ],
+      "admin-client" : [ ],
+      "realm-management" : [ {
+        "id" : "3b939f75-d013-4096-8462-48aa39261293",
+        "name" : "create-client",
+        "description" : "${role_create-client}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      }, {
+        "id" : "08714717-6150-42f3-b360-e3706cea1b4d",
+        "name" : "view-events",
+        "description" : "${role_view-events}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      }, {
+        "id" : "b20ee4e9-ba54-48c4-99fe-fc0281b9c230",
+        "name" : "view-realm",
+        "description" : "${role_view-realm}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      }, {
+        "id" : "264f5da2-4917-47b5-b89a-38b3cdedf851",
+        "name" : "manage-users",
+        "description" : "${role_manage-users}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      }, {
+        "id" : "bde13dc7-d843-4fdb-95c2-1ca5826477ac",
+        "name" : "view-identity-providers",
+        "description" : "${role_view-identity-providers}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      }, {
+        "id" : "6e3455b4-11cc-4d59-89a3-93482cc30b04",
+        "name" : "impersonation",
+        "description" : "${role_impersonation}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      }, {
+        "id" : "d69ef626-f6a7-4b83-b207-ad3fe380d93e",
+        "name" : "view-clients",
+        "description" : "${role_view-clients}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      }, {
+        "id" : "04c6b2a0-c47d-445d-90e9-8b98545fdcee",
+        "name" : "view-users",
+        "description" : "${role_view-users}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      }, {
+        "id" : "1213edcd-9442-47b3-a06a-3818acd928e5",
+        "name" : "manage-identity-providers",
+        "description" : "${role_manage-identity-providers}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      }, {
+        "id" : "357a66b3-63e9-49e2-a571-7c1e6c6180dd",
+        "name" : "realm-admin",
+        "description" : "${role_realm-admin}",
+        "scopeParamRequired" : false,
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "realm-management" : [ "create-client", "view-events", "view-users", "manage-identity-providers", "view-realm", "manage-clients", "manage-users", "view-clients", "view-identity-providers", "impersonation", "manage-events", "manage-realm" ]
+          }
+        }
+      }, {
+        "id" : "b9b695e9-4261-46ec-aca1-da0fd9ed44aa",
+        "name" : "manage-clients",
+        "description" : "${role_manage-clients}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      }, {
+        "id" : "098a9946-e58a-4a5c-b04e-5d4acfe9f6f1",
+        "name" : "manage-events",
+        "description" : "${role_manage-events}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      }, {
+        "id" : "000d9791-8f42-49d7-bbdc-01e6b5a8cc70",
+        "name" : "manage-realm",
+        "description" : "${role_manage-realm}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      } ],
+      "customer-portal-js" : [ ],
+      "security-admin-console" : [ ],
+      "product-sa-client-jwt-auth" : [ ],
+      "angular-product" : [ ],
+      "product-sa-client" : [ ],
+      "broker" : [ {
+        "id" : "89c1bae3-b2c9-4e2f-937f-7514923f5e5f",
+        "name" : "read-token",
+        "description" : "${role_read-token}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      } ],
+      "customer-portal-cli" : [ ],
+      "customer-portal" : [ ],
+      "product-portal" : [ ],
+      "account" : [ {
+        "id" : "198c3c05-7bff-408f-8ada-95a5481861f9",
+        "name" : "manage-account",
+        "description" : "${role_manage-account}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      }, {
+        "id" : "2cf786e5-e0bb-4492-bf7d-16688d12e5ff",
+        "name" : "view-profile",
+        "description" : "${role_view-profile}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      } ],
+      "offline-access-portal" : [ ],
+      "third-party" : [ {
+        "id" : "59daf30e-3933-4386-b2cd-ced19f3f1ca2",
+        "name" : "myclientrole",
+        "description" : "My client role",
+        "scopeParamRequired" : false,
+        "composite" : false
+      } ]
+    }
+  },
+  "defaultRoles" : [ "offline_access" ],
+  "requiredCredentials" : [ "password" ],
+  "otpPolicyType" : "totp",
+  "otpPolicyAlgorithm" : "HmacSHA1",
+  "otpPolicyInitialCounter" : 0,
+  "otpPolicyDigits" : 6,
+  "otpPolicyLookAheadWindow" : 1,
+  "otpPolicyPeriod" : 30,
+  "users" : [ {
+    "id" : "a7aff2b8-f001-47df-9f9f-f3f02d18f6b1",
+    "createdTimestamp" : 1447786264017,
+    "username" : "aaaa",
+    "enabled" : true,
+    "totp" : false,
+    "emailVerified" : false,
+    "credentials" : [ ],
+    "requiredActions" : [ ],
+    "realmRoles" : [ "offline_access" ],
+    "clientRoles" : {
+      "account" : [ "manage-account", "view-profile" ]
+    }
+  }, {
+    "id" : "be51490a-8473-4f83-8625-984959210741",
+    "createdTimestamp" : 1447786273233,
+    "username" : "bbbb",
+    "enabled" : true,
+    "totp" : false,
+    "emailVerified" : false,
+    "credentials" : [ ],
+    "requiredActions" : [ ],
+    "realmRoles" : [ "offline_access" ],
+    "clientRoles" : {
+      "account" : [ "manage-account", "view-profile" ]
+    }
+  }, {
+    "id" : "9b202a37-2b16-4341-bcc2-c2549586911c",
+    "username" : "bburke@redhat.com",
+    "enabled" : true,
+    "totp" : false,
+    "emailVerified" : false,
+    "firstName" : "Bill",
+    "lastName" : "Burke",
+    "email" : "bburke@redhat.com",
+    "credentials" : [ {
+      "type" : "password",
+      "hashedSaltedValue" : "FhdAutJurcyDSxVQma3VNMX2mcfnZ0MN2LToYCLWi3G+fnp793NrQ9xWzGICpsQ+nq1EA6M64o2bil+oh+ezmA==",
+      "salt" : "uBE9SOPCNIEhOdnc8ZXbFQ==",
+      "hashIterations" : 1,
+      "counter" : 0,
+      "digits" : 0,
+      "temporary" : false
+    } ],
+    "requiredActions" : [ ],
+    "realmRoles" : [ "offline_access", "user" ],
+    "clientRoles" : {
+      "account" : [ "manage-account" ]
+    }
+  }, {
+    "id" : "83454480-d38f-410f-8a36-1af1b6be5a19",
+    "createdTimestamp" : 1447786289606,
+    "username" : "cccc",
+    "enabled" : true,
+    "totp" : false,
+    "emailVerified" : false,
+    "credentials" : [ ],
+    "requiredActions" : [ ],
+    "realmRoles" : [ "offline_access" ],
+    "clientRoles" : {
+      "account" : [ "manage-account", "view-profile" ]
+    }
+  }, {
+    "id" : "999a7fe4-618a-4349-ae0c-96a9c47d34fd",
+    "username" : "mposolda@redhat.com",
+    "enabled" : true,
+    "totp" : false,
+    "emailVerified" : false,
+    "firstName" : "Marek",
+    "lastName" : "Posolda",
+    "email" : "mposolda@redhat.com",
+    "credentials" : [ {
+      "type" : "password",
+      "hashedSaltedValue" : "GmPpUa3c+8lX2IvdxktX4NfvVXdPwJKsk6tcGVrUD0s+yAUxsASPBoLbmLOUT59H28qkb7/KnAHLAi2euqcYNg==",
+      "salt" : "eA9HDWvaYqhKVCnfU2wNAg==",
+      "hashIterations" : 1,
+      "counter" : 0,
+      "digits" : 0,
+      "temporary" : false
+    } ],
+    "requiredActions" : [ ],
+    "realmRoles" : [ "offline_access", "user" ],
+    "clientRoles" : {
+      "account" : [ "manage-account" ]
+    }
+  }, {
+    "id" : "fc30bf89-c312-4d4a-9774-55555c938310",
+    "username" : "stian",
+    "enabled" : true,
+    "totp" : false,
+    "emailVerified" : false,
+    "firstName" : "Stian",
+    "lastName" : "Thorgersen",
+    "email" : "stian@redhat.com",
+    "credentials" : [ {
+      "type" : "password",
+      "hashedSaltedValue" : "VAuUKmATwpbkxNCFl1KmMYe9COd1EcpOJbs+C1S/VMjJWjJDG1Ebq4alkNUvTSFcHwtccVvXOw1zbes0QnahdA==",
+      "salt" : "91IXeHc7uNf4j0z7UZwwiw==",
+      "hashIterations" : 1,
+      "counter" : 0,
+      "digits" : 0,
+      "temporary" : false
+    } ],
+    "requiredActions" : [ ],
+    "realmRoles" : [ "offline_access", "user" ],
+    "clientRoles" : {
+      "account" : [ "manage-account" ]
+    }
+  } ],
+  "scopeMappings" : [ {
+    "client" : "offline-access-portal",
+    "roles" : [ "offline_access", "user" ]
+  } ],
+  "clientScopeMappings" : {
+    "realm-management" : [ {
+      "client" : "security-admin-console",
+      "roles" : [ "realm-admin" ]
+    } ]
+  },
+  "clients" : [ {
+    "id" : "f2fdc211-9ab9-4b91-a7ba-077ba63abacb",
+    "clientId" : "database-service",
+    "adminUrl" : "/database",
+    "baseUrl" : "/database",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "c07577a5-421b-441f-99ab-5b3b854146a6",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : true,
+    "consentRequired" : false,
+    "serviceAccountsEnabled" : false,
+    "directGrantsOnly" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "attributes" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : -1,
+    "protocolMappers" : [ {
+      "id" : "5c5d79d8-ee42-43a0-a5f8-869eb9e7240c",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : true,
+      "consentText" : "${fullName}",
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    }, {
+      "id" : "7270e5cd-383a-462c-864b-c9a62ec09669",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${username}",
+      "config" : {
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "f9dabb18-b105-4d40-ac16-a6922d692745",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${email}",
+      "config" : {
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "6cbe4afe-5c1a-403f-9bfe-94788586d1ca",
+      "name" : "given name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${givenName}",
+      "config" : {
+        "user.attribute" : "firstName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "given_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "24500a3a-d6f8-4125-8d87-549322afa2ba",
+      "name" : "family name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${familyName}",
+      "config" : {
+        "user.attribute" : "lastName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "952feb28-70a9-4288-8e43-25eaffe06059",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    } ]
+  }, {
+    "id" : "a9a0369c-3e8e-4c0a-9e9b-44f18d58bbc8",
+    "clientId" : "admin-client",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "5232b41c-8d89-4a37-b467-8c3bf6277f8f",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "serviceAccountsEnabled" : false,
+    "directGrantsOnly" : true,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "attributes" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : -1,
+    "protocolMappers" : [ {
+      "id" : "5a210a28-3542-4cc1-afc0-3825911b85be",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${username}",
+      "config" : {
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "4ecac0b1-a61a-4a91-9540-b2f5b072f650",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${email}",
+      "config" : {
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "e6ee1534-8301-414d-8264-e3ca38d47d9a",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : true,
+      "consentText" : "${fullName}",
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    }, {
+      "id" : "7dd459f7-c23c-4543-be26-6ba28bba7291",
+      "name" : "family name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${familyName}",
+      "config" : {
+        "user.attribute" : "lastName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "38feea4a-d4ea-46e2-8a9d-a312a22b9aac",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    }, {
+      "id" : "4475e482-d67d-4ebb-a998-3f801bb54557",
+      "name" : "given name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${givenName}",
+      "config" : {
+        "user.attribute" : "firstName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "given_name",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "093f1be5-ab06-4a97-8c9b-ffcbe3e4e291",
+    "clientId" : "realm-management",
+    "name" : "${client_realm-management}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "198e8543-d0f9-4095-a51c-af8ff13c2579",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : true,
+    "consentRequired" : false,
+    "serviceAccountsEnabled" : false,
+    "directGrantsOnly" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "attributes" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "protocolMappers" : [ {
+      "id" : "349da162-0405-46f1-bfa4-d67b6812af7a",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${username}",
+      "config" : {
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "7bc4b18e-e2dd-4eea-aad6-5ee807e07fb0",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${email}",
+      "config" : {
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "d529517b-c9cc-4653-b87b-b69e6b1369a2",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    }, {
+      "id" : "55d60e9b-ce56-44ff-bffe-eefc828a9e5e",
+      "name" : "family name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${familyName}",
+      "config" : {
+        "user.attribute" : "lastName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "880e5b27-6eaa-4d13-852e-ef0ff1e5ba85",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : true,
+      "consentText" : "${fullName}",
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    }, {
+      "id" : "5fd28107-0d3f-486a-9366-2ba8ebd3555d",
+      "name" : "given name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${givenName}",
+      "config" : {
+        "user.attribute" : "firstName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "given_name",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "a79cdc99-1ed3-406f-b02d-48b300c58613",
+    "clientId" : "customer-portal-js",
+    "baseUrl" : "/customer-portal-js",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "5bceb81d-118c-4871-b059-6e0323a6b1cb",
+    "redirectUris" : [ "/customer-portal-js/*" ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "serviceAccountsEnabled" : false,
+    "directGrantsOnly" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "attributes" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : -1,
+    "protocolMappers" : [ {
+      "id" : "d86ab89c-b18a-4179-9765-5b2fe1e091bd",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${username}",
+      "config" : {
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "d19687ce-8f3d-4e5e-a4a4-a4980b97ca6c",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : true,
+      "consentText" : "${fullName}",
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    }, {
+      "id" : "f3a8f4e0-ee07-4fec-a20c-dbf668b66070",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    }, {
+      "id" : "01ad03a9-e6bc-4ede-82ed-d359f781c17b",
+      "name" : "given name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${givenName}",
+      "config" : {
+        "user.attribute" : "firstName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "given_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "bb169ec6-5de3-4824-a148-8f4395aa9a96",
+      "name" : "family name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${familyName}",
+      "config" : {
+        "user.attribute" : "lastName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "7e4b9ad5-b679-4942-a12a-0f3fe7829813",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${email}",
+      "config" : {
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "4e300b13-3a93-40b4-b663-901c3cf08e00",
+    "clientId" : "security-admin-console",
+    "name" : "${client_security-admin-console}",
+    "baseUrl" : "/auth/admin/demo/console/index.html",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "3598448d-6430-486c-b2e7-061690e05042",
+    "redirectUris" : [ "/auth/admin/demo/console/*" ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "serviceAccountsEnabled" : false,
+    "directGrantsOnly" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "attributes" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "protocolMappers" : [ {
+      "id" : "a7df97a6-c744-4ed3-b559-efaf52d3cb00",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${username}",
+      "config" : {
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "7363ee08-8353-4275-9c56-e37dfd1bf5e2",
+      "name" : "locale",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "consentText" : "${locale}",
+      "config" : {
+        "user.attribute" : "locale",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "locale",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "acd0975e-4722-449e-a73e-73b11ad379a1",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${email}",
+      "config" : {
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "a97100a1-e45a-4cae-b633-7ccd08178ff4",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : true,
+      "consentText" : "${fullName}",
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    }, {
+      "id" : "ea5684e4-ffa5-40c2-89af-cf17fd97d210",
+      "name" : "family name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${familyName}",
+      "config" : {
+        "user.attribute" : "lastName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "a8c7c8fb-1906-4de3-a243-04f6809672a7",
+      "name" : "given name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${givenName}",
+      "config" : {
+        "user.attribute" : "firstName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "given_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "f12d2cdd-99ee-4344-b9c4-51c92fe89019",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    } ]
+  }, {
+    "id" : "e5c1c405-8946-4ba7-87b2-ebf95adecf95",
+    "clientId" : "product-sa-client-jwt-auth",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "clientAuthenticatorType" : "client-jwt",
+    "secret" : "9ee8df09-53ad-4c6c-aac3-ef0c56cb712d",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "serviceAccountsEnabled" : true,
+    "directGrantsOnly" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "attributes" : {
+      "jwt.credential.certificate" : "MIICnTCCAYUCBgFPPLDaTzANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdjbGllbnQxMB4XDTE1MDgxNzE3MjI0N1oXDTI1MDgxNzE3MjQyN1owEjEQMA4GA1UEAwwHY2xpZW50MTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAIUjjgv+V3s96O+Za9002Lp/trtGuHBeaeVL9dFKMKzO2MPqdRmHB4PqNlDdd28Rwf5Xn6iWdFpyUKOnI/yXDLhdcuFpR0sMNK/C9Lt+hSpPFLuzDqgtPgDotlMxiHIWDOZ7g9/gPYNXbNvjv8nSiyqoguoCQiiafW90bPHsiVLdP7ZIUwCcfi1qQm7FhxRJ1NiW5dvUkuCnnWEf0XR+Wzc5eC9EgB0taLFiPsSEIlWMm5xlahYyXkPdNOqZjiRnrTWm5Y4uk8ZcsD/KbPTf/7t7cQXipVaswgjdYi1kK2/zRwOhg1QwWFX/qmvdd+fLxV0R6VqRDhn7Qep2cxwMxLsCAwEAATANBgkqhkiG9w0BAQsFAAOCAQEAKE6OA46sf20bz8LZPoiNsqRwBUDkaMGXfnob7s/hJZIIwDEx0IAQ3uKsG7q9wb+aA6s+v7S340zb2k3IxuhFaHaZpAd4CyR5cn1FHylbzoZ7rI/3ASqHDqpljdJaFqPH+m7nZWtyDvtZf+gkZ8OjsndwsSBK1d/jMZPp29qYbl1+XfO7RCp/jDqro/R3saYFaIFiEZPeKn1hUJn6BO48vxH1xspSu9FmlvDOEAOz4AuM58z4zRMP49GcFdCWr1wkonJUHaSptJaQwmBwLFUkCbE5I1ixGMb7mjEud6Y5jhfzJiZMo2U8RfcjNbrN0diZl3jB6LQIwESnhYSghaTjNQ=="
+    },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : -1,
+    "protocolMappers" : [ {
+      "id" : "44476a5a-5910-41f0-81d0-f4df1bbf2af0",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${email}",
+      "config" : {
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "893f9ec3-cc96-45c8-a45f-1a0acd5a4b9a",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    }, {
+      "id" : "5387018a-17b8-4ab5-a321-8b55c4ba8647",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${username}",
+      "config" : {
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "d1859c79-ab34-4cfa-94ca-bddeed297851",
+      "name" : "given name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${givenName}",
+      "config" : {
+        "user.attribute" : "firstName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "given_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "7b7a51d7-d7e0-4dcd-8484-e9859d5fa936",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : true,
+      "consentText" : "${fullName}",
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    }, {
+      "id" : "1afe8b40-940a-4b8c-b4e3-e4cb77564a04",
+      "name" : "family name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${familyName}",
+      "config" : {
+        "user.attribute" : "lastName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "236116d3-22be-4d91-9a96-baa47abf2b40",
+    "clientId" : "angular-product",
+    "baseUrl" : "/angular-product/index.html",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "8dcdd603-046b-4d9b-aa6c-a2216f08adbd",
+    "redirectUris" : [ "/angular-product/*" ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "serviceAccountsEnabled" : false,
+    "directGrantsOnly" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "attributes" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : -1,
+    "protocolMappers" : [ {
+      "id" : "dcbfd946-b240-46a7-be7c-cc4805818cb1",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${email}",
+      "config" : {
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "99ee6cff-9232-4a75-95c4-6758e44eee2e",
+      "name" : "family name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${familyName}",
+      "config" : {
+        "user.attribute" : "lastName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "e7977843-998c-4c41-9d60-2f2f3c7b4d31",
+      "name" : "given name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${givenName}",
+      "config" : {
+        "user.attribute" : "firstName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "given_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "c002b2f4-c104-4767-9032-3d676ea95e84",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    }, {
+      "id" : "8da0d621-c553-4711-b8af-ff701aa00067",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : true,
+      "consentText" : "${fullName}",
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    }, {
+      "id" : "4ce074ae-0b30-489d-a6e0-250a0e9d09cc",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${username}",
+      "config" : {
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "dbbf4149-862d-4169-a245-ff1311a5fee4",
+    "clientId" : "product-sa-client",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "password",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "serviceAccountsEnabled" : true,
+    "directGrantsOnly" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "attributes" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : -1,
+    "protocolMappers" : [ {
+      "id" : "63c63de0-cace-4dcf-b9f3-748bcb30363c",
+      "name" : "given name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${givenName}",
+      "config" : {
+        "user.attribute" : "firstName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "given_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "90003b43-b9b5-4a99-9a55-cfa3a3f61bd1",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${email}",
+      "config" : {
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "5768ee0f-9ca8-4e25-af4b-20d8168a3353",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : true,
+      "consentText" : "${fullName}",
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    }, {
+      "id" : "48e4fdb0-366b-4398-9283-6caf200faa1a",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    }, {
+      "id" : "859d6733-75ce-4a4d-9327-eac92db09dde",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${username}",
+      "config" : {
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "6581a732-d6c8-4f71-b79a-8a7f65fe029d",
+      "name" : "family name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${familyName}",
+      "config" : {
+        "user.attribute" : "lastName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "0373aa1f-2d8e-4dfe-952a-c3630b816052",
+    "clientId" : "broker",
+    "name" : "${client_broker}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "14a007f3-c33d-4031-a65e-7638ad1b2ddb",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "serviceAccountsEnabled" : false,
+    "directGrantsOnly" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "attributes" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "protocolMappers" : [ {
+      "id" : "ceac6e36-c896-46a7-bb34-74c8221ff73e",
+      "name" : "family name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${familyName}",
+      "config" : {
+        "user.attribute" : "lastName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "dbc6f757-bef2-4ba2-a9d2-ca31eaea1bf4",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : true,
+      "consentText" : "${fullName}",
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    }, {
+      "id" : "4ce51699-6cd3-4a28-84f9-5436b790bf34",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${email}",
+      "config" : {
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "b69a15d2-1278-4383-821f-d30f283d2589",
+      "name" : "given name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${givenName}",
+      "config" : {
+        "user.attribute" : "firstName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "given_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "d758376d-7992-4210-82ef-dda968dbf7c6",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${username}",
+      "config" : {
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "8035b804-1d16-41e6-8d87-3819d8bea996",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    } ]
+  }, {
+    "id" : "df7f0085-4ad8-4979-b33d-e399cc8eaf49",
+    "clientId" : "customer-portal-cli",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "4db5ba21-d810-42dc-9384-5a8268013d12",
+    "redirectUris" : [ "urn:ietf:wg:oauth:2.0:oob", "http://localhost" ],
+    "webOrigins" : [ "http://localhost" ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "serviceAccountsEnabled" : false,
+    "directGrantsOnly" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "attributes" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : -1,
+    "protocolMappers" : [ {
+      "id" : "196ca389-1240-4d86-980d-d6fe94224f11",
+      "name" : "family name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${familyName}",
+      "config" : {
+        "user.attribute" : "lastName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "cfe9b599-96e4-4063-84b1-de54659b6296",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${username}",
+      "config" : {
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "f475e915-24b5-4670-a25d-2bd6166a26a5",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${email}",
+      "config" : {
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "0a5eeb46-28a8-4e32-8ffe-84059f824ee4",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    }, {
+      "id" : "c74425c3-a762-46c6-beb9-1330fb39628c",
+      "name" : "given name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${givenName}",
+      "config" : {
+        "user.attribute" : "firstName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "given_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "17174fe0-b305-4b75-92f5-1ea0a3f5f7bf",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : true,
+      "consentText" : "${fullName}",
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    } ]
+  }, {
+    "id" : "faf80527-7ecc-450b-985f-e74f6acccf13",
+    "clientId" : "customer-portal",
+    "adminUrl" : "/customer-portal",
+    "baseUrl" : "/customer-portal",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "password",
+    "redirectUris" : [ "/customer-portal/*" ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "serviceAccountsEnabled" : false,
+    "directGrantsOnly" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "attributes" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : -1,
+    "protocolMappers" : [ {
+      "id" : "3be6ab05-39af-4512-9301-78dfd4663427",
+      "name" : "family name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${familyName}",
+      "config" : {
+        "user.attribute" : "lastName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "5b7bc226-696c-4aa6-9c25-d8911900d555",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    }, {
+      "id" : "dc5c8901-5fb5-4dff-90aa-6d373e49293c",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : true,
+      "consentText" : "${fullName}",
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    }, {
+      "id" : "908647d2-97d6-4897-980d-a0653d2c7581",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${username}",
+      "config" : {
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "76fcd11a-93f6-4f49-8840-3990ba7bd6b5",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${email}",
+      "config" : {
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "be669592-3cb1-4cc2-98e9-38181f52eb80",
+      "name" : "given name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${givenName}",
+      "config" : {
+        "user.attribute" : "firstName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "given_name",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "3a5f2f8b-48ad-470e-aee8-c71744367ef7",
+    "clientId" : "product-portal",
+    "adminUrl" : "/product-portal",
+    "baseUrl" : "/product-portal",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "password",
+    "redirectUris" : [ "/product-portal/*" ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "serviceAccountsEnabled" : false,
+    "directGrantsOnly" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "attributes" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : -1,
+    "protocolMappers" : [ {
+      "id" : "22815b6d-d796-4381-866f-712814759109",
+      "name" : "given name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${givenName}",
+      "config" : {
+        "user.attribute" : "firstName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "given_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "5f837d0b-06d6-4208-a1aa-49d181f65cb8",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${email}",
+      "config" : {
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "4c26aac4-b1c2-440a-bec9-af87ea8d5f8a",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${username}",
+      "config" : {
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "2d1cfd33-7bdd-482d-9550-2cee022cd8cf",
+      "name" : "family name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${familyName}",
+      "config" : {
+        "user.attribute" : "lastName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "8ac85b5f-b149-4db7-b72e-3494ea9a6a2b",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : true,
+      "consentText" : "${fullName}",
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    }, {
+      "id" : "dce387b1-0805-4f27-bbb0-d6a49294b9f5",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    } ]
+  }, {
+    "id" : "c581706b-5a96-4ad6-8e28-8221bc1ae866",
+    "clientId" : "account",
+    "name" : "${client_account}",
+    "baseUrl" : "/auth/realms/demo/account",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "b1cef9f4-3843-494f-8fab-2aea834f6d21",
+    "defaultRoles" : [ "view-profile", "manage-account" ],
+    "redirectUris" : [ "/auth/realms/demo/account/*" ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "serviceAccountsEnabled" : false,
+    "directGrantsOnly" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "attributes" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "protocolMappers" : [ {
+      "id" : "aeb1484c-04f0-4e1f-a73b-05ecf7019ec9",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    }, {
+      "id" : "9bfc7028-7345-42ee-9f2c-8d92bc96e7d7",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${username}",
+      "config" : {
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "01d89081-4505-4223-96b0-934530f83ae8",
+      "name" : "family name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${familyName}",
+      "config" : {
+        "user.attribute" : "lastName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "bafbfb31-1a00-4527-a07d-5b11bbf3559e",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${email}",
+      "config" : {
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "c8cdee70-744e-47dc-8ffc-d0b6c7526756",
+      "name" : "given name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${givenName}",
+      "config" : {
+        "user.attribute" : "firstName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "given_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "1311046e-aa5b-48d8-944f-adeea53e70a5",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : true,
+      "consentText" : "${fullName}",
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    } ]
+  }, {
+    "id" : "e6e83103-2950-4bdf-8118-981be005aed6",
+    "clientId" : "offline-access-portal",
+    "adminUrl" : "/offline-access-portal",
+    "baseUrl" : "/offline-access-portal",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "password",
+    "redirectUris" : [ "/offline-access-portal/*" ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : true,
+    "serviceAccountsEnabled" : false,
+    "directGrantsOnly" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "attributes" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : -1,
+    "protocolMappers" : [ {
+      "id" : "6f2943c7-a0d1-4439-8cb9-c7d92e016b91",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    }, {
+      "id" : "1957c63f-1bb8-4069-8b02-226656e957b6",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : true,
+      "consentText" : "${fullName}",
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    }, {
+      "id" : "3a62f4e1-adb2-4b0e-be0a-46313896a5f7",
+      "name" : "family name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${familyName}",
+      "config" : {
+        "user.attribute" : "lastName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "952f391a-9ad8-49ab-81e5-58f0039de196",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${email}",
+      "config" : {
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "cfb0cc2e-9e51-4df6-b8a5-8ab559cf7f21",
+      "name" : "given name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${givenName}",
+      "config" : {
+        "user.attribute" : "firstName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "given_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "85c67366-c1af-4257-8839-59e89410e16b",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${username}",
+      "config" : {
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "ea87a33c-879d-4bc5-93dc-6bb85143387f",
+    "clientId" : "third-party",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "password",
+    "redirectUris" : [ "/oauth-client/*", "/oauth-client-cdi/*" ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : true,
+    "serviceAccountsEnabled" : false,
+    "directGrantsOnly" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "attributes" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : -1,
+    "protocolMappers" : [ {
+      "id" : "d3053d4b-07aa-4c5d-a43e-414919df06ce",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${username}",
+      "config" : {
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "c93190fc-8c0d-415c-879b-6f2ab78bbb67",
+      "name" : "family name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${familyName}",
+      "config" : {
+        "user.attribute" : "lastName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "201fb55f-f3ca-4ff9-8897-082751585274",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${email}",
+      "config" : {
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "9b39c00f-fd99-43b0-bd9b-b925e6c311a2",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : true,
+      "consentText" : "${fullName}",
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    }, {
+      "id" : "68749430-666c-424d-a0a2-17633bdd94d7",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    }, {
+      "id" : "af9a8820-0d8d-43bc-bbb7-19c404f3b371",
+      "name" : "given name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${givenName}",
+      "config" : {
+        "user.attribute" : "firstName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "given_name",
+        "jsonType.label" : "String"
+      }
+    } ]
+  } ],
+  "browserSecurityHeaders" : {
+    "contentSecurityPolicy" : "frame-src 'self'",
+    "xFrameOptions" : "SAMEORIGIN"
+  },
+  "smtpServer" : { },
+  "eventsEnabled" : false,
+  "eventsListeners" : [ "jboss-logging" ],
+  "enabledEventTypes" : [ "SEND_RESET_PASSWORD", "SEND_VERIFY_EMAIL", "EXECUTE_ACTIONS_ERROR", "REMOVE_FEDERATED_IDENTITY", "UPDATE_TOTP", "REMOVE_TOTP", "REVOKE_GRANT", "LOGIN_ERROR", "CLIENT_LOGIN", "RESET_PASSWORD_ERROR", "CODE_TO_TOKEN_ERROR", "CUSTOM_REQUIRED_ACTION", "UPDATE_EMAIL", "REGISTER_ERROR", "LOGOUT_ERROR", "UPDATE_EMAIL_ERROR", "UPDATE_PROFILE_ERROR", "IMPERSONATE", "LOGIN", "UPDATE_PASSWORD_ERROR", "CLIENT_UPDATE_ERROR", "UPDATE_PROFILE", "REGISTER", "LOGOUT", "FEDERATED_IDENTITY_LINK", "CLIENT_REGISTER_ERROR", "CLIENT_REGISTER", "SEND_VERIFY_EMAIL_ERROR", "UPDATE_PASSWORD", "RESET_PASSWORD", "FEDERATED_IDENTITY_LINK_ERROR", "CLIENT_DELETE", "REMOVE_TOTP_ERROR", "VERIFY_EMAIL_ERROR", "VERIFY_EMAIL", "SEND_RESET_PASSWORD_ERROR", "CLIENT_DELETE_ERROR", "CLIENT_LOGIN_ERROR", "CLIENT_UPDATE", "REMOVE_FEDERATED_IDENTITY_ERROR", "EXECUTE_ACTIONS", "CUSTOM_REQUIRED_ACTION_ERROR", "UPDATE_TOTP_ERROR", "CODE_TO_TOKEN" ],
+  "adminEventsEnabled" : true,
+  "adminEventsDetailsEnabled" : true,
+  "identityProviders" : [ {
+    "alias" : "keycloak-oidc",
+    "internalId" : "1cd4f1db-a891-42fc-967f-651b4c5d5ac1",
+    "providerId" : "keycloak-oidc",
+    "enabled" : true,
+    "updateProfileFirstLoginMode" : "on",
+    "trustEmail" : false,
+    "storeToken" : false,
+    "addReadTokenRoleOnCreate" : false,
+    "authenticateByDefault" : false,
+    "config" : {
+      "clientSecret" : "foo",
+      "clientId" : "foo",
+      "tokenUrl" : "foo",
+      "authorizationUrl" : "foo"
+    }
+  }, {
+    "alias" : "oidc",
+    "internalId" : "1b566532-c396-42d0-9d5a-d8b2d374a4e2",
+    "providerId" : "oidc",
+    "enabled" : true,
+    "updateProfileFirstLoginMode" : "on",
+    "trustEmail" : false,
+    "storeToken" : false,
+    "addReadTokenRoleOnCreate" : false,
+    "authenticateByDefault" : false,
+    "config" : {
+      "clientSecret" : "asdf",
+      "clientId" : "asdf",
+      "tokenUrl" : "asdf",
+      "authorizationUrl" : "asdf"
+    }
+  } ],
+  "identityFederationEnabled" : true,
+  "internationalizationEnabled" : false,
+  "supportedLocales" : [ ],
+  "authenticationFlows" : [ {
+    "alias" : "reset credentials",
+    "description" : "Reset credentials for a user if they forgot their password or something",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "reset-credentials-choose-user",
+      "autheticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "userSetupAllowed" : false,
+      "priority" : 10
+    }, {
+      "authenticator" : "reset-credential-email",
+      "autheticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "userSetupAllowed" : false,
+      "priority" : 20
+    }, {
+      "authenticator" : "reset-password",
+      "autheticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "userSetupAllowed" : false,
+      "priority" : 30
+    }, {
+      "authenticator" : "reset-otp",
+      "autheticatorFlow" : false,
+      "requirement" : "OPTIONAL",
+      "userSetupAllowed" : false,
+      "priority" : 40
+    } ]
+  }, {
+    "alias" : "clients",
+    "description" : "Base authentication for clients",
+    "providerId" : "client-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "client-secret",
+      "autheticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "userSetupAllowed" : false,
+      "priority" : 10
+    }, {
+      "authenticator" : "client-jwt",
+      "autheticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "userSetupAllowed" : false,
+      "priority" : 20
+    } ]
+  }, {
+    "alias" : "registration",
+    "description" : "registration flow",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "registration-page-form",
+      "flowAlias" : "registration form",
+      "autheticatorFlow" : true,
+      "requirement" : "REQUIRED",
+      "userSetupAllowed" : false,
+      "priority" : 10
+    } ]
+  }, {
+    "alias" : "registration form",
+    "description" : "registration form",
+    "providerId" : "form-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "registration-user-creation",
+      "autheticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "userSetupAllowed" : false,
+      "priority" : 20
+    }, {
+      "authenticator" : "registration-profile-action",
+      "autheticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "userSetupAllowed" : false,
+      "priority" : 40
+    }, {
+      "authenticator" : "registration-password-action",
+      "autheticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "userSetupAllowed" : false,
+      "priority" : 50
+    }, {
+      "authenticator" : "registration-recaptcha-action",
+      "autheticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "userSetupAllowed" : false,
+      "priority" : 60
+    } ]
+  }, {
+    "alias" : "browser",
+    "description" : "browser based authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "auth-cookie",
+      "autheticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "userSetupAllowed" : false,
+      "priority" : 10
+    }, {
+      "authenticator" : "auth-spnego",
+      "autheticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "userSetupAllowed" : false,
+      "priority" : 20
+    }, {
+      "flowAlias" : "forms",
+      "autheticatorFlow" : true,
+      "requirement" : "ALTERNATIVE",
+      "userSetupAllowed" : false,
+      "priority" : 30
+    } ]
+  }, {
+    "alias" : "forms",
+    "description" : "Username, password, otp and other auth forms.",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "auth-username-password-form",
+      "autheticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "userSetupAllowed" : false,
+      "priority" : 10
+    }, {
+      "authenticator" : "auth-otp-form",
+      "autheticatorFlow" : false,
+      "requirement" : "OPTIONAL",
+      "userSetupAllowed" : false,
+      "priority" : 20
+    } ]
+  }, {
+    "alias" : "direct grant",
+    "description" : "OpenID Connect Resource Owner Grant",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "direct-grant-validate-username",
+      "autheticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "userSetupAllowed" : false,
+      "priority" : 10
+    }, {
+      "authenticator" : "direct-grant-validate-password",
+      "autheticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "userSetupAllowed" : false,
+      "priority" : 20
+    }, {
+      "authenticator" : "direct-grant-validate-otp",
+      "autheticatorFlow" : false,
+      "requirement" : "OPTIONAL",
+      "userSetupAllowed" : false,
+      "priority" : 30
+    } ]
+  } ],
+  "authenticatorConfig" : [ ],
+  "requiredActions" : [ {
+    "alias" : "UPDATE_PROFILE",
+    "name" : "Update Profile",
+    "providerId" : "UPDATE_PROFILE",
+    "enabled" : true,
+    "defaultAction" : false,
+    "config" : { }
+  }, {
+    "alias" : "terms_and_conditions",
+    "name" : "Terms and Conditions",
+    "providerId" : "terms_and_conditions",
+    "enabled" : false,
+    "defaultAction" : false,
+    "config" : { }
+  }, {
+    "alias" : "VERIFY_EMAIL",
+    "name" : "Verify Email",
+    "providerId" : "VERIFY_EMAIL",
+    "enabled" : true,
+    "defaultAction" : false,
+    "config" : { }
+  }, {
+    "alias" : "CONFIGURE_TOTP",
+    "name" : "Configure Totp",
+    "providerId" : "CONFIGURE_TOTP",
+    "enabled" : true,
+    "defaultAction" : false,
+    "config" : { }
+  }, {
+    "alias" : "UPDATE_PASSWORD",
+    "name" : "Update Password",
+    "providerId" : "UPDATE_PASSWORD",
+    "enabled" : true,
+    "defaultAction" : false,
+    "config" : { }
+  } ],
+  "browserFlow" : "browser",
+  "registrationFlow" : "registration",
+  "directGrantFlow" : "direct grant",
+  "resetCredentialsFlow" : "reset credentials",
+  "clientAuthenticationFlow" : "clients"
+}, {
+  "id" : "mynewrealm",
+  "realm" : "mynewrealm",
+  "notBefore" : 0,
+  "revokeRefreshToken" : false,
+  "accessTokenLifespan" : 300,
+  "ssoSessionIdleTimeout" : 1800,
+  "ssoSessionMaxLifespan" : 36000,
+  "offlineSessionIdleTimeout" : 2592000,
+  "accessCodeLifespan" : 60,
+  "accessCodeLifespanUserAction" : 300,
+  "accessCodeLifespanLogin" : 1800,
+  "enabled" : true,
+  "sslRequired" : "external",
+  "registrationAllowed" : false,
+  "registrationEmailAsUsername" : false,
+  "rememberMe" : false,
+  "verifyEmail" : false,
+  "resetPasswordAllowed" : false,
+  "editUsernameAllowed" : false,
+  "bruteForceProtected" : false,
+  "maxFailureWaitSeconds" : 900,
+  "minimumQuickLoginWaitSeconds" : 60,
+  "waitIncrementSeconds" : 60,
+  "quickLoginCheckMilliSeconds" : 1000,
+  "maxDeltaTimeSeconds" : 43200,
+  "failureFactor" : 30,
+  "privateKey" : "MIIEowIBAAKCAQEAipWMs6L7fIFbAwGkVkPN3sw7J3lkvcFP2XyBbWm4uEruNg8Tz6WL8jRLXKiO24xO1Krf5Rdh25JZKpluciXswb6funfdgb5N0IZhiSD/mpYmlZEH5O07yIv7ojq5aVc6ZTVnfj55wRn6t0UO9rrOsjwLasToT1QYKuQBatutkOzmsDn7tjFlncGCoIwbiK3/JNsARKI1Jc4JwwilE6HZSbqSEC5O5+SLeM6b5TQUP6zUAnDDk/Z93q7Yt66XsuOkqu4FaTfdpkQi+RkJKytTbnwZvD8523I14RJTAJvypaiWHyx6c6qlPAeLALhyfeRf3Ge8O/xdFwij63Wpk/EMbQIDAQABAoIBAAbAfIdwBGKvhrihxtjxGsGlH6ivsGnSVkqZV1D2WqqX8/0sROHUBfp588YC7Frj/h88aAYoWnsxKSj7KrdjA6L4351dI6yjkfT75xqgQfPNJvoYg9Lyf/woXc0soUXxmwW9UVqEPrhaxK1TLwR0W4exhzjfeRYMWdUVIMCNDWrHHSWR/ZIpyYWvZVl3PnqpBu8VM7Q60B8bNY2eUZxXuhknLZn4OfM1yqA25SnoRiyJlfObPPjcEoW7Rs9oTqGLowrQAE0ULMUSmwzhhG942/uO356WSZnGvchLIAa1lwbXdN0kqrG8cKALZYrtruQufc1k1WkrLY2TITJocMTYPoECgYEA7jBEm1rXbGZvhHZN1RMGQ33G1N6vql7k05Q+ztl+7VL0xbxF8bBewefJ4MoXyCSHHPE7QsN10ZwI7OMH4lBBoL5+tVZ+ZJC/Mo3IqLmZcoUJPazG0wWbYcmND9h9ww34Xhm+j+pLhlFc1EGfVyXPXM8FnvmjPPFOBlfk0UjMvuECgYEAlPKEo3OJJFAFV6beT0lbmVQqor6o/jxr7MGFBylFwz6Wbybxbi3XlFRdNtUVEzJWV6Si5W0977QcxyK7jRGiXnxYnTII8F18l04qMBlF6n/ehVqaI/bDiqX/57CbcOafU1AcOwAZvXb41nhI/Gg/L3qH+QUMBOhXDlcP/Sa9uw0CgYEA4NQU3mPH9h1W5DzbSOX1Qp2loec0/2clLYXAJ3XrNk7YlxEZIIKvXu7QguufuR6pnqshmepv+tQDJL9EAN5qpDVL2xVyprBumWR15LWUXyGuUFYXMrcXLR2Xlj5ur0AvkXtRgfzRH08LhZsPsa4R5vPOxXm0GOFZGem7JcVG5mECgYBUPZ26/DtSaFe9LUmKukiuPaYniYH22KGJtCHS3Qrx1FIs52+hCxhkchqOSpGy28NtqlXfQJvJGKs2DXTZ4mFc4yMTNRtNJvKyeKjvrzuV12A5N/b55DTQE/baSU6A2k6+Rg7RZ8snF0TBuCI/b45dAgYpVytnEyk5mRAX83NXeQKBgHT1GghcVVIi1A01fLJADUglFQz1pMiccr11NROeRJPb3EDWXEgSClB4hv5pHY9iUtNxYV7s3rhCdfc+uCevH6HZH2ge+7f9HW9xnz6tRg7vLXXyV9IdpLOUyvQQCaxZ7KzOt3aGdN5a4FWDkdVyLgtV5DI9P6765aTbSjDyIOJb",
+  "publicKey" : "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAipWMs6L7fIFbAwGkVkPN3sw7J3lkvcFP2XyBbWm4uEruNg8Tz6WL8jRLXKiO24xO1Krf5Rdh25JZKpluciXswb6funfdgb5N0IZhiSD/mpYmlZEH5O07yIv7ojq5aVc6ZTVnfj55wRn6t0UO9rrOsjwLasToT1QYKuQBatutkOzmsDn7tjFlncGCoIwbiK3/JNsARKI1Jc4JwwilE6HZSbqSEC5O5+SLeM6b5TQUP6zUAnDDk/Z93q7Yt66XsuOkqu4FaTfdpkQi+RkJKytTbnwZvD8523I14RJTAJvypaiWHyx6c6qlPAeLALhyfeRf3Ge8O/xdFwij63Wpk/EMbQIDAQAB",
+  "certificate" : "MIICozCCAYsCBgFRF+OJTTANBgkqhkiG9w0BAQsFADAVMRMwEQYDVQQDDApteW5ld3JlYWxtMB4XDTE1MTExNzIzNTc0NloXDTI1MTExNzIzNTkyNlowFTETMBEGA1UEAwwKbXluZXdyZWFsbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAIqVjLOi+3yBWwMBpFZDzd7MOyd5ZL3BT9l8gW1puLhK7jYPE8+li/I0S1yojtuMTtSq3+UXYduSWSqZbnIl7MG+n7p33YG+TdCGYYkg/5qWJpWRB+TtO8iL+6I6uWlXOmU1Z34+ecEZ+rdFDva6zrI8C2rE6E9UGCrkAWrbrZDs5rA5+7YxZZ3BgqCMG4it/yTbAESiNSXOCcMIpROh2Um6khAuTufki3jOm+U0FD+s1AJww5P2fd6u2Leul7LjpKruBWk33aZEIvkZCSsrU258Gbw/OdtyNeESUwCb8qWolh8senOqpTwHiwC4cn3kX9xnvDv8XRcIo+t1qZPxDG0CAwEAATANBgkqhkiG9w0BAQsFAAOCAQEABKsK6mIwhTAzWoXFzx/h5qhjF90i98KDZ+iGaicmInwDFu3txSnsHwLq48Pm5Ks0D2tVrBqbDEGOtCwNJkrvXEzpqDJVRtWpUUA5W5NHDH1YDRm2teusYCtL6ffmSGbV1YDC0j1puBPKEM9xJIB9fop3332hRynbVzQtFpOSGj9RgBJLt7QqGtCZaVSJ1o5fxbUESVgQ7LSUn4SuOGNYtdF0ftonNxkpQMzEUu2sFcGXgCsnatmEv3hnkgMloFxraka+ahYhB50L0Z/8fC1kKkMFyKO5QNFh3r+b5YA8NPLCWCsAn9Fmryc6q5rHxAhvFemMxUUOjo7tFwKzyf0bhA==",
+  "codeSecret" : "d3dbbfb5-5b6b-4122-9fcb-ff53d62aebfc",
+  "roles" : {
+    "realm" : [ {
+      "id" : "a8e5f6e3-9835-444d-8899-e884490cb1b4",
+      "name" : "offline_access",
+      "description" : "${role_offline-access}",
+      "scopeParamRequired" : true,
+      "composite" : false
+    } ],
+    "client" : {
+      "realm-management" : [ {
+        "id" : "7451f1ae-5cd1-4c8b-8c5f-75f5618321c2",
+        "name" : "view-identity-providers",
+        "description" : "${role_view-identity-providers}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      }, {
+        "id" : "64d85ad6-3565-45cd-8d56-3e6aa108c345",
+        "name" : "create-client",
+        "description" : "${role_create-client}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      }, {
+        "id" : "77b6cbf9-44a9-4137-940d-249104598691",
+        "name" : "manage-realm",
+        "description" : "${role_manage-realm}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      }, {
+        "id" : "db6d4b5e-1eae-4a46-9e67-97c0ec102d0c",
+        "name" : "view-events",
+        "description" : "${role_view-events}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      }, {
+        "id" : "b1db57ea-cc1f-4b9b-a200-1e0bb7ffd6c5",
+        "name" : "view-users",
+        "description" : "${role_view-users}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      }, {
+        "id" : "822ac2e6-b399-41c6-9681-27472132df54",
+        "name" : "view-realm",
+        "description" : "${role_view-realm}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      }, {
+        "id" : "9424dffd-57a7-49e6-8cdc-1789e98abed1",
+        "name" : "manage-users",
+        "description" : "${role_manage-users}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      }, {
+        "id" : "82cae12f-28ce-4749-8e08-4047f7ff7e9d",
+        "name" : "impersonation",
+        "description" : "${role_impersonation}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      }, {
+        "id" : "0edd1e08-69a5-4597-bc1a-3dee984a3224",
+        "name" : "realm-admin",
+        "description" : "${role_realm-admin}",
+        "scopeParamRequired" : false,
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "realm-management" : [ "create-client", "view-identity-providers", "manage-realm", "manage-events", "view-clients", "view-users", "view-events", "view-realm", "manage-clients", "manage-users", "impersonation", "manage-identity-providers" ]
+          }
+        }
+      }, {
+        "id" : "fee2975b-bcb1-48ab-a21d-90c0049fc57c",
+        "name" : "manage-identity-providers",
+        "description" : "${role_manage-identity-providers}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      }, {
+        "id" : "a239851f-f8a9-4be0-bd10-95521c1a951b",
+        "name" : "manage-events",
+        "description" : "${role_manage-events}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      }, {
+        "id" : "fe01f41a-600e-4e86-a530-b76d822d2ca0",
+        "name" : "view-clients",
+        "description" : "${role_view-clients}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      }, {
+        "id" : "94072c24-1e70-4010-a146-9f72233c14e0",
+        "name" : "manage-clients",
+        "description" : "${role_manage-clients}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      } ],
+      "security-admin-console" : [ ],
+      "broker" : [ {
+        "id" : "96a4a79d-e555-4820-88f0-62640639dc6e",
+        "name" : "read-token",
+        "description" : "${role_read-token}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      } ],
+      "account" : [ {
+        "id" : "7091dbcd-9239-4f3c-b5a8-49466f004de4",
+        "name" : "view-profile",
+        "description" : "${role_view-profile}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      }, {
+        "id" : "ae422f88-cd9c-4d12-80dd-6ff8230711d8",
+        "name" : "manage-account",
+        "description" : "${role_manage-account}",
+        "scopeParamRequired" : false,
+        "composite" : false
+      } ]
+    }
+  },
+  "defaultRoles" : [ "offline_access" ],
+  "requiredCredentials" : [ "password" ],
+  "otpPolicyType" : "totp",
+  "otpPolicyAlgorithm" : "HmacSHA1",
+  "otpPolicyInitialCounter" : 0,
+  "otpPolicyDigits" : 6,
+  "otpPolicyLookAheadWindow" : 1,
+  "otpPolicyPeriod" : 30,
+  "clientScopeMappings" : {
+    "realm-management" : [ {
+      "client" : "security-admin-console",
+      "roles" : [ "realm-admin" ]
+    } ]
+  },
+  "clients" : [ {
+    "id" : "51f01c15-294a-4f28-935b-b82995e9f90d",
+    "clientId" : "realm-management",
+    "name" : "${client_realm-management}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "1d30c53d-6ca2-4d06-9736-8a69a7065923",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : true,
+    "consentRequired" : false,
+    "serviceAccountsEnabled" : false,
+    "directGrantsOnly" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "attributes" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "protocolMappers" : [ {
+      "id" : "22b5b169-7ab9-4acb-b55c-4b7bd39f3759",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    }, {
+      "id" : "f18fca13-fd5c-4fda-9111-3b321db2e71b",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${username}",
+      "config" : {
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "3f8d5e3f-0d5c-4ee9-94e7-8a803cb5a2ae",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${email}",
+      "config" : {
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "8a521257-f201-47fb-b06f-17986eed4121",
+      "name" : "family name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${familyName}",
+      "config" : {
+        "user.attribute" : "lastName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "d0500f07-3d6b-4eb8-a954-2f9da4781854",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : true,
+      "consentText" : "${fullName}",
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    }, {
+      "id" : "27521786-780e-4611-9091-edc8088aadd2",
+      "name" : "given name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${givenName}",
+      "config" : {
+        "user.attribute" : "firstName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "given_name",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "8cdfc36c-7d7e-4594-a25f-4894ef39269e",
+    "clientId" : "security-admin-console",
+    "name" : "${client_security-admin-console}",
+    "baseUrl" : "/auth/admin/mynewrealm/console/index.html",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "b787e86e-2dbb-4f10-b739-a24cc5d77fa5",
+    "redirectUris" : [ "/auth/admin/mynewrealm/console/*" ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "serviceAccountsEnabled" : false,
+    "directGrantsOnly" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "attributes" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "protocolMappers" : [ {
+      "id" : "d6268fe9-8b6c-4387-8bed-700e37d09e58",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${username}",
+      "config" : {
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "4a761028-ee37-4bb5-b382-8ef084252901",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    }, {
+      "id" : "c8d53d5f-11d1-488e-a320-d00aace93c80",
+      "name" : "family name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${familyName}",
+      "config" : {
+        "user.attribute" : "lastName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "0d012254-c633-4d6b-b626-b87848d22cd6",
+      "name" : "locale",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "consentText" : "${locale}",
+      "config" : {
+        "user.attribute" : "locale",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "locale",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "559f5ed9-7f60-4300-bcf4-bd7cf3209cff",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${email}",
+      "config" : {
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "aa663b13-70e1-4394-a6e7-59ae369e0a91",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : true,
+      "consentText" : "${fullName}",
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    }, {
+      "id" : "e0f351ca-2742-4fe1-a352-fa57e141a042",
+      "name" : "given name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${givenName}",
+      "config" : {
+        "user.attribute" : "firstName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "given_name",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "b10d68a4-175f-4065-a7e1-a3697dfc3dc1",
+    "clientId" : "broker",
+    "name" : "${client_broker}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "8ed66cb4-c134-4972-ab2b-036a86318783",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "serviceAccountsEnabled" : false,
+    "directGrantsOnly" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "attributes" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "protocolMappers" : [ {
+      "id" : "c965a94c-3a83-4363-99f3-7057b73e908e",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${username}",
+      "config" : {
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "cded7603-4742-47d4-a1b9-6a1a2df6194c",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${email}",
+      "config" : {
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "e062d72d-f6fa-4f5a-a478-a946ad0c4517",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    }, {
+      "id" : "a447ff4f-cc24-413a-b45a-7894c88b7322",
+      "name" : "family name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${familyName}",
+      "config" : {
+        "user.attribute" : "lastName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "f251c7b4-84c9-423d-a2fe-2c4397632889",
+      "name" : "given name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${givenName}",
+      "config" : {
+        "user.attribute" : "firstName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "given_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "ad02d245-71a7-48d1-b6de-9b1478d47452",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : true,
+      "consentText" : "${fullName}",
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    } ]
+  }, {
+    "id" : "633aca91-83e3-4e63-b4c2-f96f403612ec",
+    "clientId" : "account",
+    "name" : "${client_account}",
+    "baseUrl" : "/auth/realms/mynewrealm/account",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "f8529b2c-dd3e-4d94-af0f-84cf0d9d6abe",
+    "defaultRoles" : [ "view-profile", "manage-account" ],
+    "redirectUris" : [ "/auth/realms/mynewrealm/account/*" ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "serviceAccountsEnabled" : false,
+    "directGrantsOnly" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "attributes" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "protocolMappers" : [ {
+      "id" : "6eb34932-a782-4bdb-92fc-25c4d9d43cea",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${email}",
+      "config" : {
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "5692f01f-29ae-4bf0-a3ee-5d6fe07ee3c2",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : true,
+      "consentText" : "${fullName}",
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true"
+      }
+    }, {
+      "id" : "c89c87c2-cbdf-44df-bf5c-29ccf10728ef",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${username}",
+      "config" : {
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "0337493e-7145-4555-936c-a84308017dcf",
+      "name" : "family name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${familyName}",
+      "config" : {
+        "user.attribute" : "lastName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "9dda80c0-0d15-4b75-a4fd-d261421a28a5",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    }, {
+      "id" : "940c8402-e4dd-41d9-94e6-6ef5654afd05",
+      "name" : "given name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : true,
+      "consentText" : "${givenName}",
+      "config" : {
+        "user.attribute" : "firstName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "given_name",
+        "jsonType.label" : "String"
+      }
+    } ]
+  } ],
+  "browserSecurityHeaders" : {
+    "contentSecurityPolicy" : "frame-src 'self'",
+    "xFrameOptions" : "SAMEORIGIN"
+  },
+  "smtpServer" : { },
+  "eventsEnabled" : false,
+  "eventsListeners" : [ "jboss-logging" ],
+  "enabledEventTypes" : [ ],
+  "adminEventsEnabled" : false,
+  "adminEventsDetailsEnabled" : false,
+  "identityFederationEnabled" : false,
+  "internationalizationEnabled" : false,
+  "supportedLocales" : [ ],
+  "authenticationFlows" : [ {
+    "alias" : "clients",
+    "description" : "Base authentication for clients",
+    "providerId" : "client-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "client-secret",
+      "autheticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "userSetupAllowed" : false,
+      "priority" : 10
+    }, {
+      "authenticator" : "client-jwt",
+      "autheticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "userSetupAllowed" : false,
+      "priority" : 20
+    } ]
+  }, {
+    "alias" : "registration form",
+    "description" : "registration form",
+    "providerId" : "form-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "registration-user-creation",
+      "autheticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "userSetupAllowed" : false,
+      "priority" : 20
+    }, {
+      "authenticator" : "registration-profile-action",
+      "autheticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "userSetupAllowed" : false,
+      "priority" : 40
+    }, {
+      "authenticator" : "registration-password-action",
+      "autheticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "userSetupAllowed" : false,
+      "priority" : 50
+    }, {
+      "authenticator" : "registration-recaptcha-action",
+      "autheticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "userSetupAllowed" : false,
+      "priority" : 60
+    } ]
+  }, {
+    "alias" : "registration",
+    "description" : "registration flow",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "registration-page-form",
+      "flowAlias" : "registration form",
+      "autheticatorFlow" : true,
+      "requirement" : "REQUIRED",
+      "userSetupAllowed" : false,
+      "priority" : 10
+    } ]
+  }, {
+    "alias" : "forms",
+    "description" : "Username, password, otp and other auth forms.",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "auth-username-password-form",
+      "autheticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "userSetupAllowed" : false,
+      "priority" : 10
+    }, {
+      "authenticator" : "auth-otp-form",
+      "autheticatorFlow" : false,
+      "requirement" : "OPTIONAL",
+      "userSetupAllowed" : false,
+      "priority" : 20
+    } ]
+  }, {
+    "alias" : "browser",
+    "description" : "browser based authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "auth-cookie",
+      "autheticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "userSetupAllowed" : false,
+      "priority" : 10
+    }, {
+      "authenticator" : "auth-spnego",
+      "autheticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "userSetupAllowed" : false,
+      "priority" : 20
+    }, {
+      "flowAlias" : "forms",
+      "autheticatorFlow" : true,
+      "requirement" : "ALTERNATIVE",
+      "userSetupAllowed" : false,
+      "priority" : 30
+    } ]
+  }, {
+    "alias" : "direct grant",
+    "description" : "OpenID Connect Resource Owner Grant",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "direct-grant-validate-username",
+      "autheticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "userSetupAllowed" : false,
+      "priority" : 10
+    }, {
+      "authenticator" : "direct-grant-validate-password",
+      "autheticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "userSetupAllowed" : false,
+      "priority" : 20
+    }, {
+      "authenticator" : "direct-grant-validate-otp",
+      "autheticatorFlow" : false,
+      "requirement" : "OPTIONAL",
+      "userSetupAllowed" : false,
+      "priority" : 30
+    } ]
+  }, {
+    "alias" : "reset credentials",
+    "description" : "Reset credentials for a user if they forgot their password or something",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "reset-credentials-choose-user",
+      "autheticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "userSetupAllowed" : false,
+      "priority" : 10
+    }, {
+      "authenticator" : "reset-credential-email",
+      "autheticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "userSetupAllowed" : false,
+      "priority" : 20
+    }, {
+      "authenticator" : "reset-password",
+      "autheticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "userSetupAllowed" : false,
+      "priority" : 30
+    }, {
+      "authenticator" : "reset-otp",
+      "autheticatorFlow" : false,
+      "requirement" : "OPTIONAL",
+      "userSetupAllowed" : false,
+      "priority" : 40
+    } ]
+  } ],
+  "authenticatorConfig" : [ ],
+  "requiredActions" : [ {
+    "alias" : "UPDATE_PROFILE",
+    "name" : "Update Profile",
+    "providerId" : "UPDATE_PROFILE",
+    "enabled" : true,
+    "defaultAction" : false,
+    "config" : { }
+  }, {
+    "alias" : "UPDATE_PASSWORD",
+    "name" : "Update Password",
+    "providerId" : "UPDATE_PASSWORD",
+    "enabled" : true,
+    "defaultAction" : false,
+    "config" : { }
+  }, {
+    "alias" : "terms_and_conditions",
+    "name" : "Terms and Conditions",
+    "providerId" : "terms_and_conditions",
+    "enabled" : false,
+    "defaultAction" : false,
+    "config" : { }
+  }, {
+    "alias" : "CONFIGURE_TOTP",
+    "name" : "Configure Totp",
+    "providerId" : "CONFIGURE_TOTP",
+    "enabled" : true,
+    "defaultAction" : false,
+    "config" : { }
+  }, {
+    "alias" : "VERIFY_EMAIL",
+    "name" : "Verify Email",
+    "providerId" : "VERIFY_EMAIL",
+    "enabled" : true,
+    "defaultAction" : false,
+    "config" : { }
+  } ],
+  "browserFlow" : "browser",
+  "registrationFlow" : "registration",
+  "directGrantFlow" : "direct grant",
+  "resetCredentialsFlow" : "reset credentials",
+  "clientAuthenticationFlow" : "clients"
+} ]

--- a/cypress/integration/partial-import-test-data/multi-realm.json
+++ b/cypress/integration/partial-import-test-data/multi-realm.json
@@ -1,0 +1,113 @@
+[
+  {
+    "id": "realm1",
+    "realm": "realm1",
+    "clients": [
+      {
+        "clientId": "customer-portal",
+        "enabled": true,
+        "adminUrl": "/customer-portal",
+        "baseUrl": "/customer-portal",
+        "redirectUris": ["/customer-portal/*"],
+        "secret": "password"
+      }
+    ],
+    "users": [
+      {
+        "username": "ssilvert",
+        "enabled": true,
+        "email": "ssilvert@redhat.com",
+        "firstName": "Stan",
+        "lastName": "Silvert",
+        "credentials": [{ "type": "password", "value": "password" }],
+        "realmRoles": ["user", "offline_access"],
+        "clientRoles": {
+          "account": ["manage-account"]
+        }
+      }
+    ],
+    "groups": [
+      {
+        "id": "7a20471c-c695-4778-adb0-4ee4ae88d198",
+        "name": "group1",
+        "path": "/group1",
+        "attributes": {
+          "foo": ["bar"]
+        },
+        "realmRoles": ["create-realm"],
+        "clientRoles": {},
+        "subGroups": []
+      }
+    ],
+    "identityProviders": [
+      {
+        "alias": "keycloak-oidc",
+        "internalId": "721b5dae-5b98-4284-bcd1-f872ce2ac174",
+        "providerId": "keycloak-oidc",
+        "enabled": true,
+        "updateProfileFirstLoginMode": "on",
+        "trustEmail": false,
+        "storeToken": false,
+        "addReadTokenRoleOnCreate": false,
+        "authenticateByDefault": false,
+        "config": {
+          "clientSecret": "foo",
+          "clientId": "foo",
+          "tokenUrl": "https://foo.bar",
+          "authorizationUrl": "https://foo.bar"
+        }
+      }
+    ],
+    "roles": {
+      "realm": [
+        {
+          "id": "9d2638c8-4c62-4c42-90ea-5f3c836d0cc8",
+          "name": "offline_access",
+          "scopeParamRequired": false,
+          "composite": false
+        },
+        {
+          "id": "9d2638c8-4c62-4c42-90ea-5f3c836d0cc8",
+          "name": "another",
+          "scopeParamRequired": false,
+          "composite": false
+        }
+      ],
+      "client": {
+        "database-service": [],
+        "admin-client": [],
+        "realm-management": [
+          {
+            "id": "3b939f75-d013-4096-8462-48aa39261293",
+            "name": "create-client",
+            "description": "${role_create-client}",
+            "scopeParamRequired": false,
+            "composite": false
+          }
+        ]
+      }
+    }
+  },
+  {
+    "id": "realm2",
+    "realm": "realm2",
+    "clients": [
+      {
+        "clientId": "customer-portal",
+        "enabled": true,
+        "adminUrl": "/customer-portal",
+        "baseUrl": "/customer-portal",
+        "redirectUris": ["/customer-portal/*"],
+        "secret": "password"
+      },
+      {
+        "clientId": "customer-portal",
+        "enabled": true,
+        "adminUrl": "/customer-portal",
+        "baseUrl": "/customer-portal",
+        "redirectUris": ["/customer-portal/*"],
+        "secret": "password"
+      }
+    ]
+  }
+]

--- a/cypress/integration/partial_import_test.spec.ts
+++ b/cypress/integration/partial_import_test.spec.ts
@@ -1,33 +1,104 @@
+import CreateRealmPage from "../support/pages/admin_console/CreateRealmPage";
 import SidebarPage from "../support/pages/admin_console/SidebarPage";
 import LoginPage from "../support/pages/LoginPage";
+import Masthead from "../support/pages/admin_console/Masthead";
 import PartialImportModal from "../support/pages/admin_console/configure/realm_settings/PartialImportModal";
 import RealmSettings from "../support/pages/admin_console/configure/realm_settings/RealmSettings";
 import { keycloakBefore } from "../support/util/keycloak_before";
+import AdminClient from "../support/util/AdminClient";
+
+/**
+ * Simulates a paste event.
+ *
+ * @param pasteOptions Set of options for a simulated paste event.
+ * @param pasteOptions.destinationSelector Selector representing the DOM element that the paste event should be dispatched to.
+ * @param pasteOptions.pastePayload Simulated data that is on the clipboard.
+ * @param pasteOptions.pasteFormat The format of the simulated paste payload. Default value is 'text'.
+ */
 
 describe("Partial import test", () => {
+  const TEST_REALM = "partial-import-test-realm";
   const loginPage = new LoginPage();
   const sidebarPage = new SidebarPage();
-  const partialImportModal = new PartialImportModal();
+  const createRealmPage = new CreateRealmPage();
+  const modal = new PartialImportModal();
   const realmSettings = new RealmSettings();
 
-  beforeEach(function () {
+  beforeEach(() => {
     keycloakBefore();
     loginPage.logIn();
+
+    // doing this from the UI has the added bonus of putting you in the test realm
+    sidebarPage.goToCreateRealm();
+    createRealmPage.fillRealmName(TEST_REALM).createRealm();
+
     sidebarPage.goToRealmSettings();
     realmSettings.clickActionMenu();
   });
 
-  it("Opens and closes partial import dialog", () => {
-    partialImportModal.open();
-    cy.getId("import-button").should("be.disabled");
-    cy.getId("cancel-button").click();
-    cy.getId("import-button").should("not.exist");
+  afterEach(async () => {
+    const client = new AdminClient();
+    await client.deleteRealm(TEST_REALM);
   });
 
-  it("Import button reacts to loaded json", () => {
-    partialImportModal.open();
+  it("Opens and closes partial import dialog", () => {
+    modal.open();
+    modal.importButton().should("be.disabled");
+    modal.cancelButton().click();
+    modal.importButton().should("not.exist");
+  });
+
+  it("Import button only enabled if JSON has something to import", () => {
+    modal.open();
     cy.get("#partial-import-file").type("{}");
-    cy.getId("import-button").should("be.enabled");
+    modal.importButton().should("be.disabled");
+  });
+
+  it("Displays user options after multi-realm import", () => {
+    modal.open();
+    modal.typeResourceFile("multi-realm.json");
+
+    // Import button should be disabled if no checkboxes selected
+    modal.importButton().should("be.disabled");
+    modal.usersCheckbox().click();
+    modal.importButton().should("be.enabled");
+    modal.groupsCheckbox().click();
+    modal.importButton().should("be.enabled");
+    modal.groupsCheckbox().click();
+    modal.usersCheckbox().click();
+    modal.importButton().should("be.disabled");
+
+    // verify resource counts
+    modal.userCount().contains("1 users");
+    modal.groupCount().contains("1 groups");
+    modal.clientCount().contains("1 clients");
+    modal.idpCount().contains("1 identity providers");
+    modal.realmRolesCount().contains("2 realm roles");
+    modal.clientRolesCount().contains("1 client roles");
+
+    // import button should disable when switching realms
+    modal.usersCheckbox().click();
+    modal.importButton().should("be.enabled");
+    modal.selectRealm("realm2");
+    modal.importButton().should("be.disabled");
+
+    modal.clientCount().contains("2 clients");
+  });
+
+  it("Displays user options after realmless import", () => {
+    modal.open();
+
+    modal.typeResourceFile("client-only.json");
+
+    modal.realmSelector().should("not.exist");
+
+    modal.clientCount().contains("1 clients");
+
+    modal.userCount().should("not.exist");
+    modal.groupCount().should("not.exist");
+    modal.idpCount().should("not.exist");
+    modal.realmRolesCount().should("not.exist");
+    modal.clientRolesCount().should("not.exist");
   });
 
   // Unfortunately, the PatternFly FileUpload component does not create an id for the clear button.  So we can't easily test that function right now.

--- a/cypress/integration/partial_import_test.spec.ts
+++ b/cypress/integration/partial_import_test.spec.ts
@@ -1,20 +1,10 @@
 import CreateRealmPage from "../support/pages/admin_console/CreateRealmPage";
 import SidebarPage from "../support/pages/admin_console/SidebarPage";
 import LoginPage from "../support/pages/LoginPage";
-import Masthead from "../support/pages/admin_console/Masthead";
 import PartialImportModal from "../support/pages/admin_console/configure/realm_settings/PartialImportModal";
 import RealmSettings from "../support/pages/admin_console/configure/realm_settings/RealmSettings";
 import { keycloakBefore } from "../support/util/keycloak_before";
 import AdminClient from "../support/util/AdminClient";
-
-/**
- * Simulates a paste event.
- *
- * @param pasteOptions Set of options for a simulated paste event.
- * @param pasteOptions.destinationSelector Selector representing the DOM element that the paste event should be dispatched to.
- * @param pasteOptions.pastePayload Simulated data that is on the clipboard.
- * @param pasteOptions.pasteFormat The format of the simulated paste payload. Default value is 'text'.
- */
 
 describe("Partial import test", () => {
   const TEST_REALM = "partial-import-test-realm";

--- a/cypress/support/pages/admin_console/configure/realm_settings/PartialImportModal.ts
+++ b/cypress/support/pages/admin_console/configure/realm_settings/PartialImportModal.ts
@@ -5,4 +5,65 @@ export default class GroupModal {
     cy.getId(this.openPartialImport).click();
     return this;
   }
+
+  typeResourceFile = (filename: string) => {
+    cy.readFile(
+      "cypress/integration/partial-import-test-data/" + filename
+    ).then((myJSON) => {
+      const text = JSON.stringify(myJSON);
+
+      cy.get("#partial-import-file").type(text, {
+        parseSpecialCharSequences: false,
+      });
+    });
+  };
+
+  importButton() {
+    return cy.getId("import-button");
+  }
+
+  cancelButton() {
+    return cy.getId("cancel-button");
+  }
+
+  groupsCheckbox() {
+    return cy.getId("groups-checkbox");
+  }
+
+  usersCheckbox() {
+    return cy.getId("users-checkbox");
+  }
+
+  userCount() {
+    return cy.getId("users-count");
+  }
+
+  clientCount() {
+    return cy.getId("clients-count");
+  }
+
+  groupCount() {
+    return cy.getId("groups-count");
+  }
+
+  idpCount() {
+    return cy.getId("identityProviders-count");
+  }
+
+  realmRolesCount() {
+    return cy.getId("realmRoles-count");
+  }
+
+  clientRolesCount() {
+    return cy.getId("clientRoles-count");
+  }
+
+  realmSelector() {
+    return cy.get("#realm-selector");
+  }
+
+  selectRealm(realm: string) {
+    this.realmSelector().click();
+    cy.getId(realm + "-select-option").click();
+  }
 }

--- a/src/components/json-file-upload/JsonFileUpload.tsx
+++ b/src/components/json-file-upload/JsonFileUpload.tsx
@@ -69,7 +69,8 @@ export const JsonFileUpload = ({
         try {
           obj = JSON.parse(value as string);
         } catch (error) {
-          console.warn("Invalid json, ignoring value using {}");
+          // Ignore.  We need to be lenient on things like
+          // "Unexpected end of JSON input".
         }
 
         onChange(obj);

--- a/src/components/json-file-upload/JsonFileUpload.tsx
+++ b/src/components/json-file-upload/JsonFileUpload.tsx
@@ -69,8 +69,7 @@ export const JsonFileUpload = ({
         try {
           obj = JSON.parse(value as string);
         } catch (error) {
-          // Ignore.  We need to be lenient on things like
-          // "Unexpected end of JSON input".
+          console.warn("Invalid json, ignoring value using {}");
         }
 
         onChange(obj);

--- a/src/realm-settings/PartialImport.tsx
+++ b/src/realm-settings/PartialImport.tsx
@@ -104,40 +104,18 @@ export const PartialImportDialog = (props: PartialImportProps) => {
     resetInputState();
   }, [props.open]);
 
-  const handleClear = () => {
-    setImportEnabled(false);
-  };
-
   const handleFileChange = (value: object) => {
-    setImportEnabled(!!value);
-    setIsMultiRealm(false);
-    setImportedFile([]);
-    setTargetRealm({});
+    setIsFileSelected(!!value);
+    resetInputState();
 
-    // if user pressed clear button reset importEnabled
-    /*const nativeEvent = event.nativeEvent;
-    if (
-      nativeEvent instanceof MouseEvent &&
-      !(nativeEvent instanceof DragEvent)
-    ) {
-      setIsFileSelected(false);
-      return;
-    }*/
+    setImportedFile(value);
 
-    let rawContent: ImportedMultiRealm = [];
-    try {
-      setImportedFile(value);
-    } catch (error) {
-      // Ignore.  We need to be lenient on things like
-      // "Unexpected end of JSON input".
-    }
-
-    if (rawContent instanceof Array && rawContent.length > 0) {
-      setIsMultiRealm(rawContent.length > 1);
-      setTargetRealm(rawContent[0] || {});
+    if (value instanceof Array && value.length > 0) {
+      setIsMultiRealm(value.length > 1);
+      setTargetRealm(value[0] || {});
     } else {
       setIsMultiRealm(false);
-      setTargetRealm((rawContent as ImportedRealm) || {});
+      setTargetRealm((value as ImportedRealm) || {});
     }
   };
 
@@ -341,7 +319,6 @@ export const PartialImportDialog = (props: PartialImportProps) => {
           <JsonFileUpload
             id="partial-import-file"
             onChange={handleFileChange}
-            onClear={handleClear}
           />
         </StackItem>
 

--- a/src/realm-settings/PartialImport.tsx
+++ b/src/realm-settings/PartialImport.tsx
@@ -29,11 +29,11 @@ export type PartialImportProps = {
   toggleDialog: () => void;
 };
 
-// An exported JSON file can either be an array of realm objects
+// An imported JSON file can either be an array of realm objects
 // or a single realm object.
 type ImportedMultiRealm = [ImportedRealm?] | ImportedRealm;
 
-// The actual imported json can have a lot more members,
+// Realms in imported json can have a lot more properties,
 // but these are the ones we care about.
 type ImportedRealm = {
   id?: string;
@@ -48,15 +48,19 @@ type ImportedRealm = {
   };
 };
 
-type NonRoleMember = "users" | "clients" | "groups" | "identityProviders";
-type RoleMember = "roles.realm" | "roles.client";
+type NonRoleResource = "users" | "clients" | "groups" | "identityProviders";
+type RoleResource = "roles.realm" | "roles.client";
+type Resource = NonRoleResource | RoleResource;
 
 type CollisionOption = "FAIL" | "SKIP" | "OVERWRITE";
+
+type ResourceChecked = { [k in Resource]: boolean };
 
 export const PartialImportDialog = (props: PartialImportProps) => {
   const tRealm = useTranslation("realm-settings").t;
   const { t } = useTranslation("partial-import");
-  const [importEnabled, setImportEnabled] = useState(false);
+
+  const [isFileSelected, setIsFileSelected] = useState(false);
   const [isMultiRealm, setIsMultiRealm] = useState(false);
   const [importedFile, setImportedFile] = useState<ImportedMultiRealm>([]);
   const [isRealmSelectOpen, setIsRealmSelectOpen] = useState(false);
@@ -66,9 +70,38 @@ export const PartialImportDialog = (props: PartialImportProps) => {
   );
   const [targetRealm, setTargetRealm] = useState<ImportedRealm>({});
 
-  // when dialog opens or closes, reset importEnabled to false
+  const allResourcesUnChecked: Readonly<ResourceChecked> = {
+    users: false,
+    clients: false,
+    groups: false,
+    identityProviders: false,
+    "roles.realm": false,
+    "roles.client": false,
+  };
+
+  const [resourcesToImport, setResourcesToImport] = useState<ResourceChecked>(
+    _.cloneDeep(allResourcesUnChecked)
+  );
+
+  const [isAnyResourceChecked, setIsAnyResourceChecked] = useState(false);
+
+  const resetResourcesToImport = () => {
+    setResourcesToImport(_.cloneDeep(allResourcesUnChecked));
+    setIsAnyResourceChecked(false);
+  };
+
+  const resetInputState = () => {
+    setIsMultiRealm(false);
+    setImportedFile([]);
+    setTargetRealm({});
+    setCollisionOption("FAIL");
+    resetResourcesToImport();
+  };
+
+  // when dialog opens or closes, clear state
   useEffect(() => {
-    setImportEnabled(false);
+    setIsFileSelected(false);
+    resetInputState();
   }, [props.open]);
 
   const handleClear = () => {
@@ -87,7 +120,7 @@ export const PartialImportDialog = (props: PartialImportProps) => {
       nativeEvent instanceof MouseEvent &&
       !(nativeEvent instanceof DragEvent)
     ) {
-      setImportEnabled(false);
+      setIsFileSelected(false);
       return;
     }*/
 
@@ -114,6 +147,19 @@ export const PartialImportDialog = (props: PartialImportProps) => {
   ) => {
     setTargetRealm(realm as ImportedRealm);
     setIsRealmSelectOpen(false);
+    resetResourcesToImport();
+  };
+
+  const handleResourceCheckBox = (
+    checked: boolean,
+    event: React.FormEvent<HTMLInputElement>
+  ) => {
+    const resource: Resource = event.currentTarget.name as Resource;
+    const copyOfResourcesToImport = _.cloneDeep(resourcesToImport);
+    copyOfResourcesToImport[resource] = checked;
+    setResourcesToImport(copyOfResourcesToImport);
+    setIsAnyResourceChecked(resourcesChecked(copyOfResourcesToImport));
+    console.log(resourcesToImport);
   };
 
   const realmSelectOptions = () => {
@@ -152,22 +198,22 @@ export const PartialImportDialog = (props: PartialImportProps) => {
     ];
   };
 
-  const targetHasMembers = () => {
+  const targetHasResources = () => {
     return (
-      targetHasMember("users") ||
-      targetHasMember("groups") ||
-      targetHasMember("clients") ||
-      targetHasMember("identityProviders") ||
+      targetHasResource("users") ||
+      targetHasResource("groups") ||
+      targetHasResource("clients") ||
+      targetHasResource("identityProviders") ||
       targetHasRealmRoles() ||
       targetHasClientRoles()
     );
   };
 
-  const targetHasMember = (member: NonRoleMember) => {
+  const targetHasResource = (resource: NonRoleResource) => {
     return (
       targetRealm &&
-      targetRealm[member] instanceof Array &&
-      targetRealm[member]!.length > 0
+      targetRealm[resource] instanceof Array &&
+      targetRealm[resource]!.length > 0
     );
   };
 
@@ -191,18 +237,18 @@ export const PartialImportDialog = (props: PartialImportProps) => {
     );
   };
 
-  const itemCount = (member: NonRoleMember | RoleMember) => {
-    if (!importEnabled) return 0;
+  const itemCount = (resource: Resource) => {
+    if (!isFileSelected) return 0;
 
-    if (targetHasRealmRoles() && member === "roles.realm")
+    if (targetHasRealmRoles() && resource === "roles.realm")
       return targetRealm.roles!.realm!.length;
 
-    if (targetHasClientRoles() && member == "roles.client")
+    if (targetHasClientRoles() && resource == "roles.client")
       return clientRolesCount(targetRealm.roles!.client!);
 
-    if (!targetRealm[member as NonRoleMember]) return 0;
+    if (!targetRealm[resource as NonRoleResource]) return 0;
 
-    return targetRealm[member as NonRoleMember]!.length;
+    return targetRealm[resource as NonRoleResource]!.length;
   };
 
   const clientRolesCount = (clientRoles: { [index: string]: [] }) => {
@@ -213,22 +259,33 @@ export const PartialImportDialog = (props: PartialImportProps) => {
     return total;
   };
 
-  const memberDataListItem = (
-    member: NonRoleMember | RoleMember,
-    memberDisplayName: string
+  const resourcesChecked = (resources: ResourceChecked) => {
+    let resource: Resource;
+    for (resource in resources) {
+      if (resources[resource]) return true;
+    }
+
+    return false;
+  };
+
+  const resourceDataListItem = (
+    resource: Resource,
+    resourceDisplayName: string
   ) => {
     return (
-      <DataListItem aria-labelledby={`${member}-list-item`}>
+      <DataListItem aria-labelledby={`${resource}-list-item`}>
         <DataListItemRow>
           <DataListCheck
-            aria-labelledby={`${member}-checkbox`}
-            name={`${member}-checkbox`}
+            aria-labelledby={`${resource}-checkbox`}
+            name={resource}
+            isChecked={resourcesToImport[resource]}
+            onChange={handleResourceCheckBox}
           />
           <DataListItemCells
             dataListCells={[
-              <DataListCell key={member}>
+              <DataListCell key={resource}>
                 <span>
-                  {itemCount(member)} {memberDisplayName}
+                  {itemCount(resource)} {resourceDisplayName}
                 </span>
               </DataListCell>,
             ]}
@@ -249,7 +306,7 @@ export const PartialImportDialog = (props: PartialImportProps) => {
           id="modal-import"
           data-testid="import-button"
           key="import"
-          isDisabled={!importEnabled || !targetHasMembers()}
+          isDisabled={!isAnyResourceChecked}
           onClick={() => {
             props.toggleDialog();
           }}
@@ -283,14 +340,14 @@ export const PartialImportDialog = (props: PartialImportProps) => {
           />
         </StackItem>
 
-        {importEnabled && targetHasMembers() && (
+        {isFileSelected && targetHasResources() && (
           <>
             <StackItem>
               <Divider />
             </StackItem>
             {isMultiRealm && (
               <StackItem>
-                <Text>Select realm:</Text>
+                <Text>{t("selectRealm")}:</Text>
                 <Select
                   isOpen={isRealmSelectOpen}
                   onToggle={() => setIsRealmSelectOpen(!isRealmSelectOpen)}
@@ -302,28 +359,30 @@ export const PartialImportDialog = (props: PartialImportProps) => {
               </StackItem>
             )}
             <StackItem>
-              <Text>Choose the resources you want to import:</Text>
+              <Text>{t("chooseResources")}:</Text>
               <DataList aria-label="Resources to import" isCompact>
-                {targetHasMember("users") &&
-                  memberDataListItem("users", "users")}
-                {targetHasMember("groups") &&
-                  memberDataListItem("groups", "groups")}
-                {targetHasMember("clients") &&
-                  memberDataListItem("clients", "clients")}
-                {targetHasMember("identityProviders") &&
-                  memberDataListItem("identityProviders", "identity providers")}
+                {targetHasResource("users") &&
+                  resourceDataListItem("users", "users")}
+                {targetHasResource("groups") &&
+                  resourceDataListItem("groups", "groups")}
+                {targetHasResource("clients") &&
+                  resourceDataListItem("clients", "clients")}
+                {targetHasResource("identityProviders") &&
+                  resourceDataListItem(
+                    "identityProviders",
+                    "identity providers"
+                  )}
                 {targetHasRealmRoles() &&
-                  memberDataListItem("roles.realm", "realm roles")}
+                  resourceDataListItem("roles.realm", "realm roles")}
                 {targetHasClientRoles() &&
-                  memberDataListItem("roles.client", "client roles")}
+                  resourceDataListItem("roles.client", "client roles")}
               </DataList>
             </StackItem>
             <StackItem>
-              <Text>
-                If a resource already exists, specify what should be done:
-              </Text>
+              <Text>{t("selectIfResourceExists")}:</Text>
               <Select
                 isOpen={isCollisionSelectOpen}
+                direction="up"
                 onToggle={() => {
                   setIsCollisionSelectOpen(!isCollisionSelectOpen);
                 }}

--- a/src/realm-settings/PartialImport.tsx
+++ b/src/realm-settings/PartialImport.tsx
@@ -200,7 +200,9 @@ export const PartialImportDialog = (props: PartialImportProps) => {
   };
 
   const targetHasRoles = () => {
-    return targetRealm && targetRealm.hasOwnProperty("roles");
+    return (
+      targetRealm && Object.prototype.hasOwnProperty.call(targetRealm, "roles")
+    );
   };
 
   const targetHasRealmRoles = () => {
@@ -214,7 +216,7 @@ export const PartialImportDialog = (props: PartialImportProps) => {
   const targetHasClientRoles = () => {
     return (
       targetHasRoles() &&
-      targetRealm.roles!.hasOwnProperty("client") &&
+      Object.prototype.hasOwnProperty.call(targetRealm.roles, "client") &&
       Object.keys(targetRealm.roles!.client!).length > 0
     );
   };
@@ -235,7 +237,7 @@ export const PartialImportDialog = (props: PartialImportProps) => {
 
   const clientRolesCount = (clientRoles: { [index: string]: [] }) => {
     let total = 0;
-    for (let clientName in clientRoles) {
+    for (const clientName in clientRoles) {
       total += clientRoles[clientName].length;
     }
     return total;

--- a/src/realm-settings/PartialImport.tsx
+++ b/src/realm-settings/PartialImport.tsx
@@ -49,7 +49,7 @@ type ImportedRealm = {
 };
 
 type NonRoleResource = "users" | "clients" | "groups" | "identityProviders";
-type RoleResource = "roles.realm" | "roles.client";
+type RoleResource = "realmRoles" | "clientRoles";
 type Resource = NonRoleResource | RoleResource;
 
 type CollisionOption = "FAIL" | "SKIP" | "OVERWRITE";
@@ -75,8 +75,8 @@ export const PartialImportDialog = (props: PartialImportProps) => {
     clients: false,
     groups: false,
     identityProviders: false,
-    "roles.realm": false,
-    "roles.client": false,
+    realmRoles: false,
+    clientRoles: false,
   };
 
   const [resourcesToImport, setResourcesToImport] = useState<ResourceChecked>(
@@ -167,7 +167,11 @@ export const PartialImportDialog = (props: PartialImportProps) => {
 
     const mapper = (realm: ImportedRealm) => {
       return (
-        <SelectOption key={realm.id} value={realm}>
+        <SelectOption
+          key={realm.id}
+          value={realm}
+          data-testid={realm.id + "-select-option"}
+        >
           {realm.realm || realm.id}
         </SelectOption>
       );
@@ -240,10 +244,10 @@ export const PartialImportDialog = (props: PartialImportProps) => {
   const itemCount = (resource: Resource) => {
     if (!isFileSelected) return 0;
 
-    if (targetHasRealmRoles() && resource === "roles.realm")
+    if (targetHasRealmRoles() && resource === "realmRoles")
       return targetRealm.roles!.realm!.length;
 
-    if (targetHasClientRoles() && resource == "roles.client")
+    if (targetHasClientRoles() && resource == "clientRoles")
       return clientRolesCount(targetRealm.roles!.client!);
 
     if (!targetRealm[resource as NonRoleResource]) return 0;
@@ -280,11 +284,12 @@ export const PartialImportDialog = (props: PartialImportProps) => {
             name={resource}
             isChecked={resourcesToImport[resource]}
             onChange={handleResourceCheckBox}
+            data-testid={resource + "-checkbox"}
           />
           <DataListItemCells
             dataListCells={[
               <DataListCell key={resource}>
-                <span>
+                <span data-testid={resource + "-count"}>
                   {itemCount(resource)} {resourceDisplayName}
                 </span>
               </DataListCell>,
@@ -349,6 +354,7 @@ export const PartialImportDialog = (props: PartialImportProps) => {
               <StackItem>
                 <Text>{t("selectRealm")}:</Text>
                 <Select
+                  toggleId="realm-selector"
                   isOpen={isRealmSelectOpen}
                   onToggle={() => setIsRealmSelectOpen(!isRealmSelectOpen)}
                   onSelect={handleRealmSelect}
@@ -373,9 +379,9 @@ export const PartialImportDialog = (props: PartialImportProps) => {
                     "identity providers"
                   )}
                 {targetHasRealmRoles() &&
-                  resourceDataListItem("roles.realm", "realm roles")}
+                  resourceDataListItem("realmRoles", "realm roles")}
                 {targetHasClientRoles() &&
-                  resourceDataListItem("roles.client", "client roles")}
+                  resourceDataListItem("clientRoles", "client roles")}
               </DataList>
             </StackItem>
             <StackItem>

--- a/src/realm-settings/PartialImport.tsx
+++ b/src/realm-settings/PartialImport.tsx
@@ -137,7 +137,6 @@ export const PartialImportDialog = (props: PartialImportProps) => {
     copyOfResourcesToImport[resource] = checked;
     setResourcesToImport(copyOfResourcesToImport);
     setIsAnyResourceChecked(resourcesChecked(copyOfResourcesToImport));
-    console.log(resourcesToImport);
   };
 
   const realmSelectOptions = () => {

--- a/src/realm-settings/PartialImport.tsx
+++ b/src/realm-settings/PartialImport.tsx
@@ -1,11 +1,21 @@
 import React, { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
+import _ from "lodash";
 import {
   Button,
   ButtonVariant,
+  DataList,
+  DataListCell,
+  DataListItem,
+  DataListItemCells,
+  DataListItemRow,
+  DataListCheck,
   Divider,
   Modal,
   ModalVariant,
+  Select,
+  SelectOption,
+  SelectOptionObject,
   Stack,
   StackItem,
   Text,
@@ -19,18 +29,213 @@ export type PartialImportProps = {
   toggleDialog: () => void;
 };
 
+// An exported JSON file can either be an array of realm objects
+// or a single realm object.
+type ImportedMultiRealm = [ImportedRealm?] | ImportedRealm;
+
+// The actual imported json can have a lot more members,
+// but these are the ones we care about.
+type ImportedRealm = {
+  id?: string;
+  realm?: string;
+  users?: [];
+  clients?: [];
+  groups?: [];
+  identityProviders?: [];
+  roles?: {
+    realm?: [];
+    client?: { [index: string]: [] };
+  };
+};
+
+type NonRoleMember = "users" | "clients" | "groups" | "identityProviders";
+type RoleMember = "roles.realm" | "roles.client";
+
+type CollisionOption = "FAIL" | "SKIP" | "OVERWRITE";
+
 export const PartialImportDialog = (props: PartialImportProps) => {
   const tRealm = useTranslation("realm-settings").t;
   const { t } = useTranslation("partial-import");
   const [importEnabled, setImportEnabled] = useState(false);
+  const [isMultiRealm, setIsMultiRealm] = useState(false);
+  const [importedFile, setImportedFile] = useState<ImportedMultiRealm>([]);
+  const [isRealmSelectOpen, setIsRealmSelectOpen] = useState(false);
+  const [isCollisionSelectOpen, setIsCollisionSelectOpen] = useState(false);
+  const [collisionOption, setCollisionOption] = useState<CollisionOption>(
+    "FAIL"
+  );
+  const [targetRealm, setTargetRealm] = useState<ImportedRealm>({});
 
   // when dialog opens or closes, reset importEnabled to false
   useEffect(() => {
     setImportEnabled(false);
   }, [props.open]);
 
+  const handleClear = () => {
+    setImportEnabled(false);
+  };
+
   const handleFileChange = (value: object) => {
     setImportEnabled(!!value);
+    setIsMultiRealm(false);
+    setImportedFile([]);
+    setTargetRealm({});
+
+    // if user pressed clear button reset importEnabled
+    /*const nativeEvent = event.nativeEvent;
+    if (
+      nativeEvent instanceof MouseEvent &&
+      !(nativeEvent instanceof DragEvent)
+    ) {
+      setImportEnabled(false);
+      return;
+    }*/
+
+    let rawContent: ImportedMultiRealm = [];
+    try {
+      setImportedFile(value);
+    } catch (error) {
+      // Ignore.  We need to be lenient on things like
+      // "Unexpected end of JSON input".
+    }
+
+    if (rawContent instanceof Array && rawContent.length > 0) {
+      setIsMultiRealm(rawContent.length > 1);
+      setTargetRealm(rawContent[0] || {});
+    } else {
+      setIsMultiRealm(false);
+      setTargetRealm((rawContent as ImportedRealm) || {});
+    }
+  };
+
+  const handleRealmSelect = (
+    event: React.ChangeEvent<Element> | React.MouseEvent<Element, MouseEvent>,
+    realm: string | SelectOptionObject
+  ) => {
+    setTargetRealm(realm as ImportedRealm);
+    setIsRealmSelectOpen(false);
+  };
+
+  const realmSelectOptions = () => {
+    if (!isMultiRealm) return [];
+
+    const mapper = (realm: ImportedRealm) => {
+      return (
+        <SelectOption key={realm.id} value={realm}>
+          {realm.realm || realm.id}
+        </SelectOption>
+      );
+    };
+
+    return (importedFile as [ImportedRealm]).map(mapper);
+  };
+
+  const handleCollisionSelect = (
+    event: React.ChangeEvent<Element> | React.MouseEvent<Element, MouseEvent>,
+    option: string | SelectOptionObject
+  ) => {
+    setCollisionOption(option as CollisionOption);
+    setIsCollisionSelectOpen(false);
+  };
+
+  const collisionOptions = () => {
+    return [
+      <SelectOption key="fail" value="FAIL">
+        {t("FAIL")}
+      </SelectOption>,
+      <SelectOption key="skip" value="SKIP">
+        {t("SKIP")}
+      </SelectOption>,
+      <SelectOption key="overwrite" value="OVERWRITE">
+        {t("OVERWRITE")}
+      </SelectOption>,
+    ];
+  };
+
+  const targetHasMembers = () => {
+    return (
+      targetHasMember("users") ||
+      targetHasMember("groups") ||
+      targetHasMember("clients") ||
+      targetHasMember("identityProviders") ||
+      targetHasRealmRoles() ||
+      targetHasClientRoles()
+    );
+  };
+
+  const targetHasMember = (member: NonRoleMember) => {
+    return (
+      targetRealm &&
+      targetRealm[member] instanceof Array &&
+      targetRealm[member]!.length > 0
+    );
+  };
+
+  const targetHasRoles = () => {
+    return targetRealm && targetRealm.hasOwnProperty("roles");
+  };
+
+  const targetHasRealmRoles = () => {
+    return (
+      targetHasRoles() &&
+      targetRealm.roles!.realm instanceof Array &&
+      targetRealm.roles!.realm.length > 0
+    );
+  };
+
+  const targetHasClientRoles = () => {
+    return (
+      targetHasRoles() &&
+      targetRealm.roles!.hasOwnProperty("client") &&
+      Object.keys(targetRealm.roles!.client!).length > 0
+    );
+  };
+
+  const itemCount = (member: NonRoleMember | RoleMember) => {
+    if (!importEnabled) return 0;
+
+    if (targetHasRealmRoles() && member === "roles.realm")
+      return targetRealm.roles!.realm!.length;
+
+    if (targetHasClientRoles() && member == "roles.client")
+      return clientRolesCount(targetRealm.roles!.client!);
+
+    if (!targetRealm[member as NonRoleMember]) return 0;
+
+    return targetRealm[member as NonRoleMember]!.length;
+  };
+
+  const clientRolesCount = (clientRoles: { [index: string]: [] }) => {
+    let total = 0;
+    for (let clientName in clientRoles) {
+      total += clientRoles[clientName].length;
+    }
+    return total;
+  };
+
+  const memberDataListItem = (
+    member: NonRoleMember | RoleMember,
+    memberDisplayName: string
+  ) => {
+    return (
+      <DataListItem aria-labelledby={`${member}-list-item`}>
+        <DataListItemRow>
+          <DataListCheck
+            aria-labelledby={`${member}-checkbox`}
+            name={`${member}-checkbox`}
+          />
+          <DataListItemCells
+            dataListCells={[
+              <DataListCell key={member}>
+                <span>
+                  {itemCount(member)} {memberDisplayName}
+                </span>
+              </DataListCell>,
+            ]}
+          />
+        </DataListItemRow>
+      </DataListItem>
+    );
   };
 
   return (
@@ -44,7 +249,7 @@ export const PartialImportDialog = (props: PartialImportProps) => {
           id="modal-import"
           data-testid="import-button"
           key="import"
-          isDisabled={!importEnabled}
+          isDisabled={!importEnabled || !targetHasMembers()}
           onClick={() => {
             props.toggleDialog();
           }}
@@ -74,16 +279,61 @@ export const PartialImportDialog = (props: PartialImportProps) => {
           <JsonFileUpload
             id="partial-import-file"
             onChange={handleFileChange}
+            onClear={handleClear}
           />
         </StackItem>
-        {importEnabled && (
-          <StackItem>
-            <Divider />
-            TODO: This section will include{" "}
-            <strong>Choose the resources...</strong> and{" "}
-            <strong>If a resource already exists....</strong>
-            <Divider />
-          </StackItem>
+
+        {importEnabled && targetHasMembers() && (
+          <>
+            <StackItem>
+              <Divider />
+            </StackItem>
+            {isMultiRealm && (
+              <StackItem>
+                <Text>Select realm:</Text>
+                <Select
+                  isOpen={isRealmSelectOpen}
+                  onToggle={() => setIsRealmSelectOpen(!isRealmSelectOpen)}
+                  onSelect={handleRealmSelect}
+                  placeholderText={targetRealm.realm || targetRealm.id}
+                >
+                  {realmSelectOptions()}
+                </Select>
+              </StackItem>
+            )}
+            <StackItem>
+              <Text>Choose the resources you want to import:</Text>
+              <DataList aria-label="Resources to import" isCompact>
+                {targetHasMember("users") &&
+                  memberDataListItem("users", "users")}
+                {targetHasMember("groups") &&
+                  memberDataListItem("groups", "groups")}
+                {targetHasMember("clients") &&
+                  memberDataListItem("clients", "clients")}
+                {targetHasMember("identityProviders") &&
+                  memberDataListItem("identityProviders", "identity providers")}
+                {targetHasRealmRoles() &&
+                  memberDataListItem("roles.realm", "realm roles")}
+                {targetHasClientRoles() &&
+                  memberDataListItem("roles.client", "client roles")}
+              </DataList>
+            </StackItem>
+            <StackItem>
+              <Text>
+                If a resource already exists, specify what should be done:
+              </Text>
+              <Select
+                isOpen={isCollisionSelectOpen}
+                onToggle={() => {
+                  setIsCollisionSelectOpen(!isCollisionSelectOpen);
+                }}
+                onSelect={handleCollisionSelect}
+                placeholderText={t(collisionOption)}
+              >
+                {collisionOptions()}
+              </Select>
+            </StackItem>
+          </>
         )}
       </Stack>
     </Modal>

--- a/src/realm-settings/messages.json
+++ b/src/realm-settings/messages.json
@@ -492,7 +492,10 @@
     "confirm": "Confirm"
   },
   "partial-import": {
-    "partialImportHeaderText": "Partial import allows you to import users, clients, and resources from a previously exported json file.",
+    "partialImportHeaderText": "Partial import allows you to import users, clients, and other resources from a previously exported json file.",
+    "selectRealm": "Select realm",
+    "chooseResources": "Choose the resources you want to import",
+    "selectIfResourceExists": "If a resource already exists, specify what should be done",
     "import": "Import",
     "FAIL": "Fail import",
     "SKIP": "Skip",

--- a/src/realm-settings/messages.json
+++ b/src/realm-settings/messages.json
@@ -1,4 +1,3 @@
-  
 {
   "realm-settings": {
     "partialImport": "Partial import",
@@ -477,7 +476,6 @@
         "name": "Refresh token error",
         "description": "Refresh token error"
       }
-
     },
     "emptyEvents": "Nothing to add",
     "emptyEventsInstructions": "There are no more events types left to add",
@@ -495,7 +493,10 @@
   },
   "partial-import": {
     "partialImportHeaderText": "Partial import allows you to import users, clients, and resources from a previously exported json file.",
-    "import": "Import"
+    "import": "Import",
+    "FAIL": "Fail import",
+    "SKIP": "Skip",
+    "OVERWRITE": "Overwrite"
   },
   "onDragStart": "Dragging started for item {{id}}",
   "onDragMove": "Dragging item {{id}}",


### PR DESCRIPTION
## Brief Description
This is phase 2 of the Partial import implementation.  Phase 3 will be the final phase where the imported data is sent to the Keycloak server.

Partial import modal now handles the imported JSON and presents the user with import options as per [Marvel](https://marvelapp.com/prototype/fg26f9b/screen/75624791).  

Note: The design did not include functionality for handling JSON files with multiple realms.

## Verification Steps
1. Go to `Realm settings`.
2. Select Partial import form the Action dropdown.
3. Import a previously exported Keycloak json. (Samples included in test data for this PR. `kcexport.json` is a good one to look at)
4. Verify that modal presents the user with options as shown in the design, plus multi-realm functionality.

## Checklist:

- [X] Code has been tested locally by PR requester
- [X] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented (not applicable)
- [ ] axe report has been run and resulting a11y issues have been resolved
- [X] Unit tests have been created/updated
- [X] Formatting has been performed via prettier/eslint
- [X] Type checking has been performed via 'yarn check-types'
