### PR TITLE
Add a constant for the default locale

### DIFF
--- a/src/context/whoami/WhoAmI.tsx
+++ b/src/context/whoami/WhoAmI.tsx
@@ -2,7 +2,7 @@ import type WhoAmIRepresentation from "keycloak-admin/lib/defs/whoAmIRepresentat
 import type { AccessType } from "keycloak-admin/lib/defs/whoAmIRepresentation";
 import React, { FunctionComponent, useState } from "react";
 import environment from "../../environment";
-import i18n from "../../i18n";
+import i18n, { DEFAULT_LOCALE } from "../../i18n";
 import useRequiredContext from "../../utils/useRequiredContext";
 import { useAdminClient, useFetch } from "../auth/AdminClient";
 
@@ -19,6 +19,10 @@ export class WhoAmI {
     if (this.me === undefined) return "";
 
     return this.me.displayName;
+  }
+
+  public getLocale() {
+    return this.me?.locale ?? DEFAULT_LOCALE;
   }
 
   public getRealm() {

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -25,6 +25,8 @@ import userFederationHelp from "./user-federation/help";
 import identityProviders from "./identity-providers/messages";
 import identityProvidersHelp from "./identity-providers/help";
 
+export const DEFAULT_LOCALE = "en";
+
 const initOptions = {
   defaultNS: "common",
   resources: {
@@ -55,8 +57,8 @@ const initOptions = {
       ...userFederationHelp,
     },
   },
-  lng: "en",
-  fallbackLng: "en",
+  lng: DEFAULT_LOCALE,
+  fallbackLng: DEFAULT_LOCALE,
 
   interpolation: {
     escapeValue: false,

--- a/src/realm-settings/LocalizationTab.tsx
+++ b/src/realm-settings/LocalizationTab.tsx
@@ -27,6 +27,7 @@ import { ListEmptyState } from "../components/list-empty-state/ListEmptyState";
 import { AddMessageBundleModal } from "./AddMessageBundleModal";
 import { useAlerts } from "../components/alert/Alerts";
 import { useRealm } from "../context/realm-context/RealmContext";
+import { DEFAULT_LOCALE } from "../i18n";
 
 type LocalizationTabProps = {
   save: (realm: RealmRepresentation) => void;
@@ -54,7 +55,7 @@ export const LocalizationTab = ({
   const [supportedLocalesOpen, setSupportedLocalesOpen] = useState(false);
   const [defaultLocaleOpen, setDefaultLocaleOpen] = useState(false);
   const [filterDropdownOpen, setFilterDropdownOpen] = useState(false);
-  const [selectMenuLocale, setSelectMenuLocale] = useState("en");
+  const [selectMenuLocale, setSelectMenuLocale] = useState(DEFAULT_LOCALE);
 
   const { getValues, control, handleSubmit, formState } = useFormContext();
   const [valueSelected, setValueSelected] = useState(false);
@@ -81,7 +82,8 @@ export const LocalizationTab = ({
     try {
       const result = await adminClient.realms.getRealmLocalizationTexts({
         realm: realm.realm!,
-        selectedLocale: selectMenuLocale || getValues("defaultLocale") || "en",
+        selectedLocale:
+          selectMenuLocale || getValues("defaultLocale") || DEFAULT_LOCALE,
       });
 
       return Object.entries(result);
@@ -144,7 +146,7 @@ export const LocalizationTab = ({
         {
           realm: currentRealm!,
           selectedLocale:
-            selectMenuLocale || getValues("defaultLocale") || "en",
+            selectMenuLocale || getValues("defaultLocale") || DEFAULT_LOCALE,
           key: pair.key,
         },
         pair.value
@@ -286,7 +288,7 @@ export const LocalizationTab = ({
                             : realm.defaultLocale !== ""
                             ? t(
                                 `allSupportedLocales.${
-                                  realm.defaultLocale || "en"
+                                  realm.defaultLocale || DEFAULT_LOCALE
                                 }`
                               )
                             : t("placeholderText")
@@ -359,7 +361,7 @@ export const LocalizationTab = ({
                       selectMenuValueSelected
                         ? t(`allSupportedLocales.${selectMenuLocale}`)
                         : realm.defaultLocale !== ""
-                        ? t(`allSupportedLocales.${"en"}`)
+                        ? t(`allSupportedLocales.${DEFAULT_LOCALE}`)
                         : t("placeholderText")
                     }
                   >


### PR DESCRIPTION
Adds a constant for the default locale for this application. Also adds a `getLocale()` method to `WhoAmI` to get the locale preferred by the user.

## Motivation
Having a single constant for the default locale will make it easier to refactor the application. This is also required for a later PR that will take advantage of the `getLocale()` method for `WhoAmI`.