### PR TITLE
Disable automatically generated breadcrumbs

### DIFF
--- a/src/components/bread-crumb/PageBreadCrumbs.tsx
+++ b/src/components/bread-crumb/PageBreadCrumbs.tsx
@@ -25,6 +25,7 @@ export const PageBreadCrumbs = () => {
 
   const crumbs = _.uniqBy(
     useBreadcrumbs(routesWithCrumbs, {
+      disableDefaults: true,
       excludePaths: ["/", `/${realm}`],
     }),
     elementText

--- a/src/route-config.ts
+++ b/src/route-config.ts
@@ -42,7 +42,7 @@ import { UsersTabs } from "./user/UsersTabs";
 export type RouteDef = {
   path: string;
   component: ComponentType;
-  breadcrumb: ((t: TFunction) => string | ComponentType<any>) | null;
+  breadcrumb?: (t: TFunction) => string | ComponentType<any>;
   access: AccessType;
   matchOptions?: MatchOptions;
 };
@@ -187,7 +187,6 @@ export const routes: RouteDef[] = [
   {
     path: "/:realm/identity-providers/:id/:tab?",
     component: DetailSettings,
-    breadcrumb: null,
     access: "manage-identity-providers",
   },
   {
@@ -199,7 +198,6 @@ export const routes: RouteDef[] = [
   {
     path: "/:realm/user-federation/kerberos",
     component: UserFederationSection,
-    breadcrumb: null,
     access: "view-realm",
   },
   {
@@ -217,7 +215,6 @@ export const routes: RouteDef[] = [
   {
     path: "/:realm/user-federation/ldap",
     component: UserFederationSection,
-    breadcrumb: null,
     access: "view-realm",
   },
   {
@@ -253,7 +250,6 @@ export const routes: RouteDef[] = [
   {
     path: "/:realm/groups",
     component: GroupsSection,
-    breadcrumb: null,
     access: "query-groups",
     matchOptions: {
       exact: false,
@@ -268,7 +264,6 @@ export const routes: RouteDef[] = [
   {
     path: "*",
     component: PageNotFoundSection,
-    breadcrumb: null,
     access: "anyone",
   },
 ];


### PR DESCRIPTION
## Motivation
If `undefined` is passed into a route definition on the `breadcrumb` property a best effort attempt will be made to provide breadcrumbs from route parameters. This is however not the behavior we want, so we will have to set `disableDefaults` to `true` in order to prevent breadcrumbs from being added implicitly.

For example, without this change the breadcrumbs for a subgroup will look like this:
![Breadcrumbs with implicit entries](https://user-images.githubusercontent.com/695720/126649253-568b7ef3-9001-40bb-9d33-59e8a9addf2c.png)

And with this change, we get the expected behavior:
![Breadcrumbs that look good](https://user-images.githubusercontent.com/695720/126649328-413caf4d-568a-49ae-ab70-21da396d2e50.png)
