### PR TITLE
Allow Maven to build the frontend

### DIFF
--- a/keycloak-theme/.gitignore
+++ b/keycloak-theme/.gitignore
@@ -1,5 +1,6 @@
-# See: https://github.com/github/gitignore/blob/master/Maven.gitignore
 src/
+node/
+# https://github.com/github/gitignore/blob/master/Maven.gitignore
 target/
 pom.xml.tag
 pom.xml.releaseBackup

--- a/keycloak-theme/README.md
+++ b/keycloak-theme/README.md
@@ -5,9 +5,7 @@ The Maven build prepares the admin console to be deployed as a theme on the Keyc
 # Build Instructions
 
 ```bash
-$> npm run build
-$> cd build
-$> mvn install
+mvn install
 ```
 
 # Deployment

--- a/keycloak-theme/pom.xml
+++ b/keycloak-theme/pom.xml
@@ -55,6 +55,38 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>com.github.eirslett</groupId>
+                <artifactId>frontend-maven-plugin</artifactId>
+                <version>1.9.1</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>install-node-and-npm</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>npm install</id>
+                        <goals>
+                            <goal>npm</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>npm run build</id>
+                        <goals>
+                            <goal>npm</goal>
+                        </goals>
+                        <configuration>
+                            <arguments>run build</arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+                <configuration>
+                    <nodeVersion>v16.5.0</nodeVersion>
+                    <workingDirectory>../</workingDirectory>
+                    <installDirectory>.</installDirectory>
+                </configuration>
+            </plugin>
+            <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
                 <version>3.2.0</version>
                 <executions>


### PR DESCRIPTION
## Motivation
This will allow Java devs to build the frontend through Maven, so they do not have to deal with JavaScript tooling. Also an enabler to build the JAR on our CI so folks can try out builds on `master`.

Depends on: https://github.com/keycloak/keycloak-admin-ui/pull/854, please merge that one first.