### PR TITLE
Use new routing conventions for session routes

### DIFF
--- a/src/route-config.ts
+++ b/src/route-config.ts
@@ -29,7 +29,7 @@ import {
   RealmSettingsSection,
 } from "./realm-settings/RealmSettingsSection";
 import realmRoutes from "./realm/routes";
-import { SessionsSection } from "./sessions/SessionsSection";
+import sessionRoutes from "./sessions/routes";
 import { LdapMapperDetails } from "./user-federation/ldap/mappers/LdapMapperDetails";
 import { UserFederationKerberosSettings } from "./user-federation/UserFederationKerberosSettings";
 import { UserFederationLdapSettings } from "./user-federation/UserFederationLdapSettings";
@@ -50,13 +50,8 @@ export const routes: RouteDef[] = [
   ...clientScopesRoutes,
   ...realmRoleRoutes,
   ...realmRoutes,
+  ...sessionRoutes,
   ...userRoutes,
-  {
-    path: "/:realm/sessions",
-    component: SessionsSection,
-    breadcrumb: (t) => t("sessions:title"),
-    access: "view-realm",
-  },
   {
     path: "/:realm/events/:tab?",
     component: EventsSection,

--- a/src/sessions/routes.ts
+++ b/src/sessions/routes.ts
@@ -1,0 +1,6 @@
+import type { RouteDef } from "../route-config";
+import { SessionsRoute } from "./routes/Sessions";
+
+const routes: RouteDef[] = [SessionsRoute];
+
+export default routes;

--- a/src/sessions/routes/Sessions.ts
+++ b/src/sessions/routes/Sessions.ts
@@ -1,0 +1,19 @@
+import type { LocationDescriptorObject } from "history";
+import { generatePath } from "react-router-dom";
+import type { RouteDef } from "../../route-config";
+import { SessionsSection } from "../SessionsSection";
+
+export type SessionsParams = { realm: string };
+
+export const SessionsRoute: RouteDef = {
+  path: "/:realm/sessions",
+  component: SessionsSection,
+  breadcrumb: (t) => t("sessions:title"),
+  access: "view-realm",
+};
+
+export const toSessions = (
+  params: SessionsParams
+): LocationDescriptorObject => ({
+  pathname: generatePath(SessionsRoute.path, params),
+});


### PR DESCRIPTION
## Motivation
Aligns the routing for session routes with the conventions as discussed in the team meetingoutput. 