### PR TITLE
Centralize all route definitions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "react-error-boundary": "^3.1.3",
         "react-hook-form": "^6.15.8",
         "react-i18next": "^11.11.3",
+        "react-router-config": "^5.1.1",
         "react-router-dom": "^5.2.0",
         "use-react-router-breadcrumbs": "^2.0.2"
       },
@@ -45,6 +46,7 @@
         "@types/lodash": "^4.14.171",
         "@types/react": "^17.0.14",
         "@types/react-dom": "^17.0.9",
+        "@types/react-router-config": "^5.0.3",
         "@types/react-router-dom": "^5.1.8",
         "@types/snowpack-env": "^2.3.4",
         "@typescript-eslint/eslint-plugin": "^4.28.1",
@@ -10148,6 +10150,17 @@
       "dependencies": {
         "@types/history": "*",
         "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-router-config": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@types/react-router-config/-/react-router-config-5.0.3.tgz",
+      "integrity": "sha512-38vpjXic0+E2sIBEKUe+RrCmbc8RqcQhNV8OmU3KUcwgy/yzTeo67MhllP+0zjZWNr7Lhw+RnUkL0hzkf63nUQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/history": "*",
+        "@types/react": "*",
+        "@types/react-router": "*"
       }
     },
     "node_modules/@types/react-router-dom": {
@@ -25762,6 +25775,18 @@
         "react": ">=15"
       }
     },
+    "node_modules/react-router-config": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/react-router-config/-/react-router-config-5.1.1.tgz",
+      "integrity": "sha512-DuanZjaD8mQp1ppHjgnnUnyOlqYXZVjnov/JzFhjLEwd3Z4dYjMSnqrEzzGThH47vpCOqPPwJM2FtthLeJ8Pbg==",
+      "dependencies": {
+        "@babel/runtime": "^7.1.2"
+      },
+      "peerDependencies": {
+        "react": ">=15",
+        "react-router": ">=5"
+      }
+    },
     "node_modules/react-router-dom": {
       "version": "5.2.0",
       "integrity": "sha512-gxAmfylo2QUjcwxI63RhQ5G85Qqt4voZpUXSEqCwykV0baaOTQDR1f0PmY8AELqIyVc0NEZUj0Gov5lNGcXgsA==",
@@ -38266,6 +38291,17 @@
         "@types/react": "*"
       }
     },
+    "@types/react-router-config": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@types/react-router-config/-/react-router-config-5.0.3.tgz",
+      "integrity": "sha512-38vpjXic0+E2sIBEKUe+RrCmbc8RqcQhNV8OmU3KUcwgy/yzTeo67MhllP+0zjZWNr7Lhw+RnUkL0hzkf63nUQ==",
+      "dev": true,
+      "requires": {
+        "@types/history": "*",
+        "@types/react": "*",
+        "@types/react-router": "*"
+      }
+    },
     "@types/react-router-dom": {
       "version": "5.1.8",
       "integrity": "sha512-03xHyncBzG0PmDmf8pf3rehtjY0NpUj7TIN46FrT5n1ZWHPZvXz32gUyNboJ+xsL8cpg8bQVLcllptcQHvocrw==",
@@ -50180,6 +50216,14 @@
           "version": "16.13.1",
           "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         }
+      }
+    },
+    "react-router-config": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/react-router-config/-/react-router-config-5.1.1.tgz",
+      "integrity": "sha512-DuanZjaD8mQp1ppHjgnnUnyOlqYXZVjnov/JzFhjLEwd3Z4dYjMSnqrEzzGThH47vpCOqPPwJM2FtthLeJ8Pbg==",
+      "requires": {
+        "@babel/runtime": "^7.1.2"
       }
     },
     "react-router-dom": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "react-error-boundary": "^3.1.3",
     "react-hook-form": "^6.15.8",
     "react-i18next": "^11.11.3",
+    "react-router-config": "^5.1.1",
     "react-router-dom": "^5.2.0",
     "use-react-router-breadcrumbs": "^2.0.2"
   },
@@ -63,6 +64,7 @@
     "@types/lodash": "^4.14.171",
     "@types/react": "^17.0.14",
     "@types/react-dom": "^17.0.9",
+    "@types/react-router-config": "^5.0.3",
     "@types/react-router-dom": "^5.1.8",
     "@types/snowpack-env": "^2.3.4",
     "@typescript-eslint/eslint-plugin": "^4.28.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,31 +1,28 @@
-import React, { ReactNode, useEffect } from "react";
 import { Page } from "@patternfly/react-core";
+import React, { FunctionComponent, useEffect } from "react";
+import { ErrorBoundary } from "react-error-boundary";
 import {
   HashRouter as Router,
   Route,
   Switch,
   useParams,
 } from "react-router-dom";
-import { ErrorBoundary } from "react-error-boundary";
-
-import { Header } from "./PageHeader";
-import { PageNav } from "./PageNav";
-import { Help } from "./components/help-enabler/HelpHeader";
-
-import { ServerInfoProvider } from "./context/server-info/ServerInfoProvider";
 import { AlertProvider } from "./components/alert/Alerts";
-
-import { AccessContextProvider, useAccess } from "./context/access/Access";
-import { routes, RouteDef } from "./route-config";
 import { PageBreadCrumbs } from "./components/bread-crumb/PageBreadCrumbs";
+import { ErrorRenderer } from "./components/error/ErrorRenderer";
+import { Help } from "./components/help-enabler/HelpHeader";
+import { AccessContextProvider, useAccess } from "./context/access/Access";
+import { useRealm } from "./context/realm-context/RealmContext";
+import { ServerInfoProvider } from "./context/server-info/ServerInfoProvider";
 import { ForbiddenSection } from "./ForbiddenSection";
 import { SubGroups } from "./groups/SubGroupsContext";
-import { useRealm } from "./context/realm-context/RealmContext";
-import { ErrorRenderer } from "./components/error/ErrorRenderer";
+import { Header } from "./PageHeader";
+import { PageNav } from "./PageNav";
+import routes, { RouteConfig } from "./routes";
 
 export const mainPageContentId = "kc-main-content-page-container";
 
-const AppContexts = ({ children }: { children: ReactNode }) => (
+const AppContexts: FunctionComponent = ({ children }) => (
   <AccessContextProvider>
     <Help>
       <AlertProvider>
@@ -37,10 +34,11 @@ const AppContexts = ({ children }: { children: ReactNode }) => (
   </AccessContextProvider>
 );
 
-// set the realm form the path
-const RealmPathSelector = ({ children }: { children: ReactNode }) => {
+// TODO: Handle this logic in the provider of the realm
+const RealmPathSelector: FunctionComponent = ({ children }) => {
   const { setRealm } = useRealm();
   const { realm } = useParams<{ realm: string }>();
+
   useEffect(() => {
     if (realm) setRealm(realm);
   }, []);
@@ -50,7 +48,8 @@ const RealmPathSelector = ({ children }: { children: ReactNode }) => {
 
 // If someone tries to go directly to a route they don't
 // have access to, show forbidden page.
-type SecuredRouteProps = { route: RouteDef };
+type SecuredRouteProps = { route: RouteConfig };
+
 const SecuredRoute = ({ route }: SecuredRouteProps) => {
   const { hasAccess } = useAccess();
   if (hasAccess(route.access)) return <route.component />;
@@ -74,13 +73,8 @@ export const App = () => {
             onReset={() => window.location.reload()}
           >
             <Switch>
-              {routes(() => {}).map((route, i) => (
+              {routes.map((route, i) => (
                 <Route
-                  exact={
-                    route.matchOptions?.exact === undefined
-                      ? true
-                      : route.matchOptions.exact
-                  }
                   key={i}
                   path={route.path}
                   component={() => (

--- a/src/route-config.ts
+++ b/src/route-config.ts
@@ -1,46 +1,19 @@
 import type { TFunction } from "i18next";
-import type { BreadcrumbsRoute } from "use-react-router-breadcrumbs";
 import type { AccessType } from "keycloak-admin/lib/defs/whoAmIRepresentation";
-
+import type { BreadcrumbsRoute } from "use-react-router-breadcrumbs";
 import { AuthenticationSection } from "./authentication/AuthenticationSection";
-import { ClientScopeForm } from "./client-scopes/form/ClientScopeForm";
-import { ClientScopesSection } from "./client-scopes/ClientScopesSection";
-import { DashboardSection } from "./dashboard/Dashboard";
-import { NewClientForm } from "./clients/add/NewClientForm";
-import { ClientsSection } from "./clients/ClientsSection";
-import { ImportForm } from "./clients/import/ImportForm";
-import { EventsSection } from "./events/EventsSection";
-import { GroupsSection } from "./groups/GroupsSection";
-import { IdentityProvidersSection } from "./identity-providers/IdentityProvidersSection";
-import { PageNotFoundSection } from "./PageNotFoundSection";
-import { RealmRolesSection } from "./realm-roles/RealmRolesSection";
-import { RealmSettingsSection } from "./realm-settings/RealmSettingsSection";
-import { NewRealmForm } from "./realm/add/NewRealmForm";
-import { SessionsSection } from "./sessions/SessionsSection";
-import { UserFederationSection } from "./user-federation/UserFederationSection";
-import { UsersSection } from "./user/UsersSection";
-import { MappingDetails } from "./client-scopes/details/MappingDetails";
-import { ClientDetails } from "./clients/ClientDetails";
-import { UsersTabs } from "./user/UsersTabs";
-import { UserGroups } from "./user/UserGroups";
-import { UserFederationKerberosSettings } from "./user-federation/UserFederationKerberosSettings";
-import { UserFederationLdapSettings } from "./user-federation/UserFederationLdapSettings";
 import { RoleMappingForm } from "./client-scopes/add/RoleMappingForm";
-import { RealmRoleTabs } from "./realm-roles/RealmRoleTabs";
-import { SearchGroups } from "./groups/SearchGroups";
-import { CreateInitialAccessToken } from "./clients/initial-access/CreateInitialAccessToken";
-import { LdapMapperDetails } from "./user-federation/ldap/mappers/LdapMapperDetails";
-import {
-  AddIdentityProvider,
-  IdentityProviderCrumb,
-} from "./identity-providers/add/AddIdentityProvider";
-import { AddOpenIdConnect } from "./identity-providers/add/AddOpenIdConnect";
-import { DetailSettings } from "./identity-providers/add/DetailSettings";
+import { DashboardSection } from "./dashboard/Dashboard";
+import { PageNotFoundSection } from "./PageNotFoundSection";
 import { AESGeneratedSettings } from "./realm-settings/key-providers/aes-generated/AESGeneratedForm";
+import { ECDSAGeneratedSettings } from "./realm-settings/key-providers/ecdsa-generated/ECDSAGeneratedForm";
 import { HMACGeneratedSettings } from "./realm-settings/key-providers/hmac-generated/HMACGeneratedForm";
 import { RSAGeneratedSettings } from "./realm-settings/key-providers/rsa-generated/RSAGeneratedForm";
-import { ECDSAGeneratedSettings } from "./realm-settings/key-providers/ecdsa-generated/ECDSAGeneratedForm";
 import { RSASettings } from "./realm-settings/key-providers/rsa/RSAForm";
+import { LdapMapperDetails } from "./user-federation/ldap/mappers/LdapMapperDetails";
+import { UserFederationKerberosSettings } from "./user-federation/UserFederationKerberosSettings";
+import { UserFederationLdapSettings } from "./user-federation/UserFederationLdapSettings";
+import { UsersTabs } from "./user/UsersTabs";
 
 export type RouteDef = BreadcrumbsRoute & {
   access: AccessType;
@@ -51,142 +24,16 @@ type RoutesFn = (t: TFunction) => RouteDef[];
 
 export const routes: RoutesFn = (t: TFunction) => [
   {
-    path: "/:realm/add-realm",
-    component: NewRealmForm,
-    breadcrumb: t("realm:createRealm"),
-    access: "manage-realm",
-  },
-  {
-    path: "/:realm/clients/add-client",
-    component: NewClientForm,
-    breadcrumb: t("clients:createClient"),
-    access: "manage-clients",
-  },
-  {
-    path: "/:realm/clients/import-client",
-    component: ImportForm,
-    breadcrumb: t("clients:importClient"),
-    access: "manage-clients",
-  },
-  {
-    path: "/:realm/clients/:tab?",
-    component: ClientsSection,
-    breadcrumb: t("clients:clientList"),
-    access: "query-clients",
-  },
-  {
-    path: "/:realm/clients/initialAccessToken/create",
-    component: CreateInitialAccessToken,
-    breadcrumb: t("clients:createToken"),
-    access: "manage-clients",
-  },
-  {
-    path: "/:realm/clients/:clientId/roles/add-role",
-    component: RealmRoleTabs,
-    breadcrumb: t("roles:createRole"),
-    access: "manage-realm",
-  },
-  {
-    path: "/:realm/clients/:clientId/roles/:id/:tab?",
-    component: RealmRoleTabs,
-    breadcrumb: t("roles:roleDetails"),
-    access: "view-realm",
-  },
-  {
-    path: "/:realm/clients/:clientId/:tab",
-    component: ClientDetails,
-    breadcrumb: t("clients:clientSettings"),
-    access: "view-clients",
-  },
-  {
-    path: "/:realm/client-scopes/new",
-    component: ClientScopeForm,
-    breadcrumb: t("client-scopes:createClientScope"),
-    access: "manage-clients",
-  },
-  {
     path: "/:realm/client-scopes/:id/mappers/oidc-role-name-mapper",
     component: RoleMappingForm,
     breadcrumb: t("common:mappingDetails"),
     access: "view-clients",
   },
   {
-    path: "/:realm/client-scopes/:id/mappers/:mapperId",
-    component: MappingDetails,
-    breadcrumb: t("common:mappingDetails"),
-    access: "view-clients",
-  },
-  {
-    path: "/:realm/client-scopes/:id/:type/:tab",
-    component: ClientScopeForm,
-    breadcrumb: t("client-scopes:clientScopeDetails"),
-    access: "view-clients",
-  },
-  {
-    path: "/:realm/client-scopes",
-    component: ClientScopesSection,
-    breadcrumb: t("client-scopes:clientScopeList"),
-    access: "view-clients",
-  },
-  {
-    path: "/:realm/roles",
-    component: RealmRolesSection,
-    breadcrumb: t("roles:roleList"),
-    access: "view-realm",
-  },
-  {
-    path: "/:realm/roles/add-role",
-    component: RealmRoleTabs,
-    breadcrumb: t("roles:createRole"),
-    access: "manage-realm",
-  },
-  {
-    path: "/:realm/roles/:id/:tab?",
-    component: RealmRoleTabs,
-    breadcrumb: t("roles:roleDetails"),
-    access: "view-realm",
-  },
-  {
-    path: "/:realm/users",
-    component: UsersSection,
-    breadcrumb: t("users:title"),
-    access: "query-users",
-  },
-  {
-    path: "/:realm/users/add-user",
-    component: UsersTabs,
-    breadcrumb: t("users:createUser"),
-    access: "manage-users",
-  },
-  {
-    path: "/:realm/users/:id",
-    component: UserGroups,
-    breadcrumb: t("users:userDetails"),
-    access: "manage-users",
-  },
-  {
     path: "/:realm/users/:id/:tab",
     component: UsersTabs,
     breadcrumb: t("users:userDetails"),
     access: "manage-users",
-  },
-  {
-    path: "/:realm/sessions",
-    component: SessionsSection,
-    breadcrumb: t("sessions:title"),
-    access: "view-realm",
-  },
-  {
-    path: "/:realm/events/:tab?",
-    component: EventsSection,
-    breadcrumb: t("events:title"),
-    access: "view-events",
-  },
-  {
-    path: "/:realm/realm-settings/:tab?",
-    component: RealmSettingsSection,
-    breadcrumb: t("realmSettings"),
-    access: "view-realm",
   },
   {
     path: "/:realm/realm-settings/keys/:id?/aes-generated/settings",
@@ -225,63 +72,9 @@ export const routes: RoutesFn = (t: TFunction) => [
     access: "view-realm",
   },
   {
-    path: "/:realm/identity-providers",
-    component: IdentityProvidersSection,
-    breadcrumb: t("identityProviders"),
-    access: "view-identity-providers",
-  },
-  {
-    path: "/:realm/identity-providers/oidc",
-    component: AddOpenIdConnect,
-    breadcrumb: t("identity-providers:addOpenIdProvider"),
-    access: "manage-identity-providers",
-  },
-  {
-    path: "/:realm/identity-providers/keycloak-oidc",
-    component: AddOpenIdConnect,
-    breadcrumb: t("identity-providers:addKeycloakOpenIdProvider"),
-    access: "manage-identity-providers",
-  },
-  {
-    path: "/:realm/identity-providers/:id",
-    component: AddIdentityProvider,
-    breadcrumb: IdentityProviderCrumb,
-    access: "manage-identity-providers",
-  },
-  {
-    path: "/:realm/identity-providers/:id/:tab?",
-    component: DetailSettings,
-    breadcrumb: null,
-    access: "manage-identity-providers",
-  },
-  {
-    path: "/:realm/user-federation",
-    component: UserFederationSection,
-    breadcrumb: t("userFederation"),
-    access: "view-realm",
-  },
-  {
-    path: "/:realm/user-federation/kerberos",
-    component: UserFederationSection,
-    breadcrumb: null,
-    access: "view-realm",
-  },
-  {
-    path: "/:realm/user-federation/kerberos/:id",
-    component: UserFederationKerberosSettings,
-    breadcrumb: t("common:settings"),
-    access: "view-realm",
-  },
-  {
     path: "/:realm/user-federation/kerberos/new",
     component: UserFederationKerberosSettings,
     breadcrumb: t("common:settings"),
-    access: "view-realm",
-  },
-  {
-    path: "/:realm/user-federation/ldap",
-    component: UserFederationSection,
-    breadcrumb: null,
     access: "view-realm",
   },
   {
@@ -301,27 +94,6 @@ export const routes: RoutesFn = (t: TFunction) => [
     component: LdapMapperDetails,
     breadcrumb: t("common:mappingDetails"),
     access: "view-realm",
-  },
-  {
-    path: "/:realm/",
-    component: DashboardSection,
-    breadcrumb: t("common:home"),
-    access: "anyone",
-  },
-  {
-    path: "/:realm/groups/search",
-    component: SearchGroups,
-    breadcrumb: t("groups:searchGroups"),
-    access: "query-groups",
-  },
-  {
-    path: "/:realm/groups",
-    component: GroupsSection,
-    breadcrumb: null,
-    matchOptions: {
-      exact: false,
-    },
-    access: "query-groups",
   },
   {
     path: "/",

--- a/src/routes/AddClient.ts
+++ b/src/routes/AddClient.ts
@@ -1,0 +1,20 @@
+import type { LocationDescriptorObject } from "history";
+import { generatePath } from "react-router-dom";
+import type { RouteConfig } from ".";
+import { NewClientForm } from "../clients/add/NewClientForm";
+import type { HomeParams } from "./Home";
+
+export type AddClientParams = HomeParams;
+
+export const AddClientRoute: RouteConfig = {
+  path: "/:realm/clients/add-client",
+  component: NewClientForm,
+  breadcrumb: (t) => t("clients:createClient"),
+  access: "manage-clients",
+};
+
+export const toAddClient = (
+  params: AddClientParams
+): LocationDescriptorObject => ({
+  pathname: generatePath(AddClientRoute.path, params),
+});

--- a/src/routes/AddIdentityProvider.ts
+++ b/src/routes/AddIdentityProvider.ts
@@ -1,0 +1,25 @@
+import type { LocationDescriptorObject } from "history";
+import { generatePath } from "react-router-dom";
+import type { RouteConfig } from ".";
+import {
+  AddIdentityProvider,
+  IdentityProviderCrumb,
+} from "../identity-providers/add/AddIdentityProvider";
+import type { HomeParams } from "./Home";
+
+export type AddIdentityProviderParams = HomeParams & {
+  id: string;
+};
+
+export const AddIdentityProviderRoute: RouteConfig = {
+  path: "/:realm/identity-providers/:id",
+  component: AddIdentityProvider,
+  breadcrumb: IdentityProviderCrumb,
+  access: "manage-identity-providers",
+};
+
+export const toAddIdentityProvider = (
+  params: AddIdentityProviderParams
+): LocationDescriptorObject => ({
+  pathname: generatePath(AddIdentityProviderRoute.path, params),
+});

--- a/src/routes/AddKeycloakOpenIdProvider.ts
+++ b/src/routes/AddKeycloakOpenIdProvider.ts
@@ -1,0 +1,20 @@
+import type { LocationDescriptorObject } from "history";
+import { generatePath } from "react-router-dom";
+import type { RouteConfig } from ".";
+import { AddOpenIdConnect } from "../identity-providers/add/AddOpenIdConnect";
+import type { HomeParams } from "./Home";
+
+export type AddKeycloakOpenIdProviderParams = HomeParams;
+
+export const AddKeycloakOpenIdProviderRoute: RouteConfig = {
+  path: "/:realm/identity-providers/keycloak-oidc",
+  component: AddOpenIdConnect,
+  breadcrumb: (t) => t("identity-providers:addKeycloakOpenIdProvider"),
+  access: "manage-identity-providers",
+};
+
+export const toAddKeycloakOpenIdProvider = (
+  params: AddKeycloakOpenIdProviderParams
+): LocationDescriptorObject => ({
+  pathname: generatePath(AddKeycloakOpenIdProviderRoute.path, params),
+});

--- a/src/routes/AddOpenIdProvider.ts
+++ b/src/routes/AddOpenIdProvider.ts
@@ -1,0 +1,20 @@
+import type { LocationDescriptorObject } from "history";
+import { generatePath } from "react-router-dom";
+import type { RouteConfig } from ".";
+import { AddOpenIdConnect } from "../identity-providers/add/AddOpenIdConnect";
+import type { HomeParams } from "./Home";
+
+export type AddOpenIdProviderParams = HomeParams;
+
+export const AddOpenIdProviderRoute: RouteConfig = {
+  path: "/:realm/identity-providers/oidc",
+  component: AddOpenIdConnect,
+  breadcrumb: (t) => t("identity-providers:addOpenIdProvider"),
+  access: "manage-identity-providers",
+};
+
+export const toAddOpenIdProvider = (
+  params: AddOpenIdProviderParams
+): LocationDescriptorObject => ({
+  pathname: generatePath(AddOpenIdProviderRoute.path, params),
+});

--- a/src/routes/AddRealm.ts
+++ b/src/routes/AddRealm.ts
@@ -1,0 +1,20 @@
+import type { LocationDescriptorObject } from "history";
+import { generatePath } from "react-router-dom";
+import type { RouteConfig } from ".";
+import { NewRealmForm } from "../realm/add/NewRealmForm";
+import type { HomeParams } from "./Home";
+
+export type AddRealmParams = HomeParams;
+
+export const AddRealmRoute: RouteConfig = {
+  path: "/:realm/add-realm",
+  component: NewRealmForm,
+  breadcrumb: (t) => t("realm:createRealm"),
+  access: "manage-realm",
+};
+
+export const toAddRealm = (
+  params: AddRealmParams
+): LocationDescriptorObject => ({
+  pathname: generatePath(AddRealmRoute.path, params),
+});

--- a/src/routes/AddRole.ts
+++ b/src/routes/AddRole.ts
@@ -1,0 +1,18 @@
+import type { LocationDescriptorObject } from "history";
+import { generatePath } from "react-router-dom";
+import type { RouteConfig } from ".";
+import { RealmRoleTabs } from "../realm-roles/RealmRoleTabs";
+import type { HomeParams } from "./Home";
+
+export type AddRoleParams = HomeParams;
+
+export const AddRoleRoute: RouteConfig = {
+  path: "/:realm/roles/add-role",
+  component: RealmRoleTabs,
+  breadcrumb: (t) => t("roles:createRole"),
+  access: "manage-realm",
+};
+
+export const toAddRole = (params: AddRoleParams): LocationDescriptorObject => ({
+  pathname: generatePath(AddRoleRoute.path, params),
+});

--- a/src/routes/AddRoleToClient.ts
+++ b/src/routes/AddRoleToClient.ts
@@ -1,0 +1,22 @@
+import type { LocationDescriptorObject } from "history";
+import { generatePath } from "react-router-dom";
+import type { RouteConfig } from ".";
+import { RealmRoleTabs } from "../realm-roles/RealmRoleTabs";
+import type { HomeParams } from "./Home";
+
+export type AddRoleToClientParams = HomeParams & {
+  clientId: string;
+};
+
+export const AddRoleToClientRoute: RouteConfig = {
+  path: "/:realm/clients/:clientId/roles/add-role",
+  component: RealmRoleTabs,
+  breadcrumb: (t) => t("roles:createRole"),
+  access: "manage-realm",
+};
+
+export const toAddRoleToClient = (
+  params: AddRoleToClientParams
+): LocationDescriptorObject => ({
+  pathname: generatePath(AddRoleToClientRoute.path, params),
+});

--- a/src/routes/AddUser.ts
+++ b/src/routes/AddUser.ts
@@ -1,0 +1,18 @@
+import type { LocationDescriptorObject } from "history";
+import { generatePath } from "react-router-dom";
+import type { RouteConfig } from ".";
+import { UsersTabs } from "../user/UsersTabs";
+import type { HomeParams } from "./Home";
+
+export type AddUserParams = HomeParams;
+
+export const AddUserRoute: RouteConfig = {
+  path: "/:realm/users/add-user",
+  component: UsersTabs,
+  breadcrumb: (t) => t("users:createUser"),
+  access: "manage-users",
+};
+
+export const toAddUser = (params: AddUserParams): LocationDescriptorObject => ({
+  pathname: generatePath(AddUserRoute.path, params),
+});

--- a/src/routes/Client.ts
+++ b/src/routes/Client.ts
@@ -1,0 +1,21 @@
+import type { LocationDescriptorObject } from "history";
+import { generatePath } from "react-router-dom";
+import type { RouteConfig } from ".";
+import { ClientDetails } from "../clients/ClientDetails";
+import type { HomeParams } from "./Home";
+
+export type ClientParams = HomeParams & {
+  clientId: string;
+  tab: string;
+};
+
+export const ClientRoute: RouteConfig = {
+  path: "/:realm/clients/:clientId/:tab",
+  component: ClientDetails,
+  breadcrumb: (t) => t("clients:clientSettings"),
+  access: "view-clients",
+};
+
+export const toClient = (params: ClientParams): LocationDescriptorObject => ({
+  pathname: generatePath(ClientRoute.path, params),
+});

--- a/src/routes/ClientRole.ts
+++ b/src/routes/ClientRole.ts
@@ -1,0 +1,24 @@
+import type { LocationDescriptorObject } from "history";
+import { generatePath } from "react-router-dom";
+import type { RouteConfig } from ".";
+import { RealmRoleTabs } from "../realm-roles/RealmRoleTabs";
+import type { HomeParams } from "./Home";
+
+export type ClientRoleParams = HomeParams & {
+  clientId: string;
+  id: string;
+  tab?: string;
+};
+
+export const ClientRoleRoute: RouteConfig = {
+  path: "/:realm/clients/:clientId/roles/:id/:tab?",
+  component: RealmRoleTabs,
+  breadcrumb: (t) => t("roles:roleDetails"),
+  access: "view-realm",
+};
+
+export const toClientRole = (
+  params: ClientRoleParams
+): LocationDescriptorObject => ({
+  pathname: generatePath(ClientRoleRoute.path, params),
+});

--- a/src/routes/ClientScope.ts
+++ b/src/routes/ClientScope.ts
@@ -1,0 +1,24 @@
+import type { LocationDescriptorObject } from "history";
+import { generatePath } from "react-router-dom";
+import type { RouteConfig } from ".";
+import { ClientScopeForm } from "../client-scopes/form/ClientScopeForm";
+import type { HomeParams } from "./Home";
+
+export type ClientScopeParams = HomeParams & {
+  id: string;
+  type: string;
+  tab: string;
+};
+
+export const ClientScopeRoute: RouteConfig = {
+  path: "/:realm/client-scopes/:id/:type/:tab",
+  component: ClientScopeForm,
+  breadcrumb: (t) => t("client-scopes:clientScopeDetails"),
+  access: "view-clients",
+};
+
+export const toClientScope = (
+  params: ClientScopeParams
+): LocationDescriptorObject => ({
+  pathname: generatePath(ClientScopeRoute.path, params),
+});

--- a/src/routes/ClientScopeMapper.ts
+++ b/src/routes/ClientScopeMapper.ts
@@ -1,0 +1,23 @@
+import type { LocationDescriptorObject } from "history";
+import { generatePath } from "react-router-dom";
+import type { RouteConfig } from ".";
+import { MappingDetails } from "../client-scopes/details/MappingDetails";
+import type { HomeParams } from "./Home";
+
+export type ClientScopeMapperParams = HomeParams & {
+  id: string;
+  mapperId: string;
+};
+
+export const ClientScopeMapperRoute: RouteConfig = {
+  path: "/:realm/client-scopes/:id/mappers/:mapperId",
+  component: MappingDetails,
+  breadcrumb: (t) => t("common:mappingDetails"),
+  access: "view-clients",
+};
+
+export const toClientScopeMapper = (
+  params: ClientScopeMapperParams
+): LocationDescriptorObject => ({
+  pathname: generatePath(ClientScopeMapperRoute.path, params),
+});

--- a/src/routes/ClientScopes.ts
+++ b/src/routes/ClientScopes.ts
@@ -1,0 +1,20 @@
+import type { LocationDescriptorObject } from "history";
+import { generatePath } from "react-router-dom";
+import type { RouteConfig } from ".";
+import { ClientScopesSection } from "../client-scopes/ClientScopesSection";
+import type { HomeParams } from "./Home";
+
+export type ClientScopesParams = HomeParams;
+
+export const ClientScopesRoute: RouteConfig = {
+  path: "/:realm/client-scopes",
+  component: ClientScopesSection,
+  breadcrumb: (t) => t("client-scopes:clientScopeList"),
+  access: "view-clients",
+};
+
+export const toClientScopes = (
+  params: ClientScopesParams
+): LocationDescriptorObject => ({
+  pathname: generatePath(ClientScopesRoute.path, params),
+});

--- a/src/routes/Clients.ts
+++ b/src/routes/Clients.ts
@@ -1,0 +1,20 @@
+import type { LocationDescriptorObject } from "history";
+import { generatePath } from "react-router-dom";
+import type { RouteConfig } from ".";
+import { ClientsSection } from "../clients/ClientsSection";
+import type { HomeParams } from "./Home";
+
+export type ClientsParams = HomeParams & {
+  tab?: string;
+};
+
+export const ClientsRoute: RouteConfig = {
+  path: "/:realm/clients/:tab?",
+  component: ClientsSection,
+  breadcrumb: (t) => t("clients:clientList"),
+  access: "query-clients",
+};
+
+export const toClients = (params: ClientsParams): LocationDescriptorObject => ({
+  pathname: generatePath(ClientsRoute.path, params),
+});

--- a/src/routes/CreateInitialAccessToken.ts
+++ b/src/routes/CreateInitialAccessToken.ts
@@ -1,0 +1,20 @@
+import type { LocationDescriptorObject } from "history";
+import { generatePath } from "react-router-dom";
+import type { RouteConfig } from ".";
+import { CreateInitialAccessToken } from "../clients/initial-access/CreateInitialAccessToken";
+import type { HomeParams } from "./Home";
+
+export type CreateInitialAccessTokenParams = HomeParams;
+
+export const CreateInitialAccessTokenRoute: RouteConfig = {
+  path: "/:realm/clients/initialAccessToken/create",
+  component: CreateInitialAccessToken,
+  breadcrumb: (t) => t("clients:createToken"),
+  access: "manage-clients",
+};
+
+export const toCreateInitialAccessToken = (
+  params: CreateInitialAccessTokenParams
+): LocationDescriptorObject => ({
+  pathname: generatePath(CreateInitialAccessTokenRoute.path, params),
+});

--- a/src/routes/Events.ts
+++ b/src/routes/Events.ts
@@ -1,0 +1,20 @@
+import type { LocationDescriptorObject } from "history";
+import { generatePath } from "react-router-dom";
+import type { RouteConfig } from ".";
+import { EventsSection } from "../events/EventsSection";
+import type { HomeParams } from "./Home";
+
+export type EventsParams = HomeParams & {
+  tab?: string;
+};
+
+export const EventsRoute: RouteConfig = {
+  path: "/:realm/events/:tab?",
+  component: EventsSection,
+  breadcrumb: (t) => t("events:title"),
+  access: "view-events",
+};
+
+export const toEvents = (params: EventsParams): LocationDescriptorObject => ({
+  pathname: generatePath(EventsRoute.path, params),
+});

--- a/src/routes/Groups.ts
+++ b/src/routes/Groups.ts
@@ -1,0 +1,19 @@
+import type { LocationDescriptorObject } from "history";
+import { generatePath } from "react-router-dom";
+import type { RouteConfig } from ".";
+import { GroupsSection } from "../groups/GroupsSection";
+import type { HomeParams } from "./Home";
+
+export type GroupsParams = HomeParams;
+
+export const GroupsRoute: RouteConfig = {
+  path: "/:realm/groups",
+  component: GroupsSection,
+  breadcrumb: null,
+  access: "query-groups",
+  exact: false,
+};
+
+export const toGroups = (params: GroupsParams): LocationDescriptorObject => ({
+  pathname: generatePath(GroupsRoute.path, params),
+});

--- a/src/routes/Home.ts
+++ b/src/routes/Home.ts
@@ -1,0 +1,19 @@
+import type { LocationDescriptorObject } from "history";
+import { generatePath } from "react-router-dom";
+import type { RouteConfig } from ".";
+import { DashboardSection } from "../dashboard/Dashboard";
+
+export type HomeParams = {
+  realm: string;
+};
+
+export const HomeRoute: RouteConfig = {
+  path: "/:realm/",
+  component: DashboardSection,
+  breadcrumb: (t) => t("common:home"),
+  access: "anyone",
+};
+
+export const toHome = (params: HomeParams): LocationDescriptorObject => ({
+  pathname: generatePath(HomeRoute.path, params),
+});

--- a/src/routes/IdentityProvider.ts
+++ b/src/routes/IdentityProvider.ts
@@ -1,0 +1,23 @@
+import type { LocationDescriptorObject } from "history";
+import { generatePath } from "react-router-dom";
+import type { RouteConfig } from ".";
+import { DetailSettings } from "../identity-providers/add/DetailSettings";
+import type { HomeParams } from "./Home";
+
+export type IdentityProviderParams = HomeParams & {
+  id: string;
+  tab?: string;
+};
+
+export const IdentityProviderRoute: RouteConfig = {
+  path: "/:realm/identity-providers/:id/:tab?",
+  component: DetailSettings,
+  breadcrumb: null,
+  access: "manage-identity-providers",
+};
+
+export const toIdentityProvider = (
+  params: IdentityProviderParams
+): LocationDescriptorObject => ({
+  pathname: generatePath(IdentityProviderRoute.path, params),
+});

--- a/src/routes/IdentityProviders.ts
+++ b/src/routes/IdentityProviders.ts
@@ -1,0 +1,20 @@
+import type { LocationDescriptorObject } from "history";
+import { generatePath } from "react-router-dom";
+import type { RouteConfig } from ".";
+import { IdentityProvidersSection } from "../identity-providers/IdentityProvidersSection";
+import type { HomeParams } from "./Home";
+
+export type IdentityProvidersParams = HomeParams;
+
+export const IdentityProvidersRoute: RouteConfig = {
+  path: "/:realm/identity-providers",
+  component: IdentityProvidersSection,
+  breadcrumb: (t) => t("identityProviders"),
+  access: "view-identity-providers",
+};
+
+export const toIdentityProviders = (
+  params: IdentityProvidersParams
+): LocationDescriptorObject => ({
+  pathname: generatePath(IdentityProvidersRoute.path, params),
+});

--- a/src/routes/ImportClient.ts
+++ b/src/routes/ImportClient.ts
@@ -1,0 +1,20 @@
+import type { LocationDescriptorObject } from "history";
+import { generatePath } from "react-router-dom";
+import type { RouteConfig } from ".";
+import { ImportForm } from "../clients/import/ImportForm";
+import type { HomeParams } from "./Home";
+
+export type ImportClientParams = HomeParams;
+
+export const ImportClientRoute: RouteConfig = {
+  path: "/:realm/clients/import-client",
+  component: ImportForm,
+  breadcrumb: (t) => t("clients:importClient"),
+  access: "manage-clients",
+};
+
+export const toImportClient = (
+  params: ImportClientParams
+): LocationDescriptorObject => ({
+  pathname: generatePath(ImportClientRoute.path, params),
+});

--- a/src/routes/NewClientScope.ts
+++ b/src/routes/NewClientScope.ts
@@ -1,0 +1,20 @@
+import type { LocationDescriptorObject } from "history";
+import { generatePath } from "react-router-dom";
+import type { RouteConfig } from ".";
+import { ClientScopeForm } from "../client-scopes/form/ClientScopeForm";
+import type { HomeParams } from "./Home";
+
+export type NewClientScopeParams = HomeParams;
+
+export const NewClientScopeRoute: RouteConfig = {
+  path: "/:realm/client-scopes/new",
+  component: ClientScopeForm,
+  breadcrumb: (t) => t("client-scopes:createClientScope"),
+  access: "manage-clients",
+};
+
+export const toNewClientScope = (
+  params: NewClientScopeParams
+): LocationDescriptorObject => ({
+  pathname: generatePath(NewClientScopeRoute.path, params),
+});

--- a/src/routes/RealmSettings.ts
+++ b/src/routes/RealmSettings.ts
@@ -1,0 +1,22 @@
+import type { LocationDescriptorObject } from "history";
+import { generatePath } from "react-router-dom";
+import type { RouteConfig } from ".";
+import { RealmSettingsSection } from "../realm-settings/RealmSettingsSection";
+import type { HomeParams } from "./Home";
+
+export type RealmSettingsParams = HomeParams & {
+  tab?: string;
+};
+
+export const RealmSettingsRoute: RouteConfig = {
+  path: "/:realm/realm-settings/:tab?",
+  component: RealmSettingsSection,
+  breadcrumb: (t) => t("realmSettings"),
+  access: "view-realm",
+};
+
+export const toRealmSettings = (
+  params: RealmSettingsParams
+): LocationDescriptorObject => ({
+  pathname: generatePath(RealmSettingsRoute.path, params),
+});

--- a/src/routes/Role.ts
+++ b/src/routes/Role.ts
@@ -1,0 +1,21 @@
+import type { LocationDescriptorObject } from "history";
+import { generatePath } from "react-router-dom";
+import type { RouteConfig } from ".";
+import { RealmRoleTabs } from "../realm-roles/RealmRoleTabs";
+import type { HomeParams } from "./Home";
+
+export type RoleParams = HomeParams & {
+  id: string;
+  tab?: string;
+};
+
+export const RoleRoute: RouteConfig = {
+  path: "/:realm/roles/:id/:tab?",
+  component: RealmRoleTabs,
+  breadcrumb: (t) => t("roles:roleDetails"),
+  access: "view-realm",
+};
+
+export const toRole = (params: RoleParams): LocationDescriptorObject => ({
+  pathname: generatePath(RoleRoute.path, params),
+});

--- a/src/routes/Roles.ts
+++ b/src/routes/Roles.ts
@@ -1,0 +1,18 @@
+import type { LocationDescriptorObject } from "history";
+import { generatePath } from "react-router-dom";
+import type { RouteConfig } from ".";
+import { RealmRolesSection } from "../realm-roles/RealmRolesSection";
+import type { HomeParams } from "./Home";
+
+export type RolesParams = HomeParams;
+
+export const RolesRoute: RouteConfig = {
+  path: "/:realm/roles",
+  component: RealmRolesSection,
+  breadcrumb: (t) => t("roles:roleList"),
+  access: "view-realm",
+};
+
+export const toRoles = (params: RolesParams): LocationDescriptorObject => ({
+  pathname: generatePath(RolesRoute.path, params),
+});

--- a/src/routes/SearchGroups.ts
+++ b/src/routes/SearchGroups.ts
@@ -1,0 +1,20 @@
+import type { LocationDescriptorObject } from "history";
+import { generatePath } from "react-router-dom";
+import type { RouteConfig } from ".";
+import { SearchGroups } from "../groups/SearchGroups";
+import type { HomeParams } from "./Home";
+
+export type SearchGroupsParams = HomeParams;
+
+export const SearchGroupsRoute: RouteConfig = {
+  path: "/:realm/groups/search",
+  component: SearchGroups,
+  breadcrumb: (t) => t("groups:searchGroups"),
+  access: "query-groups",
+};
+
+export const toSearchGroups = (
+  params: SearchGroupsParams
+): LocationDescriptorObject => ({
+  pathname: generatePath(SearchGroupsRoute.path, params),
+});

--- a/src/routes/Sessions.ts
+++ b/src/routes/Sessions.ts
@@ -1,0 +1,20 @@
+import type { LocationDescriptorObject } from "history";
+import { generatePath } from "react-router-dom";
+import type { RouteConfig } from ".";
+import { SessionsSection } from "../sessions/SessionsSection";
+import type { HomeParams } from "./Home";
+
+export type SessionsParams = HomeParams;
+
+export const SessionsRoute: RouteConfig = {
+  path: "/:realm/sessions",
+  component: SessionsSection,
+  breadcrumb: (t) => t("sessions:title"),
+  access: "view-realm",
+};
+
+export const toSessions = (
+  params: SessionsParams
+): LocationDescriptorObject => ({
+  pathname: generatePath(SessionsRoute.path, params),
+});

--- a/src/routes/User.ts
+++ b/src/routes/User.ts
@@ -1,0 +1,20 @@
+import type { LocationDescriptorObject } from "history";
+import { generatePath } from "react-router-dom";
+import type { RouteConfig } from ".";
+import { UserGroups } from "../user/UserGroups";
+import type { HomeParams } from "./Home";
+
+export type UserParams = HomeParams & {
+  id: string;
+};
+
+export const UserRoute: RouteConfig = {
+  path: "/:realm/users/:id",
+  component: UserGroups,
+  breadcrumb: (t) => t("users:userDetails"),
+  access: "manage-users",
+};
+
+export const toUser = (params: UserParams): LocationDescriptorObject => ({
+  pathname: generatePath(UserRoute.path, params),
+});

--- a/src/routes/UserFederation.ts
+++ b/src/routes/UserFederation.ts
@@ -1,0 +1,20 @@
+import type { LocationDescriptorObject } from "history";
+import { generatePath } from "react-router-dom";
+import type { RouteConfig } from ".";
+import { UserFederationSection } from "../user-federation/UserFederationSection";
+import type { HomeParams } from "./Home";
+
+export type UserFederationParams = HomeParams;
+
+export const UserFederationRoute: RouteConfig = {
+  path: "/:realm/user-federation",
+  component: UserFederationSection,
+  breadcrumb: (t) => t("userFederation"),
+  access: "view-realm",
+};
+
+export const toUserFederation = (
+  params: UserFederationParams
+): LocationDescriptorObject => ({
+  pathname: generatePath(UserFederationRoute.path, params),
+});

--- a/src/routes/UserFederationKerberos.ts
+++ b/src/routes/UserFederationKerberos.ts
@@ -1,0 +1,22 @@
+import type { LocationDescriptorObject } from "history";
+import { generatePath } from "react-router-dom";
+import type { RouteConfig } from ".";
+import { UserFederationKerberosSettings } from "../user-federation/UserFederationKerberosSettings";
+import type { HomeParams } from "./Home";
+
+export type UserFederationKerberosParams = HomeParams & {
+  id: string;
+};
+
+export const UserFederationKerberosRoute: RouteConfig = {
+  path: "/:realm/user-federation/kerberos/:id",
+  component: UserFederationKerberosSettings,
+  breadcrumb: (t) => t("common:settings"),
+  access: "view-realm",
+};
+
+export const toUserFederationKerberos = (
+  params: UserFederationKerberosParams
+): LocationDescriptorObject => ({
+  pathname: generatePath(UserFederationKerberosRoute.path, params),
+});

--- a/src/routes/UserFederationLdap.ts
+++ b/src/routes/UserFederationLdap.ts
@@ -1,0 +1,20 @@
+import type { LocationDescriptorObject } from "history";
+import { generatePath } from "react-router-dom";
+import type { RouteConfig } from ".";
+import { UserFederationSection } from "../user-federation/UserFederationSection";
+import type { HomeParams } from "./Home";
+
+export type UserFederationLdapParams = HomeParams;
+
+export const UserFederationLdapRoute: RouteConfig = {
+  path: "/:realm/user-federation/ldap",
+  component: UserFederationSection,
+  breadcrumb: null,
+  access: "view-realm",
+};
+
+export const toUserFederationLdap = (
+  params: UserFederationLdapParams
+): LocationDescriptorObject => ({
+  pathname: generatePath(UserFederationLdapRoute.path, params),
+});

--- a/src/routes/UserFederationsKerberos.ts
+++ b/src/routes/UserFederationsKerberos.ts
@@ -1,0 +1,20 @@
+import type { LocationDescriptorObject } from "history";
+import { generatePath } from "react-router-dom";
+import type { RouteConfig } from ".";
+import { UserFederationSection } from "../user-federation/UserFederationSection";
+import type { HomeParams } from "./Home";
+
+export type UserFederationsKerberosParams = HomeParams;
+
+export const UserFederationsKerberosRoute: RouteConfig = {
+  path: "/:realm/user-federation/kerberos",
+  component: UserFederationSection,
+  breadcrumb: null,
+  access: "view-realm",
+};
+
+export const toUserFederationsKerberos = (
+  params: UserFederationsKerberosParams
+): LocationDescriptorObject => ({
+  pathname: generatePath(UserFederationsKerberosRoute.path, params),
+});

--- a/src/routes/Users.ts
+++ b/src/routes/Users.ts
@@ -1,0 +1,18 @@
+import type { LocationDescriptorObject } from "history";
+import { generatePath } from "react-router-dom";
+import type { RouteConfig } from ".";
+import { UsersSection } from "../user/UsersSection";
+import type { HomeParams } from "./Home";
+
+export type UsersParams = HomeParams;
+
+export const UsersRoute: RouteConfig = {
+  path: "/:realm/users",
+  component: UsersSection,
+  breadcrumb: (t) => t("users:title"),
+  access: "query-users",
+};
+
+export const toUsers = (params: UsersParams): LocationDescriptorObject => ({
+  pathname: generatePath(UsersRoute.path, params),
+});

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,0 +1,82 @@
+import type { TFunction } from "i18next";
+import type { AccessType } from "keycloak-admin/lib/defs/whoAmIRepresentation";
+import type { ComponentType } from "react";
+import { AddClientRoute } from "./AddClient";
+import { AddIdentityProviderRoute } from "./AddIdentityProvider";
+import { AddKeycloakOpenIdProviderRoute } from "./AddKeycloakOpenIdProvider";
+import { AddOpenIdProviderRoute } from "./AddOpenIdProvider";
+import { AddRealmRoute } from "./AddRealm";
+import { AddRoleRoute } from "./AddRole";
+import { AddRoleToClientRoute } from "./AddRoleToClient";
+import { AddUserRoute } from "./AddUser";
+import { ClientRoute } from "./Client";
+import { ClientRoleRoute } from "./ClientRole";
+import { ClientsRoute } from "./Clients";
+import { ClientScopeRoute } from "./ClientScope";
+import { ClientScopeMapperRoute } from "./ClientScopeMapper";
+import { ClientScopesRoute } from "./ClientScopes";
+import { CreateInitialAccessTokenRoute } from "./CreateInitialAccessToken";
+import { EventsRoute } from "./Events";
+import { GroupsRoute } from "./Groups";
+import { HomeRoute } from "./Home";
+import { IdentityProviderRoute } from "./IdentityProvider";
+import { IdentityProvidersRoute } from "./IdentityProviders";
+import { ImportClientRoute } from "./ImportClient";
+import { NewClientScopeRoute } from "./NewClientScope";
+import { RealmSettingsRoute } from "./RealmSettings";
+import { RoleRoute } from "./Role";
+import { RolesRoute } from "./Roles";
+import { SearchGroupsRoute } from "./SearchGroups";
+import { SessionsRoute } from "./Sessions";
+import { UserRoute } from "./User";
+import { UserFederationRoute } from "./UserFederation";
+import { UserFederationKerberosRoute } from "./UserFederationKerberos";
+import { UserFederationLdapRoute } from "./UserFederationLdap";
+import { UserFederationsKerberosRoute } from "./UserFederationsKerberos";
+import { UsersRoute } from "./Users";
+
+export type RouteConfig = {
+  path: string;
+  component: ComponentType;
+  breadcrumb: ((t: TFunction) => string) | null;
+  access: AccessType;
+  exact?: boolean;
+};
+
+const routes: RouteConfig[] = [
+  AddClientRoute,
+  AddIdentityProviderRoute,
+  AddKeycloakOpenIdProviderRoute,
+  AddOpenIdProviderRoute,
+  AddRealmRoute,
+  AddRoleRoute,
+  AddRoleToClientRoute,
+  AddUserRoute,
+  ClientRoute,
+  ClientRoleRoute,
+  ClientScopeRoute,
+  ClientScopeMapperRoute,
+  ClientScopesRoute,
+  ClientsRoute,
+  CreateInitialAccessTokenRoute,
+  EventsRoute,
+  GroupsRoute,
+  HomeRoute,
+  IdentityProviderRoute,
+  IdentityProvidersRoute,
+  ImportClientRoute,
+  NewClientScopeRoute,
+  RealmSettingsRoute,
+  RoleRoute,
+  RolesRoute,
+  SearchGroupsRoute,
+  SessionsRoute,
+  UserRoute,
+  UserFederationKerberosRoute,
+  UserFederationLdapRoute,
+  UserFederationRoute,
+  UserFederationsKerberosRoute,
+  UsersRoute,
+];
+
+export default routes;


### PR DESCRIPTION
## Motivation
Puts all route definitions and their respective types in a central location. This allows us to re-use these definitions in the application in a DRY manner, which will make the code more maintainable.

This is presented as as work-in-progress proposal, early feedback is appreciated.