### PR TITLE
Realm settings(keys): add updated breadcrumb for key providers

### DIFF
--- a/src/realm-settings/RealmSettingsSection.tsx
+++ b/src/realm-settings/RealmSettingsSection.tsx
@@ -4,6 +4,8 @@ import { useTranslation } from "react-i18next";
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import {
   AlertVariant,
+  Breadcrumb,
+  BreadcrumbItem,
   ButtonVariant,
   DropdownItem,
   DropdownSeparator,
@@ -42,6 +44,23 @@ type RealmSettingsHeaderProps = {
   value: boolean;
   save: () => void;
   realmName: string;
+};
+
+export const EditProviderCrumb = () => {
+  const { t } = useTranslation("realm-settings");
+  const { realm } = useRealm();
+
+  return (
+    <>
+      <Breadcrumb>
+        <BreadcrumbItem to={`#/${realm}/realm-settings/keys`}>
+          {t("keys")}
+        </BreadcrumbItem>
+        <BreadcrumbItem>{t("providers")}</BreadcrumbItem>
+        <BreadcrumbItem isActive>{t("editProvider")}</BreadcrumbItem>
+      </Breadcrumb>
+    </>
+  );
 };
 
 const RealmSettingsHeader = ({

--- a/src/route-config.ts
+++ b/src/route-config.ts
@@ -14,7 +14,10 @@ import { GroupsSection } from "./groups/GroupsSection";
 import { IdentityProvidersSection } from "./identity-providers/IdentityProvidersSection";
 import { PageNotFoundSection } from "./PageNotFoundSection";
 import { RealmRolesSection } from "./realm-roles/RealmRolesSection";
-import { RealmSettingsSection } from "./realm-settings/RealmSettingsSection";
+import {
+  EditProviderCrumb,
+  RealmSettingsSection,
+} from "./realm-settings/RealmSettingsSection";
 import { NewRealmForm } from "./realm/add/NewRealmForm";
 import { SessionsSection } from "./sessions/SessionsSection";
 import { UserFederationSection } from "./user-federation/UserFederationSection";
@@ -192,37 +195,37 @@ export const routes: RoutesFn = (t: TFunction) => [
   {
     path: "/:realm/realm-settings/keys/:id?/aes-generated/settings",
     component: AESGeneratedSettings,
-    breadcrumb: t("realm-settings:editProvider"),
+    breadcrumb: EditProviderCrumb,
     access: "view-realm",
   },
   {
     path: "/:realm/realm-settings/keys/:id?/ecdsa-generated/settings",
     component: ECDSAGeneratedSettings,
-    breadcrumb: t("realm-settings:editProvider"),
+    breadcrumb: EditProviderCrumb,
     access: "view-realm",
   },
   {
     path: "/:realm/realm-settings/keys/:id?/hmac-generated/settings",
     component: HMACGeneratedSettings,
-    breadcrumb: t("realm-settings:editProvider"),
+    breadcrumb: EditProviderCrumb,
     access: "view-realm",
   },
   {
     path: "/:realm/realm-settings/keys/:id?/java-keystore/settings",
     component: JavaKeystoreSettings,
-    breadcrumb: t("realm-settings:editProvider"),
+    breadcrumb: EditProviderCrumb,
     access: "view-realm",
   },
   {
     path: "/:realm/realm-settings/keys/:id?/rsa-generated/settings",
     component: RSAGeneratedSettings,
-    breadcrumb: t("realm-settings:editProvider"),
+    breadcrumb: EditProviderCrumb,
     access: "view-realm",
   },
   {
     path: "/:realm/realm-settings/keys/:id?/rsa/settings",
     component: RSASettings,
-    breadcrumb: t("realm-settings:editProvider"),
+    breadcrumb: EditProviderCrumb,
     access: "view-realm",
   },
   {


### PR DESCRIPTION
## Motivation
<!-- Add references to relevant tickets, issues, design specs and/or a short description of what motivated you to do it. -->
#832 

## Brief Description
<!-- Add a short answer for: 
What was done in this PR? (e.g Fix to prevent users from accessing feature X.)
Why it was done? (e.g Feature X was deprecated.)
-->

## Verification Steps
<!--
Add the steps required to verify this change. Keep in mind that these steps should be written so groups unfamiliar with the 
new functionality can follow them, such as QE or documentation.-->

1. Go to realm settings -> keys -> providers
2. Click on a provider or create a new one and then go to the provider details. 
3. Verify the breadcrumb now contains Realm settings > Keys > Providers > Edit provider

## Checklist:

- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [x] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [x] Unit tests have been created/updated

## Additional Notes
<!-- 
Add images and/or screen caps to illustrate what was changed if this pull request adds to or modifies existing user-visible appearance/output. 
-->
