### PR TITLE
Disable major updates of broken dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,12 @@ updates:
   open-pull-requests-limit: 999
   schedule:
     interval: weekly
+  ignore:
+    - dependency-name: jest
+      update-types: ["version-update:semver-major"]
+    - dependency-name: "@types/jest"
+      update-types: ["version-update:semver-major"]
+    - dependency-name: ts-jest
+      update-types: ["version-update:semver-major"]
+    - dependency-name: react-hook-form
+      update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Motivation
Prevents Dependabot from creating PRs that try to update major versions of dependencies that are known to cause issues.