### PR TITLE
Time selector was generating duplicate id's

### DIFF
--- a/src/components/time-selector/TimeSelector.tsx
+++ b/src/components/time-selector/TimeSelector.tsx
@@ -83,7 +83,6 @@ export const TimeSelector = ({
         <TextInput
           {...rest}
           type="number"
-          id={`kc-time-${new Date().getTime()}`}
           aria-label="kc-time"
           min={min || 0}
           value={timeValue}


### PR DESCRIPTION
## Motivation
The Time selector was generating duplicate id's when you go to Realm Settings.  

## Brief Description
I think it should be OK to let the id be auto-generated if needed.  I don't expect that anything relied on this ID since it was using a timestamp.

