### PR TITLE
Identity Providers(SAML): Adds data table for SAML mappers

### DIFF
--- a/src/identity-providers/IdentityProvidersSection.tsx
+++ b/src/identity-providers/IdentityProvidersSection.tsx
@@ -75,8 +75,8 @@ export const IdentityProvidersSection = () => {
       key={identityProvider.providerId}
       to={toIdentityProviderTab({
         realm,
-        providerId: identityProvider?.providerId,
-        alias: identityProvider?.alias!,
+        providerId: identityProvider.providerId,
+        alias: identityProvider.alias!,
       })}
     >
       {identityProvider.displayName

--- a/src/identity-providers/IdentityProvidersSection.tsx
+++ b/src/identity-providers/IdentityProvidersSection.tsx
@@ -75,8 +75,8 @@ export const IdentityProvidersSection = () => {
       key={identityProvider.providerId}
       to={toIdentityProviderTab({
         realm,
-        providerId: identityProvider.providerId!,
-        alias: identityProvider.alias!,
+        providerId: identityProvider?.providerId,
+        alias: identityProvider?.alias!,
       })}
     >
       {identityProvider.displayName

--- a/src/identity-providers/add/AddIdentityProvider.tsx
+++ b/src/identity-providers/add/AddIdentityProvider.tsx
@@ -18,6 +18,7 @@ import { useAdminClient } from "../../context/auth/AdminClient";
 import { useRealm } from "../../context/realm-context/RealmContext";
 import { useAlerts } from "../../components/alert/Alerts";
 import { GeneralSettings } from "./GeneralSettings";
+import { toIdentityProviderTab } from "../routes/IdentityProviderTab";
 
 export const IdentityProviderCrumb = ({ match, location }: BreadcrumbData) => {
   const { t } = useTranslation();
@@ -61,10 +62,10 @@ export const AddIdentityProvider = () => {
       await adminClient.identityProviders.create({
         ...provider,
         providerId: id,
-        alias: provider.alias,
+        alias: id,
       });
       addAlert(t("createSuccess"), AlertVariant.success);
-      history.push(`/${realm}/identity-providers/${id}/settings`);
+      history.push(toIdentityProviderTab({ realm, providerId: id, alias: id }));
     } catch (error) {
       addError("identity-providers:createError", error);
     }

--- a/src/identity-providers/add/AddIdentityProvider.tsx
+++ b/src/identity-providers/add/AddIdentityProvider.tsx
@@ -61,7 +61,7 @@ export const AddIdentityProvider = () => {
       await adminClient.identityProviders.create({
         ...provider,
         providerId: id,
-        alias: id,
+        alias: provider.alias,
       });
       addAlert(t("createSuccess"), AlertVariant.success);
       history.push(`/${realm}/identity-providers/${id}/settings`);

--- a/src/identity-providers/add/DetailSettings.tsx
+++ b/src/identity-providers/add/DetailSettings.tsx
@@ -160,15 +160,15 @@ export const DetailSettings = () => {
     ]);
 
     const components = loaderMappers.map((loaderMapper) => {
-      const provider = Object.values(loaderMapperTypes).filter(
+      const mapperType = Object.values(loaderMapperTypes).find(
         (loaderMapperType) =>
           loaderMapper.identityProviderMapper! === loaderMapperType.id!
       );
 
       const result: IdPWithMapperAttributes = {
-        ...provider[0],
+        ...mapperType,
         name: loaderMapper.name!,
-        type: provider[0].name!,
+        type: mapperType?.name!,
       };
 
       return result;

--- a/src/identity-providers/add/DetailSettings.tsx
+++ b/src/identity-providers/add/DetailSettings.tsx
@@ -97,7 +97,7 @@ export const DetailSettings = () => {
     useParams<{ providerId: string; alias: string }>();
 
   const form = useForm<IdentityProviderRepresentation>();
-  const { handleSubmit, setValue, getValues, reset } = form;
+  const { handleSubmit, getValues, reset } = form;
 
   const adminClient = useAdminClient();
   const { addAlert, addError } = useAlerts();
@@ -106,9 +106,8 @@ export const DetailSettings = () => {
 
   useFetch(
     () => adminClient.identityProviders.findOne({ alias: alias }),
-    (provider) => {
-      Object.entries(provider).forEach(([key, value]) => setValue(key, value));
-    },
+    (fetchedProvider) => {
+      reset(fetchedProvider);
     },
     []
   );

--- a/src/identity-providers/add/DetailSettings.tsx
+++ b/src/identity-providers/add/DetailSettings.tsx
@@ -105,16 +105,10 @@ export const DetailSettings = () => {
   const { realm } = useRealm();
 
   useFetch(
-    () =>
-      Promise.resolve([
-        adminClient.identityProviders.findOne({ alias: alias }),
-      ]),
-    async ([fetchedProvider]) => {
-      if (fetchedProvider) {
-        Object.entries(fetchedProvider).map(([key, value]) =>
-          setValue(key, value)
-        );
-      }
+    () => adminClient.identityProviders.findOne({ alias: alias }),
+    (provider) => {
+      Object.entries(provider).forEach(([key, value]) => setValue(key, value));
+    },
     },
     []
   );

--- a/src/identity-providers/messages.ts
+++ b/src/identity-providers/messages.ts
@@ -5,6 +5,12 @@ export default {
     searchForProvider: "Search for provider",
     provider: "Provider details",
     addProvider: "Add provider",
+    addMapper: "Add mapper",
+    mappersList: "Mappers list",
+    noMappers: "No Mappers",
+    noMappersInstructions:
+      "There are currently no mappers for this identity provider.",
+    searchForMapper: "Search for mapper",
     addKeycloakOpenIdProvider: "Add Keycloak OpenID Connect provider",
     addOpenIdProvider: "Add OpenID Connect provider",
     addSamlProvider: "Add SAML provider",

--- a/src/identity-providers/routes/IdentityProviderTab.ts
+++ b/src/identity-providers/routes/IdentityProviderTab.ts
@@ -13,7 +13,7 @@ export type IdentityProviderTabParams = {
 };
 
 export const IdentityProviderTabRoute: RouteDef = {
-  path: "/:realm/identity-providers/:providerId/:alias/:tab?",
+  path: "/:realm/identity-providers/:providerId?/:alias/:tab?",
   component: DetailSettings,
   access: "manage-identity-providers",
 };


### PR DESCRIPTION
## Motivation
<!-- Add references to relevant tickets, issues, design specs and/or a short description of what motivated you to do it. -->
https://issues.redhat.com/browse/CLUX-223

## Brief Description
<!-- Add a short answer for: 
What was done in this PR? (e.g Fix to prevent users from accessing feature X.)
Why it was done? (e.g Feature X was deprecated.)
-->
Adds data table for mappers of SAML Identity Providers

## Verification Steps
<!--
Add the steps required to verify this change. Keep in mind that these steps should be written so groups unfamiliar with the 
new functionality can follow them, such as QE or documentation.
-->

1. In the old console, go to Identity Providers -> Add Provider -> SAML v2.0
2. Save the new provider and scroll up to the Mappers tab.
3. Click the mappers tab and create a few mappers with different names and mapper types.
4. Now in the new console, go to Identity Providers and click on the SAML provider you created.
5. Click the Mappers tab and verify the data matches the table in the old console 


## Checklist:

- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [x] Help has been implemented
- [x] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated

## Additional Notes
<!-- 
Add images and/or screen caps to illustrate what was changed if this pull request adds to or modifies existing user-visible appearance/output. 
-->
