### PR TITLE
Use a Snowpack plugin to check TypeScript types

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,7 +26,6 @@ new functionality can follow them, such as QE or documentation.
 - [ ] axe report has been run and resulting a11y issues have been resolved
 - [ ] Unit tests have been created/updated
 - [ ] Formatting has been performed via prettier/eslint
-- [ ] Type checking has been performed via 'npm run check-types'
 
 ## Additional Notes
 <!-- 

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -29,6 +29,5 @@ jobs:
     - run: npm ci
     - run: npm run lint
     - run: npm run test
-    - run: npm run check-types
     - run: npm run build
     - run: npm run build-storybook

--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ If your Keycloak instance is not on `localhost:8180`, create a file `.env` with 
 
 ```bash
 $> npm run lint
-$> npm run check-types
 ```
 
 To switch to a RH-SSO themed version of this console you can run:

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@jest/types": "^27.0.6",
         "@snowpack/app-scripts-react": "^1.12.6",
         "@snowpack/plugin-postcss": "1.4.3",
+        "@snowpack/plugin-typescript": "^1.2.1",
         "@snowpack/plugin-webpack": "3.0.0",
         "@storybook/addon-actions": "^6.3.4",
         "@storybook/addon-essentials": "^6.3.4",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   },
   "scripts": {
     "build": "snowpack build",
-    "check-types": "tsc -p ./",
     "lint": "eslint \"./src/**/*.{js,jsx,ts,tsx}\"",
     "postinstall": "grunt",
     "start": "snowpack dev",
@@ -49,6 +48,7 @@
     "@jest/types": "^27.0.6",
     "@snowpack/app-scripts-react": "^1.12.6",
     "@snowpack/plugin-postcss": "1.4.3",
+    "@snowpack/plugin-typescript": "^1.2.1",
     "@snowpack/plugin-webpack": "3.0.0",
     "@storybook/addon-actions": "^6.3.4",
     "@storybook/addon-essentials": "^6.3.4",

--- a/snowpack.config.js
+++ b/snowpack.config.js
@@ -3,7 +3,7 @@ module.exports = {
   proxy: {
     "/auth/admin": "http://localhost:8180/auth/admin/",
   },
-  plugins: ["@snowpack/plugin-postcss"],
+  plugins: ["@snowpack/plugin-postcss", "@snowpack/plugin-typescript"],
   buildOptions: {
     baseUrl: "/adminv2",
     clean: true,


### PR DESCRIPTION
## Motivation
This allows types to be checked during development without running `npm run check-types` separately and reduces the need to run this task on the CI. 