### PR TITLE
change to TextInput when editing 

### DIFF
--- a/src/components/password-input/PasswordInput.tsx
+++ b/src/components/password-input/PasswordInput.tsx
@@ -8,7 +8,15 @@ import {
 } from "@patternfly/react-core";
 import { EyeIcon, EyeSlashIcon } from "@patternfly/react-icons";
 
-const PasswordInputBase = ({ innerRef, ...rest }: TextInputProps) => {
+type PasswordInputProps = TextInputProps & {
+  hasReveal?: boolean;
+};
+
+const PasswordInputBase = ({
+  hasReveal = true,
+  innerRef,
+  ...rest
+}: PasswordInputProps) => {
   const { t } = useTranslation("common-help");
   const [hidePassword, setHidePassword] = useState(true);
   return (
@@ -18,19 +26,21 @@ const PasswordInputBase = ({ innerRef, ...rest }: TextInputProps) => {
         type={hidePassword ? "password" : "text"}
         ref={innerRef}
       />
-      <Button
-        variant="control"
-        aria-label={t("showPassword")}
-        onClick={() => setHidePassword(!hidePassword)}
-      >
-        {hidePassword ? <EyeIcon /> : <EyeSlashIcon />}
-      </Button>
+      {hasReveal && (
+        <Button
+          variant="control"
+          aria-label={t("showPassword")}
+          onClick={() => setHidePassword(!hidePassword)}
+        >
+          {hidePassword ? <EyeIcon /> : <EyeSlashIcon />}
+        </Button>
+      )}
     </InputGroup>
   );
 };
 
 export const PasswordInput = React.forwardRef(
-  (props: TextInputProps, ref: React.Ref<HTMLInputElement>) => (
+  (props: PasswordInputProps, ref: React.Ref<HTMLInputElement>) => (
     <PasswordInputBase
       {...props}
       innerRef={ref as React.MutableRefObject<any>}

--- a/src/user-federation/UserFederationLdapSettings.tsx
+++ b/src/user-federation/UserFederationLdapSettings.tsx
@@ -298,7 +298,7 @@ export const UserFederationLdapSettings = () => {
           ]}
         >
           <LdapSettingsGeneral form={form} />
-          <LdapSettingsConnection form={form} />
+          <LdapSettingsConnection form={form} edit={!!id} />
           <LdapSettingsSearching form={form} />
           <LdapSettingsSynchronization form={form} />
           <LdapSettingsKerberosIntegration form={form} />

--- a/src/user-federation/ldap/LdapSettingsConnection.tsx
+++ b/src/user-federation/ldap/LdapSettingsConnection.tsx
@@ -27,6 +27,7 @@ export type LdapSettingsConnectionProps = {
   form: UseFormMethods;
   showSectionHeading?: boolean;
   showSectionDescription?: boolean;
+  edit?: boolean;
 };
 
 const testLdapProperties: Array<keyof TestLdapConnectionRepresentation> = [
@@ -43,6 +44,7 @@ export const LdapSettingsConnection = ({
   form,
   showSectionHeading = false,
   showSectionDescription = false,
+  edit = false,
 }: LdapSettingsConnectionProps) => {
   const { t } = useTranslation("user-federation");
   const { t: helpText } = useTranslation("user-federation-help");
@@ -77,6 +79,8 @@ export const LdapSettingsConnection = ({
     control: form.control,
     name: "config.authType",
   });
+
+  const PasswordComponent = edit ? TextInput : PasswordInput;
 
   return (
     <>
@@ -326,7 +330,7 @@ export const LdapSettingsConnection = ({
               }
               isRequired
             >
-              <PasswordInput
+              <PasswordComponent
                 isRequired
                 id="kc-console-bind-credentials"
                 data-testid="ldap-bind-credentials"

--- a/src/user-federation/ldap/LdapSettingsConnection.tsx
+++ b/src/user-federation/ldap/LdapSettingsConnection.tsx
@@ -80,8 +80,6 @@ export const LdapSettingsConnection = ({
     name: "config.authType",
   });
 
-  const PasswordComponent = edit ? TextInput : PasswordInput;
-
   return (
     <>
       {showSectionHeading && (
@@ -330,7 +328,8 @@ export const LdapSettingsConnection = ({
               }
               isRequired
             >
-              <PasswordComponent
+              <PasswordInput
+                hasReveal={!edit}
                 isRequired
                 id="kc-console-bind-credentials"
                 data-testid="ldap-bind-credentials"


### PR DESCRIPTION
Because keycloak doesn't store the password as clear text and returns the password as '***' it doesn't make sense to reveal the text

fixes: #971