### PR TITLE
Realm settings(localization): add locale dropdown to table

### DIFF
--- a/src/PageNav.tsx
+++ b/src/PageNav.tsx
@@ -7,6 +7,7 @@ import {
   NavGroup,
   NavList,
   PageSidebar,
+  Divider,
 } from "@patternfly/react-core";
 
 import { RealmSelector } from "./components/realm-selector/RealmSelector";
@@ -90,13 +91,9 @@ export const PageNav: React.FunctionComponent = () => {
               <RealmSelector />
             </NavItem>
           </NavList>
-          {!isOnAddRealm && (
-            <NavGroup title="">
-              <LeftNav title="home" path="/" />
-            </NavGroup>
-          )}
+          <Divider />
           {showManage && !isOnAddRealm && (
-            <NavGroup title={t("manage")}>
+            <NavGroup aria-label={t("manage")} title={t("manage")}>
               <LeftNav title="clients" path="/clients" />
               <LeftNav title="clientScopes" path="/client-scopes" />
               <LeftNav title="realmRoles" path="/roles" />
@@ -108,7 +105,7 @@ export const PageNav: React.FunctionComponent = () => {
           )}
 
           {showConfigure && !isOnAddRealm && (
-            <NavGroup title={t("configure")}>
+            <NavGroup aria-label={t("configure")} title={t("configure")}>
               <LeftNav title="realmSettings" path="/realm-settings" />
               <LeftNav title="authentication" path="/authentication" />
               <LeftNav title="identityProviders" path="/identity-providers" />

--- a/src/components/table-toolbar/KeycloakDataTable.tsx
+++ b/src/components/table-toolbar/KeycloakDataTable.tsx
@@ -375,6 +375,7 @@ export function KeycloakDataTable<T>({
       {((data && data.length > 0) ||
         search !== "" ||
         isSearching ||
+        emptyState ||
         loading) && (
         <PaginatingTableToolbar
           count={data?.length || 0}
@@ -413,7 +414,8 @@ export function KeycloakDataTable<T>({
           {!loading &&
             (!data || data.length === 0) &&
             (search !== "" || !isSearching) &&
-            searchPlaceholderKey && (
+            searchPlaceholderKey &&
+            !emptyState && (
               <ListEmptyState
                 hasIcon={true}
                 icon={icon}

--- a/src/realm-settings/LocalizationTab.tsx
+++ b/src/realm-settings/LocalizationTab.tsx
@@ -5,13 +5,16 @@ import {
   ActionGroup,
   AlertVariant,
   Button,
+  Divider,
   FormGroup,
   PageSection,
   Select,
+  SelectGroup,
   SelectOption,
   SelectVariant,
   Switch,
   TextContent,
+  ToolbarItem,
 } from "@patternfly/react-core";
 
 import type RealmRepresentation from "keycloak-admin/lib/defs/realmRepresentation";
@@ -42,19 +45,21 @@ export const LocalizationTab = ({
   save,
   reset,
   realm,
-  refresh,
 }: LocalizationTabProps) => {
   const { t } = useTranslation("realm-settings");
   const adminClient = useAdminClient();
   const [addMessageBundleModalOpen, setAddMessageBundleModalOpen] =
     useState(false);
-  const [key, setKey] = useState(0);
 
   const [supportedLocalesOpen, setSupportedLocalesOpen] = useState(false);
   const [defaultLocaleOpen, setDefaultLocaleOpen] = useState(false);
+  const [filterDropdownOpen, setFilterDropdownOpen] = useState(false);
+  const [selectMenuLocale, setSelectMenuLocale] = useState("en");
 
-  const { getValues, control, handleSubmit } = useFormContext();
+  const { getValues, control, handleSubmit, formState } = useFormContext();
   const [valueSelected, setValueSelected] = useState(false);
+  const [selectMenuValueSelected, setSelectMenuValueSelected] = useState(false);
+
   const themeTypes = useServerInfo().themes!;
   const bundleForm = useForm<BundleForm>({ mode: "onChange" });
   const { addAlert, addError } = useAlerts();
@@ -76,7 +81,18 @@ export const LocalizationTab = ({
     try {
       const result = await adminClient.realms.getRealmLocalizationTexts({
         realm: realm.realm!,
-        selectedLocale: getValues("defaultLocale") || "en",
+        selectedLocale: selectMenuLocale || getValues("defaultLocale") || "en",
+      });
+      return Object.keys(result).map((key) => [key, result[key]]);
+    }
+    return [[]];
+  };
+
+  const tableLoader = async () => {
+    if (realm) {
+      const result = await adminClient.realms.getRealmLocalizationTexts({
+        realm: currentRealm,
+        selectedLocale: selectMenuLocale,
       });
       return Object.keys(result).map((key) => [key, result[key]]);
     } catch (error) {
@@ -88,6 +104,34 @@ export const LocalizationTab = ({
     setAddMessageBundleModalOpen(!addMessageBundleModalOpen);
   };
 
+  const options = [
+    <SelectGroup label={t("defaultLocale")} key="group1">
+      {watchSupportedLocales
+        .filter((item) => item === realm?.defaultLocale)
+        .map((locale) => (
+          <SelectOption key={locale} value={locale}>
+            {t(`allSupportedLocales.${locale}`)}
+          </SelectOption>
+        ))}
+    </SelectGroup>,
+    <Divider key="divider" />,
+    <SelectGroup label={t("supportedLocales")} key="group2">
+      {watchSupportedLocales
+        .filter((item) => item !== realm?.defaultLocale)
+        .map((locale) => (
+          <SelectOption key={locale} value={locale}>
+            {t(`allSupportedLocales.${locale}`)}
+          </SelectOption>
+        ))}
+    </SelectGroup>,
+  ];
+
+  const [tableKey, setTableKey] = useState(0);
+
+  const refreshTable = () => {
+    setTableKey(new Date().getTime());
+  };
+
   const addKeyValue = async (pair: KeyValueType): Promise<void> => {
     try {
       adminClient.setConfig({
@@ -96,7 +140,8 @@ export const LocalizationTab = ({
       await adminClient.realms.addLocalization(
         {
           realm: currentRealm!,
-          selectedLocale: getValues("defaultLocale") || "en",
+          selectedLocale:
+            selectMenuLocale || getValues("defaultLocale") || "en",
           key: pair.key,
         },
         pair.value
@@ -105,7 +150,7 @@ export const LocalizationTab = ({
       adminClient.setConfig({
         realmName: currentRealm!,
       });
-      refresh();
+      refreshTable();
       addAlert(t("pairCreatedSuccess"), AlertVariant.success);
     } catch (error) {
       addError("realm-settings:pairCreatedError", error);
@@ -230,7 +275,6 @@ export const LocalizationTab = ({
                         onSelect={(_, value) => {
                           onChange(value as string);
                           setValueSelected(true);
-                          setKey(new Date().getTime());
                           setDefaultLocaleOpen(false);
                         }}
                         selections={
@@ -269,6 +313,7 @@ export const LocalizationTab = ({
             <ActionGroup>
               <Button
                 variant="primary"
+                isDisabled={!formState.isDirty}
                 type="submit"
                 data-testid="localization-tab-save"
               >
@@ -287,12 +332,42 @@ export const LocalizationTab = ({
           </TextContent>
           <div className="tableBorder">
             <KeycloakDataTable
-              key={key}
-              loader={loader}
-              ariaLabelKey="client-scopes:clientScopeList"
+              key={tableKey}
+              isSearching
+              loader={selectMenuValueSelected ? tableLoader : loader}
+              ariaLabelKey="realm-settings:localization"
+              searchTypeComponent={
+                <ToolbarItem>
+                  <Select
+                    width={180}
+                    data-testid="filter-by-locale-select"
+                    isOpen={filterDropdownOpen}
+                    className="kc-filter-by-locale-select"
+                    variant={SelectVariant.single}
+                    isDisabled={!formState.isSubmitSuccessful}
+                    onToggle={(isExpanded) => setFilterDropdownOpen(isExpanded)}
+                    onSelect={(_, value) => {
+                      setSelectMenuLocale(value.toString());
+                      setSelectMenuValueSelected(true);
+                      refreshTable();
+                      setFilterDropdownOpen(false);
+                    }}
+                    selections={
+                      selectMenuValueSelected
+                        ? t(`allSupportedLocales.${selectMenuLocale}`)
+                        : realm.defaultLocale !== ""
+                        ? t(`allSupportedLocales.${"en"}`)
+                        : t("placeholderText")
+                    }
+                  >
+                    {options}
+                  </Select>
+                </ToolbarItem>
+              }
               toolbarItem={
                 <Button
                   data-testid="add-bundle-button"
+                  isDisabled={!formState.isSubmitSuccessful}
                   onClick={() => setAddMessageBundleModalOpen(true)}
                 >
                   {t("addMessageBundle")}

--- a/src/realm-settings/LocalizationTab.tsx
+++ b/src/realm-settings/LocalizationTab.tsx
@@ -84,12 +84,13 @@ export const LocalizationTab = ({
         selectedLocale: selectMenuLocale || getValues("defaultLocale") || "en",
       });
       return Object.keys(result).map((key) => [key, result[key]]);
+    } catch (error) {
+      return [[]];
     }
-    return [[]];
   };
 
   const tableLoader = async () => {
-    if (realm) {
+    try {
       const result = await adminClient.realms.getRealmLocalizationTexts({
         realm: currentRealm,
         selectedLocale: selectMenuLocale,

--- a/src/realm-settings/LocalizationTab.tsx
+++ b/src/realm-settings/LocalizationTab.tsx
@@ -83,9 +83,10 @@ export const LocalizationTab = ({
         realm: realm.realm!,
         selectedLocale: selectMenuLocale || getValues("defaultLocale") || "en",
       });
-      return Object.keys(result).map((key) => [key, result[key]]);
+
+      return Object.entries(result);
     } catch (error) {
-      return [[]];
+      return [];
     }
   };
 
@@ -95,9 +96,10 @@ export const LocalizationTab = ({
         realm: currentRealm,
         selectedLocale: selectMenuLocale,
       });
-      return Object.keys(result).map((key) => [key, result[key]]);
+
+      return Object.entries(result);
     } catch (error) {
-      return [[]];
+      return [];
     }
   };
 

--- a/src/realm-settings/RealmSettingsSection.tsx
+++ b/src/realm-settings/RealmSettingsSection.tsx
@@ -310,7 +310,6 @@ export const RealmSettingsSection = () => {
             >
               <EventsTab />
             </Tab>
-
             <Tab
               id="localization"
               eventKey="localization"


### PR DESCRIPTION
## Motivation
<!-- Add references to relevant tickets, issues, design specs and/or a short description of what motivated you to do it. -->
https://issues.redhat.com/browse/APPDUX-1066

## Brief Description
<!-- Add a short answer for: 
What was done in this PR? (e.g Fix to prevent users from accessing feature X.)
Why it was done? (e.g Feature X was deprecated.)
-->
Adds locale filter to message bundle table as shown in https://marvelapp.com/prototype/56d9606/screen/76458142

## Verification Steps
<!--
Add the steps required to verify this change. Keep in mind that these steps should be written so groups unfamiliar with the 
new functionality can follow them, such as QE or documentation.-->


1. Go to `RealmSettings.tsx` and uncomment the Localization tab.
2. Go to Realm Settings -> Localization.
3. As per the design, the locale filter in the table should be disabled until the form above is modified and saved.
4. Save the form and verify that the new locale select filter works as expected.

## Checklist:

- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [x] Help has been implemented
- [x] axe report has been run and resulting a11y issues have been resolved
- [x] Unit tests have been created/updated

## Additional Notes
<!-- 
Add images and/or screen caps to illustrate what was changed if this pull request adds to or modifies existing user-visible appearance/output. 
-->
