### PR TITLE
Use typeahead for mapper list

### DIFF
--- a/cypress/support/pages/admin_console/manage/providers/ProviderPage.ts
+++ b/cypress/support/pages/admin_console/manage/providers/ProviderPage.ts
@@ -221,7 +221,7 @@ export default class ProviderPage {
     cy.wait(1000);
 
     cy.get("#kc-providerId").click();
-    cy.get("#kc-providerId + ul").contains(mapperType).click();
+    cy.get("button").contains(mapperType).click();
 
     cy.get(`[data-testid="ldap-mapper-name"]`).type(`${mapperType}-test`);
 

--- a/src/user-federation/ldap/mappers/LdapMapperDetails.tsx
+++ b/src/user-federation/ldap/mappers/LdapMapperDetails.tsx
@@ -223,7 +223,7 @@ export const LdapMapperDetails = () => {
             >
               <Controller
                 name="providerId"
-                defaultValue=" "
+                defaultValue=""
                 control={form.control}
                 data-testid="ldap-mapper-type-select"
                 render={({ onChange, value }) => (
@@ -239,7 +239,7 @@ export const LdapMapperDetails = () => {
                       setIsMapperDropdownOpen(false);
                     }}
                     selections={value}
-                    variant={SelectVariant.single}
+                    variant={SelectVariant.typeahead}
                   >
                     <SelectOption
                       key={0}


### PR DESCRIPTION
## Motivation
Adds a typeahead to the LDAP mapper select list, as requested in UXD demo and referenced in https://github.com/keycloak/keycloak-admin-ui/issues/705.

## Brief Description
LDAP mapper select list consists of 11 items, which qualifies for the PF guideline that each list with > 10 items should use the typeahead variant. Simple change to add the variant.

## Verification Steps
1. Go to User Fed and create an LDAP provider if one doesn't already exist.
2. In the LDAP provider details, go to the **Mappers** tab and click **Add mapper**.
3. In the **Mapper type** dropdown, verify that you can narrow the list of mapper types by typing the first few chars of one or more mapper types.

## Checklist:
- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [x] Help has been implemented
- [x] Unit tests have been created/updated
- [x] Formatting has been performed via prettier/eslint
- [x] Type checking has been performed via 'yarn check-types'

## Additional Notes
none