### PR TITLE
Fix help text for minimum quick login wait

### DIFF
--- a/src/realm-settings/messages.ts
+++ b/src/realm-settings/messages.ts
@@ -578,7 +578,7 @@ export default {
     maxFailureWait: "Max wait",
     maxDeltaTime: "Failure reset time",
     quickLoginCheckMilliSeconds: "Quick login check milliseconds",
-    minimumQuickLoginWaitSeconds: "Minimum quick login wait",
+    minimumQuickLoginWait: "Minimum quick login wait",
   },
   "partial-import": {
     partialImportHeaderText:

--- a/src/realm-settings/security-defences/BruteForceDetection.tsx
+++ b/src/realm-settings/security-defences/BruteForceDetection.tsx
@@ -153,7 +153,7 @@ export const BruteForceDetection = ({
             />
           </FormGroup>
 
-          <Time name="minimumQuickLoginWaitSeconds" />
+          <Time name="minimumQuickLoginWait" />
         </>
       )}
 


### PR DESCRIPTION
## Motivation
Fix help text for minimum quick login wait.  Before, it was pointing to minimumQuickLoginWaitSeconds, which it was looking for in the wrong bundle.  Now, both help text and label use minimumQuickLoginWait, which exists in both messages.ts and help.ts.
