### PR TITLE
Fix loginRealm to work on old and new Keycloak

### DIFF
--- a/keycloak-theme/pom.xml
+++ b/keycloak-theme/pom.xml
@@ -137,7 +137,7 @@
 <![CDATA[
   <script id="environment" type="application/json">
     {
-      "loginRealm": "master",
+      "loginRealm": "${loginRealm!"master"}",
       "authServerUrl": "${authServerUrl}",
       "authUrl": "${authUrl}",
       "consoleBaseUrl": "${consoleBaseUrl}",


### PR DESCRIPTION
## Motivation
`loginRealm` in `index.ftl` is currently hard-coded to "master".

## Brief Description
Change so that new Keycloak server code that passes the value for `loginRealm` can provide that value.  For older Keycloak servers, it will continue to default to "master"

## Verification Steps
CI can verify if this is working in the default case.  You won't be able to test passing the `loginRealm` to the Freemarker template until my PR is integrated into Keycloak server.

## Checklist:

- [X] Code has been tested locally by PR requester
