### PR TITLE
Don't complain about Windows line endings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,7 +2,7 @@
 module.exports = {
   root: true,
   parserOptions: {
-    project: './tsconfig.json',
+    project: "./tsconfig.json",
   },
   env: {
     node: true,
@@ -31,7 +31,13 @@ module.exports = {
     // https://github.com/yannickcr/eslint-plugin-react/issues/2777#issuecomment-814968432
     "react/prop-types": "off",
     // Prevent fragments from being added that have only a single child.
-    "react/jsx-no-useless-fragment": "error"
+    "react/jsx-no-useless-fragment": "error",
+    "prettier/prettier": [
+      "error",
+      {
+        endOfLine: "auto",
+      },
+    ],
   },
   overrides: [
     {


### PR DESCRIPTION
## Motivation
Prettier setting to allow Windows users to maintain existing line endings.  Otherwise, prettier complains in VS code.  The line endings are handled by git on commit so that we should never see Windows line endings in our repo.

REVIEWER: Please test to make sure you can still do normal commits with this change.  The commit hook depends on the eslint config, which is what this PR is changing.
