### PR TITLE
Upgrade PatternFly to a prerelease version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "hasInstallScript": true,
       "license": "Apache",
       "dependencies": {
-        "@patternfly/patternfly": "^4.115.2",
+        "@patternfly/patternfly": "^4.122.2",
         "@patternfly/react-core": "4.135.0",
         "@patternfly/react-icons": "4.11.0",
         "@patternfly/react-table": "4.29.0",
@@ -3476,9 +3476,9 @@
       }
     },
     "node_modules/@patternfly/patternfly": {
-      "version": "4.115.2",
-      "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-4.115.2.tgz",
-      "integrity": "sha512-7hbJ4pRmj+rlXclD2F/UwceO6fS+9flGsgHc4eUc7NyTN2GXl6PLcqrjE2CtiKEPV90+KwsGQGJXZj8bz9HweA=="
+      "version": "4.122.2",
+      "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-4.122.2.tgz",
+      "integrity": "sha512-kSoW8mt9eEJcAZX2lX4r/SYvFd44GGb8PUSDjMrpKDZqgn9/9VFh1rSChG4v5kCK6cpS99/gdTapZc3ylf8Rpw=="
     },
     "node_modules/@patternfly/react-core": {
       "version": "4.135.0",
@@ -36842,9 +36842,9 @@
       }
     },
     "@patternfly/patternfly": {
-      "version": "4.115.2",
-      "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-4.115.2.tgz",
-      "integrity": "sha512-7hbJ4pRmj+rlXclD2F/UwceO6fS+9flGsgHc4eUc7NyTN2GXl6PLcqrjE2CtiKEPV90+KwsGQGJXZj8bz9HweA=="
+      "version": "4.122.2",
+      "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-4.122.2.tgz",
+      "integrity": "sha512-kSoW8mt9eEJcAZX2lX4r/SYvFd44GGb8PUSDjMrpKDZqgn9/9VFh1rSChG4v5kCK6cpS99/gdTapZc3ylf8Rpw=="
     },
     "@patternfly/react-core": {
       "version": "4.135.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "prepare": "husky install"
   },
   "dependencies": {
-    "@patternfly/patternfly": "^4.115.2",
+    "@patternfly/patternfly": "^4.122.2",
     "@patternfly/react-core": "4.135.0",
     "@patternfly/react-icons": "4.11.0",
     "@patternfly/react-table": "4.29.0",

--- a/src/user/user-section.css
+++ b/src/user/user-section.css
@@ -28,11 +28,6 @@ button#kc-join-groups-button {
   margin-left: var(--pf-global--spacer--md);
 }
 
-
-.pf-c-toolbar__content-section {
-  margin-bottom: calc(var(--pf-global--spacer--lg) * -1);
-}
-
 .pf-c-chip.kc-consents-chip::before {
   padding: 0px;
   border: 0;


### PR DESCRIPTION
## Motivation
There are some fixes in PatternFly that are needed for the the Snowpack 3 (https://github.com/keycloak/keycloak-admin-ui/pull/839) upgrade that are only available in a prerelease version.
