### PR TITLE
Comment out localization tab.

### DIFF
--- a/cypress/integration/realm_settings_test.spec.ts
+++ b/cypress/integration/realm_settings_test.spec.ts
@@ -52,7 +52,7 @@ describe("Realm settings", () => {
     return this;
   };
 
-  const addBundle = () => {
+  /*const addBundle = () => {
     const localizationUrl = `/auth/admin/realms/${realmName}/localization/en`;
     cy.intercept(localizationUrl).as("localizationFetch");
 
@@ -64,7 +64,7 @@ describe("Realm settings", () => {
     cy.wait(["@localizationFetch"]);
 
     return this;
-  };
+  };*/
 
   it("Go to general tab", function () {
     sidebarPage.goToRealmSettings();
@@ -215,7 +215,7 @@ describe("Realm settings", () => {
     realmSettingsPage.testSelectFilter();
   });
 
-  it("add locale", () => {
+  /* it("add locale", () => {
     sidebarPage.goToRealmSettings();
 
     cy.getId("rs-localization-tab").click();
@@ -225,7 +225,7 @@ describe("Realm settings", () => {
     masthead.checkNotificationMessage(
       "Success! The localization text has been created."
     );
-  });
+  });*/
 
   it("Realm header settings", () => {
     sidebarPage.goToRealmSettings();

--- a/src/realm-settings/RealmSettingsSection.tsx
+++ b/src/realm-settings/RealmSettingsSection.tsx
@@ -31,7 +31,7 @@ import { EventsTab } from "./event-config/EventsTab";
 import type ComponentRepresentation from "keycloak-admin/lib/defs/componentRepresentation";
 import { KeysProvidersTab } from "./KeysProvidersTab";
 import { useServerInfo } from "../context/server-info/ServerInfoProvider";
-import { LocalizationTab } from "./LocalizationTab";
+//import { LocalizationTab } from "./LocalizationTab";
 import { WhoAmIContext } from "../context/whoami/WhoAmI";
 import type UserRepresentation from "keycloak-admin/lib/defs/userRepresentation";
 import { SecurityDefences } from "./security-defences/SecurityDefences";
@@ -283,7 +283,7 @@ export const RealmSettingsSection = () => {
               <EventsTab />
             </Tab>
 
-            <Tab
+            {/*     <Tab
               id="localization"
               eventKey="localization"
               data-testid="rs-localization-tab"
@@ -298,7 +298,7 @@ export const RealmSettingsSection = () => {
                   realm={realm}
                 />
               )}
-            </Tab>
+              </Tab> */}
             <Tab
               id="securityDefences"
               eventKey="securityDefences"


### PR DESCRIPTION
## Motivation
Tests for https://github.com/keycloak/keycloak-admin-ui/pull/856 are failing because you can't go to the Realm Settings for any realm except master.  The reason is that we are getting a NPE on WildFly 14+.  I believe that there is a bug in WildFly.  It is probably not initializing the localization when you create a new realm.

However, I see some possible issues with the implementation on our side as well.  Our localization tab assumes that you should always be able to create bundle keys and values for English.  I believe this should not be the case.

The error is actually caused when you try to make the REST call to admin/realms/mynewrealm/localization/en.  But the old console does not make this call until you explicitly create the locale for en.  So you don't see the error in the old console.

This PR should allow us to continue until we decide what to do.