### PR TITLE
Lazy load routed components

### DIFF
--- a/snowpack.config.mjs
+++ b/snowpack.config.mjs
@@ -40,6 +40,7 @@ export default {
   ],
   optimize: {
     bundle: true,
+    splitting: true,
   },
   devOptions: {
     hmrErrorOverlay: false,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
-import React, { ReactNode, useEffect } from "react";
-import { Page } from "@patternfly/react-core";
+import React, { ReactNode, useEffect, Suspense } from "react";
+import { Page, Spinner } from "@patternfly/react-core";
 import {
   HashRouter as Router,
   Route,
@@ -58,6 +58,12 @@ const SecuredRoute = ({ route }: SecuredRouteProps) => {
   return <ForbiddenSection />;
 };
 
+const Loading = () => (
+  <div className="pf-u-text-align-center">
+    <Spinner />
+  </div>
+);
+
 export const App = () => {
   return (
     <AppContexts>
@@ -74,18 +80,20 @@ export const App = () => {
             onReset={() => window.location.reload()}
           >
             <Switch>
-              {routes.map((route, i) => (
-                <Route
-                  exact={route.matchOptions?.exact ?? true}
-                  key={i}
-                  path={route.path}
-                  component={() => (
-                    <RealmPathSelector>
-                      <SecuredRoute route={route} />
-                    </RealmPathSelector>
-                  )}
-                />
-              ))}
+              <Suspense fallback={<Loading />}>
+                {routes.map((route, i) => (
+                  <Route
+                    exact={route.matchOptions?.exact ?? true}
+                    key={i}
+                    path={route.path}
+                    component={() => (
+                      <RealmPathSelector>
+                        <SecuredRoute route={route} />
+                      </RealmPathSelector>
+                    )}
+                  />
+                ))}
+              </Suspense>
             </Switch>
           </ErrorBoundary>
         </Page>

--- a/src/authentication/AuthenticationSection.tsx
+++ b/src/authentication/AuthenticationSection.tsx
@@ -42,7 +42,7 @@ const realmFlows = [
   "dockerAuthenticationFlow",
 ];
 
-export const AuthenticationSection = () => {
+const AuthenticationSection = () => {
   const { t } = useTranslation("authentication");
   const adminClient = useAdminClient();
   const { realm } = useRealm();
@@ -253,3 +253,5 @@ export const AuthenticationSection = () => {
     </>
   );
 };
+
+export default AuthenticationSection;

--- a/src/authentication/routes/Authentication.ts
+++ b/src/authentication/routes/Authentication.ts
@@ -1,13 +1,13 @@
 import type { LocationDescriptorObject } from "history";
+import { lazy } from "react";
 import { generatePath } from "react-router-dom";
 import type { RouteDef } from "../../route-config";
-import { AuthenticationSection } from "../AuthenticationSection";
 
 export type AuthenticationParams = { realm: string };
 
 export const AuthenticationRoute: RouteDef = {
   path: "/:realm/authentication",
-  component: AuthenticationSection,
+  component: lazy(() => import("../AuthenticationSection")),
   breadcrumb: (t) => t("authentication"),
   access: "view-realm",
 };

--- a/src/client-scopes/ClientScopesSection.tsx
+++ b/src/client-scopes/ClientScopesSection.tsx
@@ -33,7 +33,7 @@ import { toNewClientScope } from "./routes/NewClientScope";
 
 import "./client-scope.css";
 
-export const ClientScopesSection = () => {
+const ClientScopesSection = () => {
   const { realm } = useRealm();
   const { t } = useTranslation("client-scopes");
   const { url } = useRouteMatch();
@@ -256,3 +256,5 @@ export const ClientScopesSection = () => {
     </>
   );
 };
+
+export default ClientScopesSection;

--- a/src/client-scopes/add/RoleMappingForm.tsx
+++ b/src/client-scopes/add/RoleMappingForm.tsx
@@ -27,7 +27,7 @@ import { ViewHeader } from "../../components/view-header/ViewHeader";
 import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
 import { useRealm } from "../../context/realm-context/RealmContext";
 
-export const RoleMappingForm = () => {
+const RoleMappingForm = () => {
   const { realm } = useRealm();
   const adminClient = useAdminClient();
   const history = useHistory();
@@ -301,3 +301,5 @@ export const RoleMappingForm = () => {
     </>
   );
 };
+
+export default RoleMappingForm;

--- a/src/client-scopes/details/MappingDetails.tsx
+++ b/src/client-scopes/details/MappingDetails.tsx
@@ -38,7 +38,7 @@ type Params = {
   mapperId: string;
 };
 
-export const MappingDetails = () => {
+const MappingDetails = () => {
   const { t } = useTranslation("client-scopes");
   const adminClient = useAdminClient();
   const { addAlert } = useAlerts();
@@ -369,3 +369,5 @@ export const MappingDetails = () => {
     </>
   );
 };
+
+export default MappingDetails;

--- a/src/client-scopes/form/ClientScopeForm.tsx
+++ b/src/client-scopes/form/ClientScopeForm.tsx
@@ -32,7 +32,7 @@ import {
 } from "../../components/client-scope/ClientScopeTypes";
 import { useRealm } from "../../context/realm-context/RealmContext";
 
-export const ClientScopeForm = () => {
+const ClientScopeForm = () => {
   const { t } = useTranslation("client-scopes");
   const [clientScope, setClientScope] =
     useState<ClientScopeDefaultOptionalType>();
@@ -257,3 +257,5 @@ export const ClientScopeForm = () => {
     </>
   );
 };
+
+export default ClientScopeForm;

--- a/src/client-scopes/routes/ClientScope.ts
+++ b/src/client-scopes/routes/ClientScope.ts
@@ -1,7 +1,7 @@
 import type { LocationDescriptorObject } from "history";
+import { lazy } from "react";
 import { generatePath } from "react-router-dom";
 import type { RouteDef } from "../../route-config";
-import { ClientScopeForm } from "../form/ClientScopeForm";
 
 export type ClientScopeParams = {
   realm: string;
@@ -12,7 +12,7 @@ export type ClientScopeParams = {
 
 export const ClientScopeRoute: RouteDef = {
   path: "/:realm/client-scopes/:id/:type/:tab",
-  component: ClientScopeForm,
+  component: lazy(() => import("../form/ClientScopeForm")),
   breadcrumb: (t) => t("client-scopes:clientScopeDetails"),
   access: "view-clients",
 };

--- a/src/client-scopes/routes/ClientScopes.ts
+++ b/src/client-scopes/routes/ClientScopes.ts
@@ -1,13 +1,13 @@
 import type { LocationDescriptorObject } from "history";
+import { lazy } from "react";
 import { generatePath } from "react-router-dom";
 import type { RouteDef } from "../../route-config";
-import { ClientScopesSection } from "../ClientScopesSection";
 
 export type ClientScopesParams = { realm: string };
 
 export const ClientScopesRoute: RouteDef = {
   path: "/:realm/client-scopes",
-  component: ClientScopesSection,
+  component: lazy(() => import("../ClientScopesSection")),
   breadcrumb: (t) => t("client-scopes:clientScopeList"),
   access: "view-clients",
 };

--- a/src/client-scopes/routes/Mapper.ts
+++ b/src/client-scopes/routes/Mapper.ts
@@ -1,7 +1,7 @@
 import type { LocationDescriptorObject } from "history";
+import { lazy } from "react";
 import { generatePath } from "react-router-dom";
 import type { RouteDef } from "../../route-config";
-import { MappingDetails } from "../details/MappingDetails";
 
 export type MapperParams = {
   realm: string;
@@ -11,7 +11,7 @@ export type MapperParams = {
 
 export const MapperRoute: RouteDef = {
   path: "/:realm/client-scopes/:id/mappers/:mapperId",
-  component: MappingDetails,
+  component: lazy(() => import("../details/MappingDetails")),
   breadcrumb: (t) => t("common:mappingDetails"),
   access: "view-clients",
 };

--- a/src/client-scopes/routes/NewClientScope.ts
+++ b/src/client-scopes/routes/NewClientScope.ts
@@ -1,13 +1,13 @@
 import type { LocationDescriptorObject } from "history";
+import { lazy } from "react";
 import { generatePath } from "react-router-dom";
 import type { RouteDef } from "../../route-config";
-import { ClientScopeForm } from "../form/ClientScopeForm";
 
 export type NewClientScopeParams = { realm: string };
 
 export const NewClientScopeRoute: RouteDef = {
   path: "/:realm/client-scopes/new",
-  component: ClientScopeForm,
+  component: lazy(() => import("../form/ClientScopeForm")),
   breadcrumb: (t) => t("client-scopes:createClientScope"),
   access: "manage-clients",
 };

--- a/src/client-scopes/routes/OidcRoleNameMapper.ts
+++ b/src/client-scopes/routes/OidcRoleNameMapper.ts
@@ -1,7 +1,7 @@
 import type { LocationDescriptorObject } from "history";
+import { lazy } from "react";
 import { generatePath } from "react-router-dom";
 import type { RouteDef } from "../../route-config";
-import { RoleMappingForm } from "../add/RoleMappingForm";
 
 export type OidcRoleNameMapperParams = {
   realm: string;
@@ -10,7 +10,7 @@ export type OidcRoleNameMapperParams = {
 
 export const OidcRoleNameMapperRoute: RouteDef = {
   path: "/:realm/client-scopes/:id/mappers/oidc-role-name-mapper",
-  component: RoleMappingForm,
+  component: lazy(() => import("../add/RoleMappingForm")),
   breadcrumb: (t) => t("common:mappingDetails"),
   access: "view-clients",
 };

--- a/src/clients/ClientDetails.tsx
+++ b/src/clients/ClientDetails.tsx
@@ -122,7 +122,7 @@ export type SaveOptions = {
   messageKey?: string;
 };
 
-export const ClientDetails = () => {
+const ClientDetails = () => {
   const { t } = useTranslation("clients");
   const adminClient = useAdminClient();
   const { addAlert } = useAlerts();
@@ -376,3 +376,5 @@ export const ClientDetails = () => {
     </>
   );
 };
+
+export default ClientDetails;

--- a/src/clients/ClientsSection.tsx
+++ b/src/clients/ClientsSection.tsx
@@ -27,7 +27,7 @@ import { toAddClient } from "./routes/AddClient";
 import { toClient } from "./routes/Client";
 import { toImportClient } from "./routes/ImportClient";
 
-export const ClientsSection = () => {
+const ClientsSection = () => {
   const { t } = useTranslation("clients");
   const { addAlert } = useAlerts();
 
@@ -198,3 +198,5 @@ export const ClientsSection = () => {
     </>
   );
 };
+
+export default ClientsSection;

--- a/src/clients/add/NewClientForm.tsx
+++ b/src/clients/add/NewClientForm.tsx
@@ -20,7 +20,7 @@ import { toClients } from "../routes/Clients";
 import { CapabilityConfig } from "./CapabilityConfig";
 import { GeneralSettings } from "./GeneralSettings";
 
-export const NewClientForm = () => {
+const NewClientForm = () => {
   const { t } = useTranslation("clients");
   const { realm } = useRealm();
   const adminClient = useAdminClient();
@@ -152,3 +152,5 @@ export const NewClientForm = () => {
     </>
   );
 };
+
+export default NewClientForm;

--- a/src/clients/import/ImportForm.tsx
+++ b/src/clients/import/ImportForm.tsx
@@ -23,7 +23,7 @@ import { ClientDescription } from "../ClientDescription";
 import { toClient } from "../routes/Client";
 import { toClients } from "../routes/Clients";
 
-export const ImportForm = () => {
+const ImportForm = () => {
   const { t } = useTranslation("clients");
   const history = useHistory();
   const adminClient = useAdminClient();
@@ -105,3 +105,5 @@ export const ImportForm = () => {
     </>
   );
 };
+
+export default ImportForm;

--- a/src/clients/initial-access/CreateInitialAccessToken.tsx
+++ b/src/clients/initial-access/CreateInitialAccessToken.tsx
@@ -22,7 +22,7 @@ import { useAlerts } from "../../components/alert/Alerts";
 import { AccessTokenDialog } from "./AccessTokenDialog";
 import { toClients } from "../routes/Clients";
 
-export const CreateInitialAccessToken = () => {
+const CreateInitialAccessToken = () => {
   const { t } = useTranslation("clients");
   const { handleSubmit, control } = useForm();
 
@@ -142,3 +142,5 @@ export const CreateInitialAccessToken = () => {
     </>
   );
 };
+
+export default CreateInitialAccessToken;

--- a/src/clients/routes/AddClient.ts
+++ b/src/clients/routes/AddClient.ts
@@ -1,13 +1,13 @@
 import type { LocationDescriptorObject } from "history";
+import { lazy } from "react";
 import { generatePath } from "react-router-dom";
 import type { RouteDef } from "../../route-config";
-import { NewClientForm } from "../add/NewClientForm";
 
 export type AddClientParams = { realm: string };
 
 export const AddClientRoute: RouteDef = {
   path: "/:realm/clients/add-client",
-  component: NewClientForm,
+  component: lazy(() => import("../add/NewClientForm")),
   breadcrumb: (t) => t("clients:createClient"),
   access: "manage-clients",
 };

--- a/src/clients/routes/Client.ts
+++ b/src/clients/routes/Client.ts
@@ -1,7 +1,7 @@
 import type { LocationDescriptorObject } from "history";
+import { lazy } from "react";
 import { generatePath } from "react-router-dom";
 import type { RouteDef } from "../../route-config";
-import { ClientDetails } from "../ClientDetails";
 
 export type ClientTab = "settings" | "roles" | "clientScopes" | "advanced";
 
@@ -13,7 +13,7 @@ export type ClientParams = {
 
 export const ClientRoute: RouteDef = {
   path: "/:realm/clients/:clientId/:tab",
-  component: ClientDetails,
+  component: lazy(() => import("../ClientDetails")),
   breadcrumb: (t) => t("clients:clientSettings"),
   access: "view-clients",
 };

--- a/src/clients/routes/Clients.ts
+++ b/src/clients/routes/Clients.ts
@@ -1,7 +1,7 @@
 import type { LocationDescriptorObject } from "history";
+import { lazy } from "react";
 import { generatePath } from "react-router-dom";
 import type { RouteDef } from "../../route-config";
-import { ClientsSection } from "../ClientsSection";
 
 export type ClientsTab = "list" | "initialAccessToken";
 
@@ -12,7 +12,7 @@ export type ClientsParams = {
 
 export const ClientsRoute: RouteDef = {
   path: "/:realm/clients/:tab?",
-  component: ClientsSection,
+  component: lazy(() => import("../ClientsSection")),
   breadcrumb: (t) => t("clients:clientList"),
   access: "query-clients",
 };

--- a/src/clients/routes/CreateInitialAccessToken.ts
+++ b/src/clients/routes/CreateInitialAccessToken.ts
@@ -1,13 +1,13 @@
 import type { LocationDescriptorObject } from "history";
+import { lazy } from "react";
 import { generatePath } from "react-router-dom";
 import type { RouteDef } from "../../route-config";
-import { CreateInitialAccessToken } from "../initial-access/CreateInitialAccessToken";
 
 export type CreateInitialAccessTokenParams = { realm: string };
 
 export const CreateInitialAccessTokenRoute: RouteDef = {
   path: "/:realm/clients/initialAccessToken/create",
-  component: CreateInitialAccessToken,
+  component: lazy(() => import("../initial-access/CreateInitialAccessToken")),
   breadcrumb: (t) => t("clients:createToken"),
   access: "manage-clients",
 };

--- a/src/clients/routes/ImportClient.ts
+++ b/src/clients/routes/ImportClient.ts
@@ -1,13 +1,13 @@
 import type { LocationDescriptorObject } from "history";
+import { lazy } from "react";
 import { generatePath } from "react-router-dom";
 import type { RouteDef } from "../../route-config";
-import { ImportForm } from "../import/ImportForm";
 
 export type ImportClientParams = { realm: string };
 
 export const ImportClientRoute: RouteDef = {
   path: "/:realm/clients/import-client",
-  component: ImportForm,
+  component: lazy(() => import("../import/ImportForm")),
   breadcrumb: (t) => t("clients:importClient"),
   access: "manage-clients",
 };

--- a/src/dashboard/Dashboard.tsx
+++ b/src/dashboard/Dashboard.tsx
@@ -169,7 +169,7 @@ const Dashboard = () => {
   );
 };
 
-export const DashboardSection = () => {
+const DashboardSection = () => {
   const { realm } = useRealm();
   const isMasterRealm = realm === "master";
   return (
@@ -179,3 +179,5 @@ export const DashboardSection = () => {
     </>
   );
 };
+
+export default DashboardSection;

--- a/src/dashboard/routes/Dashboard.ts
+++ b/src/dashboard/routes/Dashboard.ts
@@ -1,13 +1,13 @@
 import type { LocationDescriptorObject } from "history";
+import { lazy } from "react";
 import { generatePath } from "react-router-dom";
 import type { RouteDef } from "../../route-config";
-import { DashboardSection } from "../Dashboard";
 
 export type DashboardParams = { realm?: string };
 
 export const DashboardRoute: RouteDef = {
   path: "/:realm?",
-  component: DashboardSection,
+  component: lazy(() => import("../Dashboard")),
   breadcrumb: (t) => t("common:home"),
   access: "anyone",
 };

--- a/src/events/EventsSection.tsx
+++ b/src/events/EventsSection.tsx
@@ -26,7 +26,7 @@ import { useRealm } from "../context/realm-context/RealmContext";
 import { AdminEvents } from "./AdminEvents";
 import "./events-section.css";
 
-export const EventsSection = () => {
+const EventsSection = () => {
   const { t } = useTranslation("events");
   const adminClient = useAdminClient();
   const { realm } = useRealm();
@@ -188,3 +188,5 @@ export const EventsSection = () => {
     </>
   );
 };
+
+export default EventsSection;

--- a/src/events/routes/Events.ts
+++ b/src/events/routes/Events.ts
@@ -1,7 +1,7 @@
 import type { LocationDescriptorObject } from "history";
+import { lazy } from "react";
 import { generatePath } from "react-router-dom";
 import type { RouteDef } from "../../route-config";
-import { EventsSection } from "../EventsSection";
 
 export type EventsTab = "userEvents" | "adminEvents";
 
@@ -12,7 +12,7 @@ export type EventsParams = {
 
 export const EventsRoute: RouteDef = {
   path: "/:realm/events/:tab?",
-  component: EventsSection,
+  component: lazy(() => import("../EventsSection")),
   breadcrumb: (t) => t("events:title"),
   access: "view-events",
 };

--- a/src/groups/GroupsSection.tsx
+++ b/src/groups/GroupsSection.tsx
@@ -26,7 +26,7 @@ import { GroupsModal } from "./GroupsModal";
 
 import "./GroupsSection.css";
 
-export const GroupsSection = () => {
+const GroupsSection = () => {
   const { t } = useTranslation("groups");
   const [activeTab, setActiveTab] = useState(0);
 
@@ -171,3 +171,5 @@ export const GroupsSection = () => {
     </>
   );
 };
+
+export default GroupsSection;

--- a/src/groups/SearchGroups.tsx
+++ b/src/groups/SearchGroups.tsx
@@ -28,7 +28,7 @@ type SearchGroup = GroupRepresentation & {
   link?: string;
 };
 
-export const SearchGroups = () => {
+const SearchGroups = () => {
   const { t } = useTranslation("groups");
   const adminClient = useAdminClient();
   const { realm } = useRealm();
@@ -173,3 +173,5 @@ export const SearchGroups = () => {
     </>
   );
 };
+
+export default SearchGroups;

--- a/src/groups/routes/Groups.tsx
+++ b/src/groups/routes/Groups.tsx
@@ -1,13 +1,13 @@
 import type { LocationDescriptorObject } from "history";
+import { lazy } from "react";
 import { generatePath } from "react-router-dom";
 import type { RouteDef } from "../../route-config";
-import { GroupsSection } from "../GroupsSection";
 
 export type GroupsParams = { realm: string };
 
 export const GroupsRoute: RouteDef = {
   path: "/:realm/groups",
-  component: GroupsSection,
+  component: lazy(() => import("../GroupsSection")),
   access: "query-groups",
   matchOptions: {
     exact: false,

--- a/src/groups/routes/GroupsSearch.tsx
+++ b/src/groups/routes/GroupsSearch.tsx
@@ -1,13 +1,13 @@
 import type { LocationDescriptorObject } from "history";
+import { lazy } from "react";
 import { generatePath } from "react-router-dom";
 import type { RouteDef } from "../../route-config";
-import { SearchGroups } from "../SearchGroups";
 
 export type GroupsSearchParams = { realm: string };
 
 export const GroupsSearchRoute: RouteDef = {
   path: "/:realm/groups/search",
-  component: SearchGroups,
+  component: lazy(() => import("../SearchGroups")),
   breadcrumb: (t) => t("groups:searchGroups"),
   access: "query-groups",
 };

--- a/src/identity-providers/IdentityProvidersSection.tsx
+++ b/src/identity-providers/IdentityProvidersSection.tsx
@@ -35,7 +35,7 @@ import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
 import { ProviderIconMapper } from "./ProviderIconMapper";
 import { ManageOderDialog } from "./ManageOrderDialog";
 
-export const IdentityProvidersSection = () => {
+const IdentityProvidersSection = () => {
   const { t } = useTranslation("identity-providers");
   const identityProviders = _.groupBy(
     useServerInfo().identityProviders,
@@ -248,3 +248,5 @@ export const IdentityProvidersSection = () => {
     </>
   );
 };
+
+export default IdentityProvidersSection;

--- a/src/identity-providers/add/AddIdentityProvider.tsx
+++ b/src/identity-providers/add/AddIdentityProvider.tsx
@@ -42,7 +42,7 @@ export const IdentityProviderCrumb = ({ match, location }: BreadcrumbData) => {
   );
 };
 
-export const AddIdentityProvider = () => {
+const AddIdentityProvider = () => {
   const { t } = useTranslation("identity-providers");
   const { id } = useParams<{ id: string }>();
   const form = useForm<IdentityProviderRepresentation>();
@@ -111,3 +111,5 @@ export const AddIdentityProvider = () => {
     </>
   );
 };
+
+export default AddIdentityProvider;

--- a/src/identity-providers/add/AddOpenIdConnect.tsx
+++ b/src/identity-providers/add/AddOpenIdConnect.tsx
@@ -23,7 +23,7 @@ type DiscoveryIdentity = IdentityProviderRepresentation & {
   discoveryEndpoint?: string;
 };
 
-export const AddOpenIdConnect = () => {
+const AddOpenIdConnect = () => {
   const { t } = useTranslation("identity-providers");
   const history = useHistory();
   const { url } = useRouteMatch();
@@ -101,3 +101,5 @@ export const AddOpenIdConnect = () => {
     </>
   );
 };
+
+export default AddOpenIdConnect;

--- a/src/identity-providers/add/DetailSettings.tsx
+++ b/src/identity-providers/add/DetailSettings.tsx
@@ -78,7 +78,7 @@ const Header = ({ onChange, value, save, toggleDeleteDialog }: HeaderProps) => {
   );
 };
 
-export const DetailSettings = () => {
+const DetailSettings = () => {
   const { t } = useTranslation("identity-providers");
   const { id } = useParams<{ id: string }>();
 
@@ -217,3 +217,5 @@ export const DetailSettings = () => {
     </>
   );
 };
+
+export default DetailSettings;

--- a/src/identity-providers/routes/IdentityProvider.ts
+++ b/src/identity-providers/routes/IdentityProvider.ts
@@ -1,10 +1,8 @@
 import type { LocationDescriptorObject } from "history";
+import { lazy } from "react";
 import { generatePath } from "react-router-dom";
 import type { RouteDef } from "../../route-config";
-import {
-  AddIdentityProvider,
-  IdentityProviderCrumb,
-} from "../add/AddIdentityProvider";
+import { IdentityProviderCrumb } from "../add/AddIdentityProvider";
 
 export type IdentityProviderParams = {
   realm: string;
@@ -13,7 +11,7 @@ export type IdentityProviderParams = {
 
 export const IdentityProviderRoute: RouteDef = {
   path: "/:realm/identity-providers/:id",
-  component: AddIdentityProvider,
+  component: lazy(() => import("../add/AddIdentityProvider")),
   breadcrumb: () => IdentityProviderCrumb,
   access: "manage-identity-providers",
 };

--- a/src/identity-providers/routes/IdentityProviderKeycloakOidc.ts
+++ b/src/identity-providers/routes/IdentityProviderKeycloakOidc.ts
@@ -1,13 +1,13 @@
 import type { LocationDescriptorObject } from "history";
+import { lazy } from "react";
 import { generatePath } from "react-router-dom";
 import type { RouteDef } from "../../route-config";
-import { AddOpenIdConnect } from "../add/AddOpenIdConnect";
 
 export type IdentityProviderKeycloakOidcParams = { realm: string };
 
 export const IdentityProviderKeycloakOidcRoute: RouteDef = {
   path: "/:realm/identity-providers/keycloak-oidc",
-  component: AddOpenIdConnect,
+  component: lazy(() => import("../add/AddOpenIdConnect")),
   breadcrumb: (t) => t("identity-providers:addKeycloakOpenIdProvider"),
   access: "manage-identity-providers",
 };

--- a/src/identity-providers/routes/IdentityProviderOidc.ts
+++ b/src/identity-providers/routes/IdentityProviderOidc.ts
@@ -1,13 +1,13 @@
 import type { LocationDescriptorObject } from "history";
+import { lazy } from "react";
 import { generatePath } from "react-router-dom";
 import type { RouteDef } from "../../route-config";
-import { AddOpenIdConnect } from "../add/AddOpenIdConnect";
 
 export type IdentityProviderOidcParams = { realm: string };
 
 export const IdentityProviderOidcRoute: RouteDef = {
   path: "/:realm/identity-providers/oidc",
-  component: AddOpenIdConnect,
+  component: lazy(() => import("../add/AddOpenIdConnect")),
   breadcrumb: (t) => t("identity-providers:addOpenIdProvider"),
   access: "manage-identity-providers",
 };

--- a/src/identity-providers/routes/IdentityProviderTab.ts
+++ b/src/identity-providers/routes/IdentityProviderTab.ts
@@ -1,7 +1,7 @@
 import type { LocationDescriptorObject } from "history";
+import { lazy } from "react";
 import { generatePath } from "react-router-dom";
 import type { RouteDef } from "../../route-config";
-import { DetailSettings } from "../add/DetailSettings";
 
 export type IdentityProviderTab = "settings";
 
@@ -13,7 +13,7 @@ export type IdentityProviderTabParams = {
 
 export const IdentityProviderTabRoute: RouteDef = {
   path: "/:realm/identity-providers/:id/:tab?",
-  component: DetailSettings,
+  component: lazy(() => import("../add/DetailSettings")),
   access: "manage-identity-providers",
 };
 

--- a/src/identity-providers/routes/IdentityProviders.ts
+++ b/src/identity-providers/routes/IdentityProviders.ts
@@ -1,13 +1,13 @@
 import type { LocationDescriptorObject } from "history";
+import { lazy } from "react";
 import { generatePath } from "react-router-dom";
 import type { RouteDef } from "../../route-config";
-import { IdentityProvidersSection } from "../IdentityProvidersSection";
 
 export type IdentityProvidersParams = { realm: string };
 
 export const IdentityProvidersRoute: RouteDef = {
   path: "/:realm/identity-providers",
-  component: IdentityProvidersSection,
+  component: lazy(() => import("../IdentityProvidersSection")),
   breadcrumb: (t) => t("identityProviders"),
   access: "view-identity-providers",
 };

--- a/src/realm-roles/RealmRoleTabs.tsx
+++ b/src/realm-roles/RealmRoleTabs.tsx
@@ -42,7 +42,7 @@ type myRealmRepresentation = RealmRepresentation & {
   };
 };
 
-export const RealmRoleTabs = () => {
+const RealmRoleTabs = () => {
   const { t } = useTranslation("roles");
   const form = useForm<RoleFormType>({ mode: "onChange" });
   const history = useHistory();
@@ -397,3 +397,5 @@ export const RealmRoleTabs = () => {
     </>
   );
 };
+
+export default RealmRoleTabs;

--- a/src/realm-roles/RealmRolesSection.tsx
+++ b/src/realm-roles/RealmRolesSection.tsx
@@ -4,7 +4,7 @@ import { ViewHeader } from "../components/view-header/ViewHeader";
 import { useAdminClient } from "../context/auth/AdminClient";
 import { RolesList } from "./RolesList";
 
-export const RealmRolesSection = () => {
+const RealmRolesSection = () => {
   const adminClient = useAdminClient();
 
   const loader = (first?: number, max?: number, search?: string) => {
@@ -31,3 +31,5 @@ export const RealmRolesSection = () => {
     </>
   );
 };
+
+export default RealmRolesSection;

--- a/src/realm-roles/routes/AddRole.ts
+++ b/src/realm-roles/routes/AddRole.ts
@@ -1,13 +1,13 @@
 import type { LocationDescriptorObject } from "history";
+import { lazy } from "react";
 import { generatePath } from "react-router-dom";
 import type { RouteDef } from "../../route-config";
-import { RealmRoleTabs } from "../RealmRoleTabs";
 
 export type AddRoleParams = { realm: string };
 
 export const AddRoleRoute: RouteDef = {
   path: "/:realm/roles/add-role",
-  component: RealmRoleTabs,
+  component: lazy(() => import("../RealmRoleTabs")),
   breadcrumb: (t) => t("roles:createRole"),
   access: "manage-realm",
 };

--- a/src/realm-roles/routes/AddRoleToClient.ts
+++ b/src/realm-roles/routes/AddRoleToClient.ts
@@ -1,7 +1,7 @@
 import type { LocationDescriptorObject } from "history";
+import { lazy } from "react";
 import { generatePath } from "react-router-dom";
 import type { RouteDef } from "../../route-config";
-import { RealmRoleTabs } from "../RealmRoleTabs";
 
 export type AddRoleToClientParams = {
   realm: string;
@@ -10,7 +10,7 @@ export type AddRoleToClientParams = {
 
 export const AddRoleToClientRoute: RouteDef = {
   path: "/:realm/clients/:clientId/roles/add-role",
-  component: RealmRoleTabs,
+  component: lazy(() => import("../RealmRoleTabs")),
   breadcrumb: (t) => t("roles:createRole"),
   access: "manage-realm",
 };

--- a/src/realm-roles/routes/ClientRole.ts
+++ b/src/realm-roles/routes/ClientRole.ts
@@ -1,7 +1,7 @@
 import type { LocationDescriptorObject } from "history";
+import { lazy } from "react";
 import { generatePath } from "react-router-dom";
 import type { RouteDef } from "../../route-config";
-import { RealmRoleTabs } from "../RealmRoleTabs";
 
 export type ClientRoleParams = {
   realm: string;
@@ -12,7 +12,7 @@ export type ClientRoleParams = {
 
 export const ClientRoleRoute: RouteDef = {
   path: "/:realm/clients/:clientId/roles/:id/:tab?",
-  component: RealmRoleTabs,
+  component: lazy(() => import("../RealmRoleTabs")),
   breadcrumb: (t) => t("roles:roleDetails"),
   access: "view-realm",
 };

--- a/src/realm-roles/routes/RealmRole.ts
+++ b/src/realm-roles/routes/RealmRole.ts
@@ -1,7 +1,7 @@
 import type { LocationDescriptorObject } from "history";
+import { lazy } from "react";
 import { generatePath } from "react-router-dom";
 import type { RouteDef } from "../../route-config";
-import { RealmRoleTabs } from "../RealmRoleTabs";
 
 export type RealmRoleParams = {
   realm: string;
@@ -11,7 +11,7 @@ export type RealmRoleParams = {
 
 export const RealmRoleRoute: RouteDef = {
   path: "/:realm/roles/:id/:tab?",
-  component: RealmRoleTabs,
+  component: lazy(() => import("../RealmRoleTabs")),
   breadcrumb: (t) => t("roles:roleDetails"),
   access: "view-realm",
 };

--- a/src/realm-roles/routes/RealmRoles.ts
+++ b/src/realm-roles/routes/RealmRoles.ts
@@ -1,13 +1,13 @@
 import type { LocationDescriptorObject } from "history";
+import { lazy } from "react";
 import { generatePath } from "react-router-dom";
 import type { RouteDef } from "../../route-config";
-import { RealmRolesSection } from "../RealmRolesSection";
 
 export type RealmRolesParams = { realm: string };
 
 export const RealmRolesRoute: RouteDef = {
   path: "/:realm/roles",
-  component: RealmRolesSection,
+  component: lazy(() => import("../RealmRolesSection")),
   breadcrumb: (t) => t("roles:roleList"),
   access: "view-realm",
 };

--- a/src/realm-settings/RealmSettingsSection.tsx
+++ b/src/realm-settings/RealmSettingsSection.tsx
@@ -143,7 +143,7 @@ const RealmSettingsHeader = ({
   );
 };
 
-export const RealmSettingsSection = () => {
+const RealmSettingsSection = () => {
   const { t } = useTranslation("realm-settings");
   const adminClient = useAdminClient();
   const { realm: realmName } = useRealm();
@@ -350,3 +350,5 @@ export const RealmSettingsSection = () => {
     </>
   );
 };
+
+export default RealmSettingsSection;

--- a/src/realm-settings/key-providers/aes-generated/AESGeneratedForm.tsx
+++ b/src/realm-settings/key-providers/aes-generated/AESGeneratedForm.tsx
@@ -344,7 +344,7 @@ export const AESGeneratedForm = ({
   );
 };
 
-export const AESGeneratedSettings = () => {
+const AESGeneratedSettings = () => {
   const { t } = useTranslation("realm-settings");
   const providerId = useRouteMatch<MatchParams>(
     "/:realm/realm-settings/keys/:id?/:providerType?/settings"
@@ -358,3 +358,5 @@ export const AESGeneratedSettings = () => {
     </>
   );
 };
+
+export default AESGeneratedSettings;

--- a/src/realm-settings/key-providers/ecdsa-generated/ECDSAGeneratedForm.tsx
+++ b/src/realm-settings/key-providers/ecdsa-generated/ECDSAGeneratedForm.tsx
@@ -335,7 +335,7 @@ export const ECDSAGeneratedForm = ({
   );
 };
 
-export const ECDSAGeneratedSettings = () => {
+const ECDSAGeneratedSettings = () => {
   const { t } = useTranslation("realm-settings");
   const providerId = useRouteMatch<MatchParams>(
     "/:realm/realm-settings/keys/:id?/:providerType?/settings"
@@ -349,3 +349,5 @@ export const ECDSAGeneratedSettings = () => {
     </>
   );
 };
+
+export default ECDSAGeneratedSettings;

--- a/src/realm-settings/key-providers/hmac-generated/HMACGeneratedForm.tsx
+++ b/src/realm-settings/key-providers/hmac-generated/HMACGeneratedForm.tsx
@@ -386,7 +386,7 @@ export const HMACGeneratedForm = ({
   );
 };
 
-export const HMACGeneratedSettings = () => {
+const HMACGeneratedSettings = () => {
   const { t } = useTranslation("realm-settings");
   const providerId = useRouteMatch<MatchParams>(
     "/:realm/realm-settings/keys/:id?/:providerType?/settings"
@@ -400,3 +400,5 @@ export const HMACGeneratedSettings = () => {
     </>
   );
 };
+
+export default HMACGeneratedSettings;

--- a/src/realm-settings/key-providers/java-keystore/JavaKeystoreForm.tsx
+++ b/src/realm-settings/key-providers/java-keystore/JavaKeystoreForm.tsx
@@ -455,7 +455,7 @@ export const JavaKeystoreForm = ({
   );
 };
 
-export const JavaKeystoreSettings = () => {
+const JavaKeystoreSettings = () => {
   const { t } = useTranslation("realm-settings");
   const providerId = useRouteMatch<MatchParams>(
     "/:realm/realm-settings/keys/:id?/:providerType?/settings"
@@ -469,3 +469,5 @@ export const JavaKeystoreSettings = () => {
     </>
   );
 };
+
+export default JavaKeystoreSettings;

--- a/src/realm-settings/key-providers/rsa-generated/RSAGeneratedForm.tsx
+++ b/src/realm-settings/key-providers/rsa-generated/RSAGeneratedForm.tsx
@@ -387,7 +387,7 @@ export const RSAGeneratedForm = ({
   );
 };
 
-export const RSAGeneratedSettings = () => {
+const RSAGeneratedSettings = () => {
   const { t } = useTranslation("realm-settings");
   const providerId = useRouteMatch<MatchParams>(
     "/:realm/realm-settings/keys/:id?/:providerType?/settings"
@@ -401,3 +401,5 @@ export const RSAGeneratedSettings = () => {
     </>
   );
 };
+
+export default RSAGeneratedSettings;

--- a/src/realm-settings/key-providers/rsa/RSAForm.tsx
+++ b/src/realm-settings/key-providers/rsa/RSAForm.tsx
@@ -413,7 +413,7 @@ export const RSAForm = ({
   );
 };
 
-export const RSASettings = () => {
+const RSASettings = () => {
   const { t } = useTranslation("realm-settings");
   const providerId = useRouteMatch<MatchParams>(
     "/:realm/realm-settings/keys/:id?/:providerType?/settings"
@@ -427,3 +427,5 @@ export const RSASettings = () => {
     </>
   );
 };
+
+export default RSASettings;

--- a/src/realm-settings/routes/AesGeneratedSettings.ts
+++ b/src/realm-settings/routes/AesGeneratedSettings.ts
@@ -1,7 +1,7 @@
 import type { LocationDescriptorObject } from "history";
+import { lazy } from "react";
 import { generatePath } from "react-router-dom";
 import type { RouteDef } from "../../route-config";
-import { AESGeneratedSettings } from "../key-providers/aes-generated/AESGeneratedForm";
 import { EditProviderCrumb } from "../RealmSettingsSection";
 
 export type AesGeneratedSettingsParams = {
@@ -11,7 +11,9 @@ export type AesGeneratedSettingsParams = {
 
 export const AesGeneratedSettingsRoute: RouteDef = {
   path: "/:realm/realm-settings/keys/:id/aes-generated/settings",
-  component: AESGeneratedSettings,
+  component: lazy(
+    () => import("../key-providers/aes-generated/AESGeneratedForm")
+  ),
   breadcrumb: () => EditProviderCrumb,
   access: "view-realm",
 };

--- a/src/realm-settings/routes/EcdsaGeneratedSettings.ts
+++ b/src/realm-settings/routes/EcdsaGeneratedSettings.ts
@@ -1,7 +1,7 @@
 import type { LocationDescriptorObject } from "history";
+import { lazy } from "react";
 import { generatePath } from "react-router-dom";
 import type { RouteDef } from "../../route-config";
-import { ECDSAGeneratedSettings } from "../key-providers/ecdsa-generated/ECDSAGeneratedForm";
 import { EditProviderCrumb } from "../RealmSettingsSection";
 
 export type EcdsaGeneratedSettingsParams = {
@@ -11,7 +11,9 @@ export type EcdsaGeneratedSettingsParams = {
 
 export const EcdsaGeneratedSettingsRoute: RouteDef = {
   path: "/:realm/realm-settings/keys/:id/ecdsa-generated/settings",
-  component: ECDSAGeneratedSettings,
+  component: lazy(
+    () => import("../key-providers/ecdsa-generated/ECDSAGeneratedForm")
+  ),
   breadcrumb: () => EditProviderCrumb,
   access: "view-realm",
 };

--- a/src/realm-settings/routes/HmacGeneratedSettings.ts
+++ b/src/realm-settings/routes/HmacGeneratedSettings.ts
@@ -1,7 +1,7 @@
 import type { LocationDescriptorObject } from "history";
+import { lazy } from "react";
 import { generatePath } from "react-router-dom";
 import type { RouteDef } from "../../route-config";
-import { HMACGeneratedSettings } from "../key-providers/hmac-generated/HMACGeneratedForm";
 import { EditProviderCrumb } from "../RealmSettingsSection";
 
 export type HmacGeneratedSettingsParams = {
@@ -11,7 +11,9 @@ export type HmacGeneratedSettingsParams = {
 
 export const HmacGeneratedSettingsRoute: RouteDef = {
   path: "/:realm/realm-settings/keys/:id/hmac-generated/settings",
-  component: HMACGeneratedSettings,
+  component: lazy(
+    () => import("../key-providers/hmac-generated/HMACGeneratedForm")
+  ),
   breadcrumb: () => EditProviderCrumb,
   access: "view-realm",
 };

--- a/src/realm-settings/routes/JavaKeystoreSettings.ts
+++ b/src/realm-settings/routes/JavaKeystoreSettings.ts
@@ -1,7 +1,7 @@
 import type { LocationDescriptorObject } from "history";
+import { lazy } from "react";
 import { generatePath } from "react-router-dom";
 import type { RouteDef } from "../../route-config";
-import { JavaKeystoreSettings } from "../key-providers/java-keystore/JavaKeystoreForm";
 import { EditProviderCrumb } from "../RealmSettingsSection";
 
 export type JavaKeystoreSettingsParams = {
@@ -11,7 +11,9 @@ export type JavaKeystoreSettingsParams = {
 
 export const JavaKeystoreSettingsRoute: RouteDef = {
   path: "/:realm/realm-settings/keys/:id/java-keystore/settings",
-  component: JavaKeystoreSettings,
+  component: lazy(
+    () => import("../key-providers/java-keystore/JavaKeystoreForm")
+  ),
   breadcrumb: () => EditProviderCrumb,
   access: "view-realm",
 };

--- a/src/realm-settings/routes/RealmSettings.ts
+++ b/src/realm-settings/routes/RealmSettings.ts
@@ -1,7 +1,7 @@
 import type { LocationDescriptorObject } from "history";
+import { lazy } from "react";
 import { generatePath } from "react-router-dom";
 import type { RouteDef } from "../../route-config";
-import { RealmSettingsSection } from "../RealmSettingsSection";
 
 export type RealmSettingsTab =
   | "general"
@@ -20,7 +20,7 @@ export type RealmSettingsParams = {
 
 export const RealmSettingsRoute: RouteDef = {
   path: "/:realm/realm-settings/:tab?",
-  component: RealmSettingsSection,
+  component: lazy(() => import("../RealmSettingsSection")),
   breadcrumb: (t) => t("realmSettings"),
   access: "view-realm",
 };

--- a/src/realm-settings/routes/RsaGeneratedSettings.ts
+++ b/src/realm-settings/routes/RsaGeneratedSettings.ts
@@ -1,7 +1,7 @@
 import type { LocationDescriptorObject } from "history";
+import { lazy } from "react";
 import { generatePath } from "react-router-dom";
 import type { RouteDef } from "../../route-config";
-import { RSAGeneratedSettings } from "../key-providers/rsa-generated/RSAGeneratedForm";
 import { EditProviderCrumb } from "../RealmSettingsSection";
 
 export type RsaGeneratedSettingsParams = {
@@ -11,7 +11,9 @@ export type RsaGeneratedSettingsParams = {
 
 export const RsaGeneratedSettingsRoute: RouteDef = {
   path: "/:realm/realm-settings/keys/:id/rsa-generated/settings",
-  component: RSAGeneratedSettings,
+  component: lazy(
+    () => import("../key-providers/rsa-generated/RSAGeneratedForm")
+  ),
   breadcrumb: () => EditProviderCrumb,
   access: "view-realm",
 };

--- a/src/realm-settings/routes/RsaSettings.ts
+++ b/src/realm-settings/routes/RsaSettings.ts
@@ -1,7 +1,7 @@
 import type { LocationDescriptorObject } from "history";
+import { lazy } from "react";
 import { generatePath } from "react-router-dom";
 import type { RouteDef } from "../../route-config";
-import { RSASettings } from "../key-providers/rsa/RSAForm";
 import { EditProviderCrumb } from "../RealmSettingsSection";
 
 export type RsaSettingsParams = {
@@ -11,7 +11,7 @@ export type RsaSettingsParams = {
 
 export const RsaSettingsRoute: RouteDef = {
   path: "/:realm/realm-settings/keys/:id/rsa/settings",
-  component: RSASettings,
+  component: lazy(() => import("../key-providers/rsa/RSAForm")),
   breadcrumb: () => EditProviderCrumb,
   access: "view-realm",
 };

--- a/src/realm/add/NewRealmForm.tsx
+++ b/src/realm/add/NewRealmForm.tsx
@@ -20,7 +20,7 @@ import { useAdminClient } from "../../context/auth/AdminClient";
 import { useRealm } from "../../context/realm-context/RealmContext";
 import { useWhoAmI } from "../../context/whoami/WhoAmI";
 
-export const NewRealmForm = () => {
+const NewRealmForm = () => {
   const { t } = useTranslation("realm");
   const history = useHistory();
   const { refresh } = useWhoAmI();
@@ -118,3 +118,5 @@ export const NewRealmForm = () => {
     </>
   );
 };
+
+export default NewRealmForm;

--- a/src/realm/routes/AddRealm.ts
+++ b/src/realm/routes/AddRealm.ts
@@ -1,13 +1,13 @@
 import type { LocationDescriptorObject } from "history";
+import { lazy } from "react";
 import { generatePath } from "react-router-dom";
 import type { RouteDef } from "../../route-config";
-import { NewRealmForm } from "../add/NewRealmForm";
 
 export type AddRealmParams = { realm: string };
 
 export const AddRealmRoute: RouteDef = {
   path: "/:realm/add-realm",
-  component: NewRealmForm,
+  component: lazy(() => import("../add/NewRealmForm")),
   breadcrumb: (t) => t("realm:createRealm"),
   access: "manage-realm",
 };

--- a/src/sessions/SessionsSection.tsx
+++ b/src/sessions/SessionsSection.tsx
@@ -28,7 +28,7 @@ const Clients = (row: UserSessionRepresentation) => {
   );
 };
 
-export const SessionsSection = () => {
+const SessionsSection = () => {
   const { t } = useTranslation("sessions");
   const adminClient = useAdminClient();
   const [filterDropdownOpen, setFilterDropdownOpen] = useState(false);
@@ -141,3 +141,5 @@ export const SessionsSection = () => {
     </>
   );
 };
+
+export default SessionsSection;

--- a/src/sessions/routes/Sessions.ts
+++ b/src/sessions/routes/Sessions.ts
@@ -1,13 +1,13 @@
 import type { LocationDescriptorObject } from "history";
+import { lazy } from "react";
 import { generatePath } from "react-router-dom";
 import type { RouteDef } from "../../route-config";
-import { SessionsSection } from "../SessionsSection";
 
 export type SessionsParams = { realm: string };
 
 export const SessionsRoute: RouteDef = {
   path: "/:realm/sessions",
-  component: SessionsSection,
+  component: lazy(() => import("../SessionsSection")),
   breadcrumb: (t) => t("sessions:title"),
   access: "view-realm",
 };

--- a/src/user-federation/UserFederationKerberosSettings.tsx
+++ b/src/user-federation/UserFederationKerberosSettings.tsx
@@ -79,7 +79,7 @@ const KerberosSettingsHeader = ({
   );
 };
 
-export const UserFederationKerberosSettings = () => {
+const UserFederationKerberosSettings = () => {
   const { t } = useTranslation("user-federation");
   const form = useForm<ComponentRepresentation>({ mode: "onChange" });
   const history = useHistory();
@@ -198,3 +198,5 @@ export const UserFederationKerberosSettings = () => {
     </>
   );
 };
+
+export default UserFederationKerberosSettings;

--- a/src/user-federation/UserFederationLdapSettings.tsx
+++ b/src/user-federation/UserFederationLdapSettings.tsx
@@ -172,7 +172,7 @@ const LdapSettingsHeader = ({
   );
 };
 
-export const UserFederationLdapSettings = () => {
+const UserFederationLdapSettings = () => {
   const { t } = useTranslation("user-federation");
   const form = useForm<ComponentRepresentation>({ mode: "onChange" });
   const history = useHistory();
@@ -375,3 +375,5 @@ export const UserFederationLdapSettings = () => {
     </>
   );
 };
+
+export default UserFederationLdapSettings;

--- a/src/user-federation/UserFederationSection.tsx
+++ b/src/user-federation/UserFederationSection.tsx
@@ -26,7 +26,7 @@ import { useAdminClient, useFetch } from "../context/auth/AdminClient";
 import { useRealm } from "../context/realm-context/RealmContext";
 import "./user-federation.css";
 
-export const UserFederationSection = () => {
+const UserFederationSection = () => {
   const [userFederations, setUserFederations] =
     useState<ComponentRepresentation[]>();
   const { addAlert } = useAlerts();
@@ -205,3 +205,5 @@ export const UserFederationSection = () => {
     </>
   );
 };
+
+export default UserFederationSection;

--- a/src/user-federation/ldap/mappers/LdapMapperDetails.tsx
+++ b/src/user-federation/ldap/mappers/LdapMapperDetails.tsx
@@ -35,7 +35,7 @@ import { LdapMapperHardcodedAttribute } from "./LdapMapperHardcodedAttribute";
 import { LdapMapperRoleGroup } from "./LdapMapperRoleGroup";
 import { useRealm } from "../../../context/realm-context/RealmContext";
 
-export const LdapMapperDetails = () => {
+const LdapMapperDetails = () => {
   const form = useForm<ComponentRepresentation>();
   const [mapping, setMapping] = useState<ComponentRepresentation>();
 
@@ -398,3 +398,5 @@ export const LdapMapperDetails = () => {
     </>
   );
 };
+
+export default LdapMapperDetails;

--- a/src/user-federation/routes/NewKerberosUserFederation.ts
+++ b/src/user-federation/routes/NewKerberosUserFederation.ts
@@ -1,13 +1,13 @@
 import type { LocationDescriptorObject } from "history";
+import { lazy } from "react";
 import { generatePath } from "react-router-dom";
 import type { RouteDef } from "../../route-config";
-import { UserFederationKerberosSettings } from "../UserFederationKerberosSettings";
 
 export type NewKerberosUserFederationParams = { realm: string };
 
 export const NewKerberosUserFederationRoute: RouteDef = {
   path: "/:realm/user-federation/kerberos/new",
-  component: UserFederationKerberosSettings,
+  component: lazy(() => import("../UserFederationKerberosSettings")),
   breadcrumb: (t) => t("common:settings"),
   access: "view-realm",
 };

--- a/src/user-federation/routes/NewLdapUserFederation.ts
+++ b/src/user-federation/routes/NewLdapUserFederation.ts
@@ -1,13 +1,13 @@
 import type { LocationDescriptorObject } from "history";
+import { lazy } from "react";
 import { generatePath } from "react-router-dom";
 import type { RouteDef } from "../../route-config";
-import { UserFederationLdapSettings } from "../UserFederationLdapSettings";
 
 export type NewLdapUserFederationParams = { realm: string };
 
 export const NewLdapUserFederationRoute: RouteDef = {
   path: "/:realm/user-federation/ldap/new",
-  component: UserFederationLdapSettings,
+  component: lazy(() => import("../UserFederationLdapSettings")),
   breadcrumb: (t) => t("user-federation:addOneLdap"),
   access: "view-realm",
 };

--- a/src/user-federation/routes/UserFederation.ts
+++ b/src/user-federation/routes/UserFederation.ts
@@ -1,13 +1,13 @@
 import type { LocationDescriptorObject } from "history";
+import { lazy } from "react";
 import { generatePath } from "react-router-dom";
 import type { RouteDef } from "../../route-config";
-import { UserFederationSection } from "../UserFederationSection";
 
 export type UserFederationParams = { realm: string };
 
 export const UserFederationRoute: RouteDef = {
   path: "/:realm/user-federation",
-  component: UserFederationSection,
+  component: lazy(() => import("../UserFederationSection")),
   breadcrumb: (t) => t("userFederation"),
   access: "view-realm",
 };

--- a/src/user-federation/routes/UserFederationKerberos.ts
+++ b/src/user-federation/routes/UserFederationKerberos.ts
@@ -1,7 +1,7 @@
 import type { LocationDescriptorObject } from "history";
+import { lazy } from "react";
 import { generatePath } from "react-router-dom";
 import type { RouteDef } from "../../route-config";
-import { UserFederationKerberosSettings } from "../UserFederationKerberosSettings";
 
 export type UserFederationKerberosParams = {
   realm: string;
@@ -10,7 +10,7 @@ export type UserFederationKerberosParams = {
 
 export const UserFederationKerberosRoute: RouteDef = {
   path: "/:realm/user-federation/kerberos/:id",
-  component: UserFederationKerberosSettings,
+  component: lazy(() => import("../UserFederationKerberosSettings")),
   breadcrumb: (t) => t("common:settings"),
   access: "view-realm",
 };

--- a/src/user-federation/routes/UserFederationLdap.ts
+++ b/src/user-federation/routes/UserFederationLdap.ts
@@ -1,7 +1,7 @@
 import type { LocationDescriptorObject } from "history";
+import { lazy } from "react";
 import { generatePath } from "react-router-dom";
 import type { RouteDef } from "../../route-config";
-import { UserFederationLdapSettings } from "../UserFederationLdapSettings";
 
 export type UserFederationLdapParams = {
   realm: string;
@@ -11,7 +11,7 @@ export type UserFederationLdapParams = {
 
 export const UserFederationLdapRoute: RouteDef = {
   path: "/:realm/user-federation/ldap/:id/:tab?",
-  component: UserFederationLdapSettings,
+  component: lazy(() => import("../UserFederationLdapSettings")),
   breadcrumb: (t) => t("common:settings"),
   access: "view-realm",
 };

--- a/src/user-federation/routes/UserFederationLdapMapper.ts
+++ b/src/user-federation/routes/UserFederationLdapMapper.ts
@@ -1,7 +1,7 @@
 import type { LocationDescriptorObject } from "history";
+import { lazy } from "react";
 import { generatePath } from "react-router-dom";
 import type { RouteDef } from "../../route-config";
-import { LdapMapperDetails } from "../ldap/mappers/LdapMapperDetails";
 
 export type UserFederationLdapMapperParams = {
   realm: string;
@@ -12,7 +12,7 @@ export type UserFederationLdapMapperParams = {
 
 export const UserFederationLdapMapperRoute: RouteDef = {
   path: "/:realm/user-federation/ldap/:id/:tab/:mapperId",
-  component: LdapMapperDetails,
+  component: lazy(() => import("../ldap/mappers/LdapMapperDetails")),
   breadcrumb: (t) => t("common:mappingDetails"),
   access: "view-realm",
 };

--- a/src/user-federation/routes/UserFederationsKerberos.ts
+++ b/src/user-federation/routes/UserFederationsKerberos.ts
@@ -1,13 +1,13 @@
 import type { LocationDescriptorObject } from "history";
+import { lazy } from "react";
 import { generatePath } from "react-router-dom";
 import type { RouteDef } from "../../route-config";
-import { UserFederationSection } from "../UserFederationSection";
 
 export type UserFederationsKerberosParams = { realm: string };
 
 export const UserFederationsKerberosRoute: RouteDef = {
   path: "/:realm/user-federation/kerberos",
-  component: UserFederationSection,
+  component: lazy(() => import("../UserFederationSection")),
   access: "view-realm",
 };
 

--- a/src/user-federation/routes/UserFederationsLdap.ts
+++ b/src/user-federation/routes/UserFederationsLdap.ts
@@ -1,13 +1,13 @@
 import type { LocationDescriptorObject } from "history";
+import { lazy } from "react";
 import { generatePath } from "react-router-dom";
 import type { RouteDef } from "../../route-config";
-import { UserFederationSection } from "../UserFederationSection";
 
 export type UserFederationsLdapParams = { realm: string };
 
 export const UserFederationsLdapRoute: RouteDef = {
   path: "/:realm/user-federation/ldap",
-  component: UserFederationSection,
+  component: lazy(() => import("../UserFederationSection")),
   access: "view-realm",
 };
 

--- a/src/user/UsersSection.tsx
+++ b/src/user/UsersSection.tsx
@@ -31,7 +31,7 @@ type BruteUser = UserRepresentation & {
   brute?: Record<string, object>;
 };
 
-export const UsersSection = () => {
+const UsersSection = () => {
   const { t } = useTranslation("users");
   const adminClient = useAdminClient();
   const { addAlert } = useAlerts();
@@ -262,3 +262,5 @@ export const UsersSection = () => {
     </>
   );
 };
+
+export default UsersSection;

--- a/src/user/UsersTabs.tsx
+++ b/src/user/UsersTabs.tsx
@@ -20,7 +20,7 @@ import { UserConsents } from "./UserConsents";
 import type GroupRepresentation from "keycloak-admin/lib/defs/groupRepresentation";
 import { useRealm } from "../context/realm-context/RealmContext";
 
-export const UsersTabs = () => {
+const UsersTabs = () => {
   const { t } = useTranslation("roles");
   const { addAlert } = useAlerts();
   const history = useHistory();
@@ -124,3 +124,5 @@ export const UsersTabs = () => {
     </>
   );
 };
+
+export default UsersTabs;

--- a/src/user/routes/AddUser.ts
+++ b/src/user/routes/AddUser.ts
@@ -1,13 +1,13 @@
 import type { LocationDescriptorObject } from "history";
+import { lazy } from "react";
 import { generatePath } from "react-router-dom";
 import type { RouteDef } from "../../route-config";
-import { UsersTabs } from "../UsersTabs";
 
 export type AddUserParams = { realm: string };
 
 export const AddUserRoute: RouteDef = {
   path: "/:realm/users/add-user",
-  component: UsersTabs,
+  component: lazy(() => import("../UsersTabs")),
   breadcrumb: (t) => t("users:createUser"),
   access: "manage-users",
 };

--- a/src/user/routes/User.ts
+++ b/src/user/routes/User.ts
@@ -1,7 +1,7 @@
 import type { LocationDescriptorObject } from "history";
+import { lazy } from "react";
 import { generatePath } from "react-router-dom";
 import type { RouteDef } from "../../route-config";
-import { UsersTabs } from "../UsersTabs";
 
 export type UserTab = "settings" | "groups" | "consents";
 
@@ -13,7 +13,7 @@ export type UserParams = {
 
 export const UserRoute: RouteDef = {
   path: "/:realm/users/:id/:tab",
-  component: UsersTabs,
+  component: lazy(() => import("../UsersTabs")),
   breadcrumb: (t) => t("users:userDetails"),
   access: "manage-users",
 };

--- a/src/user/routes/Users.ts
+++ b/src/user/routes/Users.ts
@@ -1,13 +1,13 @@
 import type { LocationDescriptorObject } from "history";
+import { lazy } from "react";
 import { generatePath } from "react-router-dom";
 import type { RouteDef } from "../../route-config";
-import { UsersSection } from "../UsersSection";
 
 export type UsersParams = { realm: string };
 
 export const UsersRoute: RouteDef = {
   path: "/:realm/users",
-  component: UsersSection,
+  component: lazy(() => import("../UsersSection")),
   breadcrumb: (t) => t("users:title"),
   access: "query-users",
 };


### PR DESCRIPTION
## Motivation
Lazily loads components when the user navigates to a route using [`React.lazy()`](https://reactjs.org/docs/code-splitting.html#reactlazy). Doing this reduces the amount of code loaded on each page, increasing the percieved performance of the application.

Incidentally, this will also prevent errors when a component has a cyclic import to a route. 