### PR TITLE
Add action to automatically publish snapshots

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,22 @@
+name: Publish package
+on:
+  push:
+    branches: [master]
+defaults:
+  run:
+    working-directory: keycloak-theme
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions: 
+      contents: read
+      packages: write 
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v2
+        with:
+          java-version: 11
+          distribution: adopt
+      - run: mvn --batch-mode deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/keycloak-theme/pom.xml
+++ b/keycloak-theme/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>org.keycloak</groupId>
     <artifactId>keycloak-admin-ui</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>16.0.0-SNAPSHOT</version>
     <name>Keycloak Administration UI</name>
 
     <licenses>
@@ -31,15 +31,13 @@
         </license>
     </licenses>
 
-    <repositories>
+    <distributionManagement>
         <repository>
-            <id>jboss</id>
-            <url>https://repository.jboss.org/nexus/content/groups/public/</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
+            <id>github</id>
+            <name>GitHub Packages</name>
+            <url>https://maven.pkg.github.com/keycloak/keycloak-admin-ui</url>
         </repository>
-    </repositories>
+    </distributionManagement>
 
     <build>
         <plugins>


### PR DESCRIPTION
## Motivation
This will allow us to automatically publish a snapshot version on every commit on master, which can be used to in the main Keycloak project to include the latest changes from the Admin Console. For more information see @ssilvert's PR https://github.com/keycloak/keycloak/pull/8366
