### PR TITLE
Remove snowpack error overlay

### DIFF
--- a/snowpack.config.js
+++ b/snowpack.config.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   extends: "@snowpack/app-scripts-react",
   proxy: {
     "/auth/admin": "http://localhost:8180/auth/admin/",
@@ -13,6 +13,7 @@ module.exports = {
     clean: true,
   },
   devOptions: {
+    hmrErrorOverlay: false,
     out: "build/src/main/resources/admin/resources", // For snowpack 3, "out" goes under buildOptions.
   },
 };

--- a/snowpack.config.js
+++ b/snowpack.config.js
@@ -1,4 +1,4 @@
-export default {
+module.exports = {
   extends: "@snowpack/app-scripts-react",
   proxy: {
     "/auth/admin": "http://localhost:8180/auth/admin/",


### PR DESCRIPTION
## Motivation
Remove the snowpack error overlay since it obscures the UI and is redundant with the information that is available in the console.

## Brief Description
Simple snowpack config file change that sets the error overlay to false.

## Verification Steps
Generate an error by modifying the code and verify that the error overlay no longer appears in the browser window, but the error still appears in the console window.

## Checklist:
- [x] Code has been tested locally by PR requester
- [x] Formatting has been performed via prettier/eslint

## Additional Notes
none