### PR TITLE
Add scripts needed for release.

### DIFF
--- a/get-version.sh
+++ b/get-version.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -e
+
+awk '/"version":/ { print $2 }' package.json | sed 's/"//g' | sed 's/,//'

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -e
+
+VERSION=`./get-version.sh`
+echo "Version: $VERSION"
+
+echo "------------------------------------------------------------------------------------------------------------"
+echo "Building:"
+echo ""
+
+mvn --file=./keycloak-theme/pom.xml -DretryFailedDeploymentCount=10 -DautoReleaseAfterClose=true clean deploy
+
+echo "------------------------------------------------------------------------------------------------------------"
+echo "Create tag:"
+echo ""
+
+git tag $VERSION
+git push origin $VERSION
+
+echo "------------------------------------------------------------------------------------------------------------"
+echo "Upload to GitHub releases:"
+echo ""
+
+hub release create -m "$VERSION" $VERSION

--- a/set-version.sh
+++ b/set-version.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -e
+
+NEW_VERSION=$1
+sed -i 's/"version": .*/"version": "'$NEW_VERSION'",/' package.json
+mvn --file=./keycloak-theme/pom.xml versions:set -DnewVersion=$NEW_VERSION -DgenerateBackupPoms=false -DgroupId=org.keycloak* -DartifactId=*


### PR DESCRIPTION
## Brief Description
This PR contains our "Keycloak standard" scripts needed to do a release.  They are based on the scripts used in other Keycloak projects.

## Verification Steps
I was only able to verify that `get-version.sh` and `set-version.sh` are working properly.  `release.sh` requires our org.keycloak credentials to the maven central repo, so I think only Stian can run it.

As a Windows user, I don't write a lot of shell scripts.  So please review and let me know if you see anything obviously wrong, especially with `release.sh`.