### PR TITLE
Run Maven build on Github actions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,20 @@
+name: Maven CI
+on:
+  push:
+    branches: [master]
+defaults:
+  run:
+    working-directory: keycloak-theme
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+      - run: mvn --batch-mode package
+      - uses: actions/upload-artifact@v2
+        with:
+          path: target/**/*.jar


### PR DESCRIPTION
## Motivation
Runs the Maven build on Github Actions to detect breakage and uploads an artifact for the resulting JAR file. Allows non-JS devs to get the build result without having to build the project themselves.

Depends on: https://github.com/keycloak/keycloak-admin-ui/pull/857, please merge that one first.
