### PR TITLE
Prefer Array#includes() over Array#indexOf()

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,9 @@
 /** @type {import("eslint").Linter.Config } */
 module.exports = {
   root: true,
+  parserOptions: {
+    project: './tsconfig.json',
+  },
   env: {
     node: true,
   },
@@ -17,7 +20,9 @@ module.exports = {
     },
   },
   rules: {
-    // Always prefer using an optional chain expression, as it's more concise and easier to read.
+    // Prefer using `includes()` to check if values exist over `indexOf() === -1`, as it's a more appropriate API for this.
+    "@typescript-eslint/prefer-includes": "error",
+    // Prefer using an optional chain expression, as it's more concise and easier to read.
     "@typescript-eslint/prefer-optional-chain": "error",
     "no-unused-vars": "off",
     "@typescript-eslint/no-unused-vars": "error",

--- a/src/clients/ClientsSection.tsx
+++ b/src/clients/ClientsSection.tsx
@@ -171,7 +171,7 @@ export const ClientsSection = () => {
                     if (client.rootUrl) {
                       if (
                         !client.rootUrl.startsWith("http") ||
-                        client.rootUrl.indexOf("$") !== -1
+                        client.rootUrl.includes("$")
                       ) {
                         client.rootUrl =
                           client.rootUrl

--- a/src/components/bread-crumb/GroupBreadCrumbs.tsx
+++ b/src/components/bread-crumb/GroupBreadCrumbs.tsx
@@ -16,7 +16,7 @@ export const GroupBreadCrumbs = () => {
 
   useEffect(() => {
     return history.listen(({ pathname }) => {
-      if (pathname.indexOf("/groups") === -1 || pathname.endsWith("/groups")) {
+      if (!pathname.includes("/groups") || pathname.endsWith("/groups")) {
         clear();
       }
     });

--- a/src/components/keycloak-tabs/KeycloakTabs.tsx
+++ b/src/components/keycloak-tabs/KeycloakTabs.tsx
@@ -15,7 +15,7 @@ const createUrl = (
   let url = path;
   for (const key in params) {
     const value = params[key];
-    if (url.indexOf(key) !== -1) {
+    if (url.includes(key)) {
       url = url.replace(new RegExp(`:${key}\\??`), value || "");
     }
   }

--- a/src/identity-providers/add/DetailSettings.tsx
+++ b/src/identity-providers/add/DetailSettings.tsx
@@ -133,7 +133,7 @@ export const DetailSettings = () => {
   });
 
   const sections = [t("generalSettings"), t("advancedSettings")];
-  const isOIDC = id.indexOf("oidc") !== -1;
+  const isOIDC = id.includes("oidc");
 
   if (isOIDC) {
     sections.splice(1, 0, t("oidcSettings"));

--- a/src/user-federation/ldap/mappers/LdapMapperList.tsx
+++ b/src/user-federation/ldap/mappers/LdapMapperList.tsx
@@ -69,7 +69,7 @@ export const LdapMapperList = () => {
   });
 
   const getUrl = (url: string) => {
-    if (url.indexOf("/mappers") === -1) {
+    if (!url.includes("/mappers")) {
       return `${url}/mappers`;
     }
     return `${url}`;


### PR DESCRIPTION
Change code to prefer using `includes()` over `indexOf() === -1` to check if items exist in an array. Also adds an ESLint rule to enforce this.

## Motivation
This comes up as a review comment every once and a while, enforcing it as a rule will prevent some trivial review comments.
