### PR TITLE
Add button on authentication flows

### DIFF
--- a/cypress/integration/authentication_test.spec.ts
+++ b/cypress/integration/authentication_test.spec.ts
@@ -56,4 +56,26 @@ describe("Authentication test", () => {
 
     cy.get(".react-flow").should("exist");
   });
+
+  it("should add a execution", () => {
+    listingPage.goToItemDetails("Copy of browser");
+    detailPage.addExecution(
+      "Copy of browser forms",
+      "console-username-password"
+    );
+
+    masthead.checkNotificationMessage("Flow successfully updated");
+    detailPage.executionExists("Username Password Challenge");
+  });
+
+  it("should add a condition", () => {
+    listingPage.goToItemDetails("Copy of browser");
+    detailPage.addCondition(
+      "Copy of browser Browser - Conditional OTP",
+      "conditional-user-role"
+    );
+
+    masthead.checkNotificationMessage("Flow successfully updated");
+    detailPage.executionExists("Username Password Challenge");
+  });
 });

--- a/cypress/support/pages/admin_console/manage/authentication/FlowDetail.ts
+++ b/cypress/support/pages/admin_console/manage/authentication/FlowDetail.ts
@@ -36,4 +36,28 @@ export default class FlowDetails {
     cy.get("#diagramView").click();
     return this;
   }
+
+  private clickEditDropdownForFlow(subFlowName: string, option: string) {
+    cy.getId(`${subFlowName}-edit-dropdown`).click().contains(option).click();
+  }
+
+  addExecution(subFlowName: string, executionTestId: string) {
+    this.clickEditDropdownForFlow(subFlowName, "Add step");
+
+    cy.get(".pf-c-pagination").should("exist");
+    cy.getId(executionTestId).click();
+    cy.getId("modal-add").click();
+
+    return this;
+  }
+
+  addCondition(subFlowName: string, executionTestId: string) {
+    this.clickEditDropdownForFlow(subFlowName, "Add condition");
+
+    cy.get(".pf-c-pagination").should("not.exist");
+    cy.getId(executionTestId).click();
+    cy.getId("modal-add").click();
+
+    return this;
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "version": "0.0.1",
       "license": "Apache",
       "dependencies": {
-        "@keycloak/keycloak-admin-client": "^16.0.0-dev.2",
+        "@keycloak/keycloak-admin-client": "^16.0.0-dev.3",
         "@patternfly/patternfly": "^4.132.2",
         "@patternfly/react-core": "4.152.4",
         "@patternfly/react-icons": "4.11.14",
@@ -2541,9 +2541,9 @@
       }
     },
     "node_modules/@keycloak/keycloak-admin-client": {
-      "version": "16.0.0-dev.2",
-      "resolved": "https://registry.npmjs.org/@keycloak/keycloak-admin-client/-/keycloak-admin-client-16.0.0-dev.2.tgz",
-      "integrity": "sha512-eLeN4/O5OWjU0fIIvndv0oLSRQN3q0bdMep19E+09/qL4jeNeBR4ltxLKd0mnW1FY53cZJ+QWLaq/lfgRXFfzA==",
+      "version": "16.0.0-dev.3",
+      "resolved": "https://registry.npmjs.org/@keycloak/keycloak-admin-client/-/keycloak-admin-client-16.0.0-dev.3.tgz",
+      "integrity": "sha512-Uhg+8T5+lJ56GOfOnZDpA7RgFtomuOHDr2YonodT7ZuXGTD6wNQC30yi6cjfWDv0Jv/nf6pRbQ+tAgC7vBazSg==",
       "dependencies": {
         "axios": "^0.21.0",
         "camelize": "^1.0.0",
@@ -19360,9 +19360,9 @@
       }
     },
     "@keycloak/keycloak-admin-client": {
-      "version": "16.0.0-dev.2",
-      "resolved": "https://registry.npmjs.org/@keycloak/keycloak-admin-client/-/keycloak-admin-client-16.0.0-dev.2.tgz",
-      "integrity": "sha512-eLeN4/O5OWjU0fIIvndv0oLSRQN3q0bdMep19E+09/qL4jeNeBR4ltxLKd0mnW1FY53cZJ+QWLaq/lfgRXFfzA==",
+      "version": "16.0.0-dev.3",
+      "resolved": "https://registry.npmjs.org/@keycloak/keycloak-admin-client/-/keycloak-admin-client-16.0.0-dev.3.tgz",
+      "integrity": "sha512-Uhg+8T5+lJ56GOfOnZDpA7RgFtomuOHDr2YonodT7ZuXGTD6wNQC30yi6cjfWDv0Jv/nf6pRbQ+tAgC7vBazSg==",
       "requires": {
         "axios": "^0.21.0",
         "camelize": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "version": "0.0.1",
       "license": "Apache",
       "dependencies": {
-        "@keycloak/keycloak-admin-client": "^16.0.0-dev.3",
+        "@keycloak/keycloak-admin-client": "^16.0.0-dev.4",
         "@patternfly/patternfly": "^4.132.2",
         "@patternfly/react-core": "4.152.4",
         "@patternfly/react-icons": "4.11.14",
@@ -2541,9 +2541,9 @@
       }
     },
     "node_modules/@keycloak/keycloak-admin-client": {
-      "version": "16.0.0-dev.3",
-      "resolved": "https://registry.npmjs.org/@keycloak/keycloak-admin-client/-/keycloak-admin-client-16.0.0-dev.3.tgz",
-      "integrity": "sha512-Uhg+8T5+lJ56GOfOnZDpA7RgFtomuOHDr2YonodT7ZuXGTD6wNQC30yi6cjfWDv0Jv/nf6pRbQ+tAgC7vBazSg==",
+      "version": "16.0.0-dev.4",
+      "resolved": "https://registry.npmjs.org/@keycloak/keycloak-admin-client/-/keycloak-admin-client-16.0.0-dev.4.tgz",
+      "integrity": "sha512-8Wp/hqi6TWnt+woxoRwhklPP1SBw+EGzMGQQdErHrkTvfXCd0JFeECRzIZyGcmeFLbvpyLMwLPYFYknC20CENQ==",
       "dependencies": {
         "axios": "^0.21.0",
         "camelize": "^1.0.0",
@@ -2587,9 +2587,9 @@
       }
     },
     "node_modules/@npmcli/arborist": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@npmcli/arborist/-/arborist-2.7.1.tgz",
-      "integrity": "sha512-EGDHJs6dna/52BrStr/6aaRcMLrYxGbSjT4V3JzvoTBY9/w5i2+1KNepmsG80CAsGADdo6nuNnFwb7sDRm8ZAw==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/arborist/-/arborist-2.8.2.tgz",
+      "integrity": "sha512-6E1XJ0YXBaI9J+25gcTF110MGNx3jv6npr4Rz1U0UAqkuVV7bbDznVJvNqi6F0p8vgrE+Smf9jDTn1DR+7uBjQ==",
       "dev": true,
       "dependencies": {
         "@npmcli/installed-package-contents": "^1.0.7",
@@ -2608,10 +2608,10 @@
         "mkdirp": "^1.0.4",
         "mkdirp-infer-owner": "^2.0.0",
         "npm-install-checks": "^4.0.0",
-        "npm-package-arg": "^8.1.0",
+        "npm-package-arg": "^8.1.5",
         "npm-pick-manifest": "^6.1.0",
         "npm-registry-fetch": "^11.0.0",
-        "pacote": "^11.2.6",
+        "pacote": "^11.3.5",
         "parse-conflict-json": "^1.1.1",
         "proc-log": "^1.0.0",
         "promise-all-reject-late": "^1.0.0",
@@ -2621,7 +2621,6 @@
         "rimraf": "^3.0.2",
         "semver": "^7.3.5",
         "ssri": "^8.0.1",
-        "tar": "^6.1.0",
         "treeverse": "^1.0.4",
         "walk-up-path": "^1.0.0"
       },
@@ -8276,6 +8275,20 @@
       "version": "1.0.0",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
@@ -14975,6 +14988,21 @@
         "@rollup/plugin-inject": "^4.0.0"
       }
     },
+    "node_modules/rollup/node_modules/fsevents": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+      "deprecated": "\"Please update to latest v2.3 or v2.2\"",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/rsvp": {
       "version": "4.8.5",
       "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
@@ -16504,9 +16532,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "6.1.8",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.8.tgz",
-      "integrity": "sha512-sb9b0cp855NbkMJcskdSYA7b11Q8JsX4qe4pyUAfHp+Y6jBjJeek2ZVlwEfWayshEIwlIzXx0Fain3QG9JPm2A==",
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
       "dev": true,
       "dependencies": {
         "chownr": "^2.0.0",
@@ -19360,9 +19388,9 @@
       }
     },
     "@keycloak/keycloak-admin-client": {
-      "version": "16.0.0-dev.3",
-      "resolved": "https://registry.npmjs.org/@keycloak/keycloak-admin-client/-/keycloak-admin-client-16.0.0-dev.3.tgz",
-      "integrity": "sha512-Uhg+8T5+lJ56GOfOnZDpA7RgFtomuOHDr2YonodT7ZuXGTD6wNQC30yi6cjfWDv0Jv/nf6pRbQ+tAgC7vBazSg==",
+      "version": "16.0.0-dev.4",
+      "resolved": "https://registry.npmjs.org/@keycloak/keycloak-admin-client/-/keycloak-admin-client-16.0.0-dev.4.tgz",
+      "integrity": "sha512-8Wp/hqi6TWnt+woxoRwhklPP1SBw+EGzMGQQdErHrkTvfXCd0JFeECRzIZyGcmeFLbvpyLMwLPYFYknC20CENQ==",
       "requires": {
         "axios": "^0.21.0",
         "camelize": "^1.0.0",
@@ -19397,9 +19425,9 @@
       }
     },
     "@npmcli/arborist": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@npmcli/arborist/-/arborist-2.7.1.tgz",
-      "integrity": "sha512-EGDHJs6dna/52BrStr/6aaRcMLrYxGbSjT4V3JzvoTBY9/w5i2+1KNepmsG80CAsGADdo6nuNnFwb7sDRm8ZAw==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/arborist/-/arborist-2.8.2.tgz",
+      "integrity": "sha512-6E1XJ0YXBaI9J+25gcTF110MGNx3jv6npr4Rz1U0UAqkuVV7bbDznVJvNqi6F0p8vgrE+Smf9jDTn1DR+7uBjQ==",
       "dev": true,
       "requires": {
         "@npmcli/installed-package-contents": "^1.0.7",
@@ -19418,10 +19446,10 @@
         "mkdirp": "^1.0.4",
         "mkdirp-infer-owner": "^2.0.0",
         "npm-install-checks": "^4.0.0",
-        "npm-package-arg": "^8.1.0",
+        "npm-package-arg": "^8.1.5",
         "npm-pick-manifest": "^6.1.0",
         "npm-registry-fetch": "^11.0.0",
-        "pacote": "^11.2.6",
+        "pacote": "^11.3.5",
         "parse-conflict-json": "^1.1.1",
         "proc-log": "^1.0.0",
         "promise-all-reject-late": "^1.0.0",
@@ -19431,7 +19459,6 @@
         "rimraf": "^3.0.2",
         "semver": "^7.3.5",
         "ssri": "^8.0.1",
-        "tar": "^6.1.0",
         "treeverse": "^1.0.4",
         "walk-up-path": "^1.0.0"
       },
@@ -23836,6 +23863,13 @@
       "version": "1.0.0",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
+    },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "optional": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -28791,6 +28825,15 @@
       "dev": true,
       "requires": {
         "fsevents": "~2.1.2"
+      },
+      "dependencies": {
+        "fsevents": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+          "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "rollup-plugin-polyfill-node": {
@@ -30003,9 +30046,9 @@
       }
     },
     "tar": {
-      "version": "6.1.8",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.8.tgz",
-      "integrity": "sha512-sb9b0cp855NbkMJcskdSYA7b11Q8JsX4qe4pyUAfHp+Y6jBjJeek2ZVlwEfWayshEIwlIzXx0Fain3QG9JPm2A==",
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
       "dev": true,
       "requires": {
         "chownr": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "prepare": "husky install"
   },
   "dependencies": {
-    "@keycloak/keycloak-admin-client": "^16.0.0-dev.2",
+    "@keycloak/keycloak-admin-client": "^16.0.0-dev.3",
     "@patternfly/patternfly": "^4.132.2",
     "@patternfly/react-core": "4.152.4",
     "@patternfly/react-icons": "4.11.14",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "prepare": "husky install"
   },
   "dependencies": {
-    "@keycloak/keycloak-admin-client": "^16.0.0-dev.3",
+    "@keycloak/keycloak-admin-client": "^16.0.0-dev.4",
     "@patternfly/patternfly": "^4.132.2",
     "@patternfly/react-core": "4.152.4",
     "@patternfly/react-icons": "4.11.14",

--- a/src/authentication/FlowDetails.tsx
+++ b/src/authentication/FlowDetails.tsx
@@ -32,6 +32,10 @@ import {
 import { FlowDiagram } from "./components/FlowDiagram";
 import { useAlerts } from "../components/alert/Alerts";
 
+export const providerConditionFilter = (
+  value: AuthenticationProviderRepresentation
+) => value.displayName?.startsWith("Condition ");
+
 export const FlowDetails = () => {
   const { t } = useTranslation("authentication");
   const adminClient = useAdminClient();

--- a/src/authentication/FlowDetails.tsx
+++ b/src/authentication/FlowDetails.tsx
@@ -14,6 +14,7 @@ import {
 import { CheckCircleIcon, TableIcon } from "@patternfly/react-icons";
 
 import type AuthenticationExecutionInfoRepresentation from "@keycloak/keycloak-admin-client/lib/defs/authenticationExecutionInfoRepresentation";
+import type { AuthenticationProviderRepresentation } from "@keycloak/keycloak-admin-client/lib/defs/authenticatorConfigRepresentation";
 import type AuthenticationFlowRepresentation from "@keycloak/keycloak-admin-client/lib/defs/authenticationFlowRepresentation";
 import type { FlowParams } from "./routes/Flow";
 import { ViewHeader } from "../components/view-header/ViewHeader";
@@ -22,14 +23,19 @@ import { EmptyExecutionState } from "./EmptyExecutionState";
 import { toUpperCase } from "../util";
 import { FlowHeader } from "./components/FlowHeader";
 import { FlowRow } from "./components/FlowRow";
-import { ExecutionList, IndexChange, LevelChange } from "./execution-model";
+import {
+  ExecutionList,
+  ExpandableExecution,
+  IndexChange,
+  LevelChange,
+} from "./execution-model";
 import { FlowDiagram } from "./components/FlowDiagram";
 import { useAlerts } from "../components/alert/Alerts";
 
 export const FlowDetails = () => {
   const { t } = useTranslation("authentication");
   const adminClient = useAdminClient();
-  const { addAlert } = useAlerts();
+  const { addAlert, addError } = useAlerts();
   const { id, usedBy, builtIn } = useParams<FlowParams>();
   const [key, setKey] = useState(0);
   const refresh = () => setKey(new Date().getTime());
@@ -94,12 +100,7 @@ export const FlowDetails = () => {
       refresh();
       addAlert(t("updateFlowSuccess"), AlertVariant.success);
     } catch (error: any) {
-      addAlert(
-        t("updateFlowError", {
-          error: error.response?.data?.errorMessage || error,
-        }),
-        AlertVariant.danger
-      );
+      addError("authentication:updateFlowError", error);
     }
   };
 
@@ -114,12 +115,23 @@ export const FlowDetails = () => {
       refresh();
       addAlert(t("updateFlowSuccess"), AlertVariant.success);
     } catch (error: any) {
-      addAlert(
-        t("updateFlowError", {
-          error: error.response?.data?.errorMessage || error,
-        }),
-        AlertVariant.danger
-      );
+      addError("authentication:updateFlowError", error);
+    }
+  };
+
+  const addExecution = async (
+    execution: ExpandableExecution,
+    type: AuthenticationProviderRepresentation
+  ) => {
+    try {
+      await adminClient.authenticationManagement.addExecutionToFlow({
+        flow: execution.displayName!,
+        provider: type.id!,
+      });
+      refresh();
+      addAlert(t("updateFlowSuccess"), AlertVariant.success);
+    } catch (error) {
+      addError("authentication:updateFlowError", error);
     }
   };
 
@@ -215,6 +227,7 @@ export const FlowDetails = () => {
                       setExecutionList(executionList.clone());
                     }}
                     onRowChange={update}
+                    onAddExecution={addExecution}
                   />
                 ))}
               </>

--- a/src/authentication/components/EditFlowDropdown.tsx
+++ b/src/authentication/components/EditFlowDropdown.tsx
@@ -1,0 +1,25 @@
+import React, { useState } from "react";
+import { Dropdown, DropdownItem, DropdownToggle } from "@patternfly/react-core";
+import { PlusIcon } from "@patternfly/react-icons";
+
+export const EditFlowDropdown = () => {
+  const [open, setOpen] = useState(false);
+  return (
+    <Dropdown
+      isPlain
+      position="right"
+      id="user-dropdown"
+      isOpen={open}
+      toggle={
+        <DropdownToggle onToggle={(open) => setOpen(open)}>
+          <PlusIcon />
+        </DropdownToggle>
+      }
+      dropdownItems={[
+        <DropdownItem key="addStep">Add Step</DropdownItem>,
+        <DropdownItem key="addCondition">Add Condition</DropdownItem>,
+        <DropdownItem key="addSubFlow">Add Sub-flow</DropdownItem>,
+      ]}
+    />
+  );
+};

--- a/src/authentication/components/EditFlowDropdown.tsx
+++ b/src/authentication/components/EditFlowDropdown.tsx
@@ -42,7 +42,7 @@ export const EditFlowDropdown = ({
       <Dropdown
         isPlain
         position="right"
-        id="user-dropdown"
+        data-testid={`${execution.displayName}-edit-dropdown`}
         isOpen={open}
         toggle={
           <DropdownToggle onToggle={(open) => setOpen(open)}>

--- a/src/authentication/components/EditFlowDropdown.tsx
+++ b/src/authentication/components/EditFlowDropdown.tsx
@@ -1,25 +1,45 @@
 import React, { useState } from "react";
+import { useTranslation } from "react-i18next";
 import { Dropdown, DropdownItem, DropdownToggle } from "@patternfly/react-core";
 import { PlusIcon } from "@patternfly/react-icons";
 
+import { AddStepModal } from "./modals/AddStepModal";
+
+type AddedType = "step" | "condition" | "subFlow";
+
 export const EditFlowDropdown = () => {
+  const { t } = useTranslation("authentication");
   const [open, setOpen] = useState(false);
+  const [type, setType] = useState<AddedType>();
+
   return (
-    <Dropdown
-      isPlain
-      position="right"
-      id="user-dropdown"
-      isOpen={open}
-      toggle={
-        <DropdownToggle onToggle={(open) => setOpen(open)}>
-          <PlusIcon />
-        </DropdownToggle>
-      }
-      dropdownItems={[
-        <DropdownItem key="addStep">Add Step</DropdownItem>,
-        <DropdownItem key="addCondition">Add Condition</DropdownItem>,
-        <DropdownItem key="addSubFlow">Add Sub-flow</DropdownItem>,
-      ]}
-    />
+    <>
+      <Dropdown
+        isPlain
+        position="right"
+        id="user-dropdown"
+        isOpen={open}
+        toggle={
+          <DropdownToggle onToggle={(open) => setOpen(open)}>
+            <PlusIcon />
+          </DropdownToggle>
+        }
+        dropdownItems={[
+          <DropdownItem key="addStep" onClick={() => setType("step")}>
+            {t("addStep")}
+          </DropdownItem>,
+          <DropdownItem key="addCondition" onClick={() => setType("condition")}>
+            {t("addCondition")}
+          </DropdownItem>,
+          <DropdownItem key="addSubFlow" onClick={() => setType("subFlow")}>
+            {t("addSubFlow")}
+          </DropdownItem>,
+        ]}
+        onSelect={() => setOpen(false)}
+      />
+      {type === "step" && (
+        <AddStepModal name="" onSelect={() => setType(undefined)} />
+      )}
+    </>
   );
 };

--- a/src/authentication/components/FlowDiagram.tsx
+++ b/src/authentication/components/FlowDiagram.tsx
@@ -26,6 +26,7 @@ import { EndSubFlowNode, StartSubFlowNode } from "./diagram/SubFlowNode";
 import { ConditionalNode } from "./diagram/ConditionalNode";
 import { ButtonEdge } from "./diagram/ButtonEdge";
 import { getLayoutedElements } from "./diagram/auto-layout";
+import { providerConditionFilter } from "../FlowDetails";
 
 import "./flow-diagram.css";
 
@@ -54,7 +55,7 @@ const createNode = (ex: ExpandableExecution) => {
   if (ex.executionList) {
     nodeType = "startSubFlow";
   }
-  if (ex.displayName?.startsWith("Condition")) {
+  if (providerConditionFilter(ex)) {
     nodeType = "conditional";
   }
   return {

--- a/src/authentication/components/FlowRow.tsx
+++ b/src/authentication/components/FlowRow.tsx
@@ -13,6 +13,7 @@ import {
 } from "@patternfly/react-core";
 
 import type AuthenticationExecutionInfoRepresentation from "@keycloak/keycloak-admin-client/lib/defs/authenticationExecutionInfoRepresentation";
+import type { AuthenticationProviderRepresentation } from "@keycloak/keycloak-admin-client/lib/defs/authenticatorConfigRepresentation";
 import type { ExpandableExecution } from "../execution-model";
 import { FlowTitle } from "./FlowTitle";
 import { FlowRequirementDropdown } from "./FlowRequirementDropdown";
@@ -25,15 +26,26 @@ type FlowRowProps = {
   execution: ExpandableExecution;
   onRowClick: (execution: ExpandableExecution) => void;
   onRowChange: (execution: AuthenticationExecutionInfoRepresentation) => void;
+  onAddExecution: (
+    execution: ExpandableExecution,
+    type: AuthenticationProviderRepresentation
+  ) => void;
 };
 
 export const FlowRow = ({
   execution,
   onRowClick,
   onRowChange,
+  onAddExecution,
 }: FlowRowProps) => {
   const { t } = useTranslation("authentication");
   const hasSubList = !!execution.executionList?.length;
+
+  const onSelect = (value?: AuthenticationProviderRepresentation) => {
+    if (value) {
+      onAddExecution(execution, value);
+    }
+  };
   return (
     <>
       <DataListItem
@@ -87,7 +99,9 @@ export const FlowRow = ({
                 {execution.configurable && (
                   <ExecutionConfigModal execution={execution} />
                 )}
-                {execution.authenticationFlow && <EditFlowDropdown />}
+                {execution.authenticationFlow && (
+                  <EditFlowDropdown execution={execution} onSelect={onSelect} />
+                )}
               </DataListCell>,
             ]}
           />
@@ -101,6 +115,7 @@ export const FlowRow = ({
               execution={execution}
               onRowClick={onRowClick}
               onRowChange={onRowChange}
+              onAddExecution={onAddExecution}
             />
           ))}
         </>

--- a/src/authentication/components/FlowRow.tsx
+++ b/src/authentication/components/FlowRow.tsx
@@ -87,7 +87,7 @@ export const FlowRow = ({
                 {execution.configurable && (
                   <ExecutionConfigModal execution={execution} />
                 )}
-                {execution.executionList && <EditFlowDropdown />}
+                {execution.authenticationFlow && <EditFlowDropdown />}
               </DataListCell>,
             ]}
           />

--- a/src/authentication/components/FlowRow.tsx
+++ b/src/authentication/components/FlowRow.tsx
@@ -16,9 +16,10 @@ import type AuthenticationExecutionInfoRepresentation from "@keycloak/keycloak-a
 import type { ExpandableExecution } from "../execution-model";
 import { FlowTitle } from "./FlowTitle";
 import { FlowRequirementDropdown } from "./FlowRequirementDropdown";
+import { ExecutionConfigModal } from "./ExecutionConfigModal";
+import { EditFlowDropdown } from "./EditFlowDropdown";
 
 import "./flow-row.css";
-import { ExecutionConfigModal } from "./ExecutionConfigModal";
 
 type FlowRowProps = {
   execution: ExpandableExecution;
@@ -86,6 +87,7 @@ export const FlowRow = ({
                 {execution.configurable && (
                   <ExecutionConfigModal execution={execution} />
                 )}
+                {execution.executionList && <EditFlowDropdown />}
               </DataListCell>,
             ]}
           />

--- a/src/authentication/components/FlowRow.tsx
+++ b/src/authentication/components/FlowRow.tsx
@@ -41,11 +41,6 @@ export const FlowRow = ({
   const { t } = useTranslation("authentication");
   const hasSubList = !!execution.executionList?.length;
 
-  const onSelect = (value?: AuthenticationProviderRepresentation) => {
-    if (value) {
-      onAddExecution(execution, value);
-    }
-  };
   return (
     <>
       <DataListItem
@@ -100,7 +95,10 @@ export const FlowRow = ({
                   <ExecutionConfigModal execution={execution} />
                 )}
                 {execution.authenticationFlow && (
-                  <EditFlowDropdown execution={execution} onSelect={onSelect} />
+                  <EditFlowDropdown
+                    execution={execution}
+                    onAddExecution={onAddExecution}
+                  />
                 )}
               </DataListCell>,
             ]}

--- a/src/authentication/components/modals/AddStepModal.tsx
+++ b/src/authentication/components/modals/AddStepModal.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import {
+  Form,
+  FormGroup,
+  Modal,
+  ModalVariant,
+  Radio,
+} from "@patternfly/react-core";
+import { useTranslation } from "react-i18next";
+
+type AddStepModalProps = {
+  name: string;
+  onSelect: () => void;
+};
+
+export const AddStepModal = ({ name, onSelect }: AddStepModalProps) => {
+  const { t } = useTranslation("authentication");
+
+  return (
+    <Modal
+      variant={ModalVariant.small}
+      isOpen={true}
+      title={t("executionConfig", { name })}
+      onClose={() => onSelect()}
+    >
+      <Form>
+        <FormGroup
+          isInline
+          fieldId="simple-form-checkbox-group"
+          label="How can we contact you?"
+        >
+          <Radio name="Email" label="Email" id="inlinecheck01" />
+          <Radio name="Email" label="Controlled radio" id="inlinecheck02" />
+          <Radio
+            name="Email"
+            label="Reversed radio example"
+            id="inlinecheck03"
+          />
+        </FormGroup>
+      </Form>
+    </Modal>
+  );
+};

--- a/src/authentication/components/modals/AddStepModal.tsx
+++ b/src/authentication/components/modals/AddStepModal.tsx
@@ -1,4 +1,5 @@
-import React from "react";
+import React, { useState } from "react";
+import { useTranslation } from "react-i18next";
 import {
   Form,
   FormGroup,
@@ -6,15 +7,39 @@ import {
   ModalVariant,
   Radio,
 } from "@patternfly/react-core";
-import { useTranslation } from "react-i18next";
+
+import type { AuthenticationProviderRepresentation } from "@keycloak/keycloak-admin-client/lib/defs/authenticatorConfigRepresentation";
+import { useAdminClient, useFetch } from "../../../context/auth/AdminClient";
+
+type FlowType = "client" | "form" | "basic";
 
 type AddStepModalProps = {
   name: string;
+  type: FlowType;
   onSelect: () => void;
 };
 
-export const AddStepModal = ({ name, onSelect }: AddStepModalProps) => {
+export const AddStepModal = ({ name, type, onSelect }: AddStepModalProps) => {
   const { t } = useTranslation("authentication");
+  const adminClient = useAdminClient();
+
+  const [, setProviders] = useState<AuthenticationProviderRepresentation[]>();
+
+  useFetch(
+    () => {
+      switch (type) {
+        case "client":
+          return adminClient.authenticationManagement.getClientAuthenticatorProviders();
+        case "form":
+          return adminClient.authenticationManagement.getFormActionProviders();
+        case "basic":
+        default:
+          return adminClient.authenticationManagement.getAuthenticatorProviders();
+      }
+    },
+    (providers) => setProviders(providers),
+    []
+  );
 
   return (
     <Modal
@@ -25,11 +50,15 @@ export const AddStepModal = ({ name, onSelect }: AddStepModalProps) => {
     >
       <Form>
         <FormGroup
-          isInline
           fieldId="simple-form-checkbox-group"
           label="How can we contact you?"
         >
-          <Radio name="Email" label="Email" id="inlinecheck01" />
+          <Radio
+            name="Email"
+            label="Email"
+            id="inlinecheck01"
+            description="Some description can be long and then it will still look nice because patternfly is super and does this kind of things for us"
+          />
           <Radio name="Email" label="Controlled radio" id="inlinecheck02" />
           <Radio
             name="Email"

--- a/src/authentication/components/modals/AddSubFlowModal.tsx
+++ b/src/authentication/components/modals/AddSubFlowModal.tsx
@@ -1,0 +1,113 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { useForm } from "react-hook-form";
+import {
+  Button,
+  ButtonVariant,
+  Form,
+  FormGroup,
+  Modal,
+  ModalVariant,
+  TextInput,
+  ValidatedOptions,
+} from "@patternfly/react-core";
+
+import { HelpItem } from "../../../components/help-enabler/HelpItem";
+
+type AddSubFlowProps = {
+  name: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+};
+
+export const AddSubFlowModal = ({
+  name,
+  onConfirm,
+  onCancel,
+}: AddSubFlowProps) => {
+  const { t } = useTranslation("authentication");
+  const { register, errors, handleSubmit } = useForm();
+
+  return (
+    <Modal
+      variant={ModalVariant.medium}
+      isOpen={true}
+      title={t("addStepTo", { name })}
+      onClose={() => onCancel()}
+      actions={[
+        <Button
+          id="modal-add"
+          data-testid="modal-add"
+          key="add"
+          onClick={() => onConfirm()}
+        >
+          {t("common:add")}
+        </Button>,
+        <Button
+          data-testid="cancel"
+          id="modal-cancel"
+          key="cancel"
+          variant={ButtonVariant.link}
+          onClick={() => {
+            onCancel();
+          }}
+        >
+          {t("common:cancel")}
+        </Button>,
+      ]}
+    >
+      <Form
+        id="execution-config-form"
+        isHorizontal
+        onSubmit={handleSubmit(onConfirm)}
+      >
+        <FormGroup
+          label={t("common:name")}
+          fieldId="name"
+          helperTextInvalid={t("common:required")}
+          validated={
+            errors.name ? ValidatedOptions.error : ValidatedOptions.default
+          }
+          isRequired
+          labelIcon={
+            <HelpItem
+              helpText="authentication-help:name"
+              forLabel={t("name")}
+              forID="name"
+            />
+          }
+        >
+          <TextInput
+            type="text"
+            id="name"
+            name="name"
+            data-testid="name"
+            ref={register({ required: true })}
+            validated={
+              errors.name ? ValidatedOptions.error : ValidatedOptions.default
+            }
+          />
+        </FormGroup>
+        <FormGroup
+          label={t("common:description")}
+          fieldId="description"
+          labelIcon={
+            <HelpItem
+              helpText="authentication-help:description"
+              forLabel={t("common:description")}
+              forID="description"
+            />
+          }
+        >
+          <TextInput
+            type="text"
+            id="description"
+            name="description"
+            data-testid="description"
+            ref={register}
+          />
+        </FormGroup>
+      </Form>
+    </Modal>
+  );
+};

--- a/src/authentication/messages.ts
+++ b/src/authentication/messages.ts
@@ -43,6 +43,7 @@ export default {
     addSubFlow: "Add sub-flow",
     addCondition: "Add condition",
     addStep: "Add step",
+    addStepTo: "Add step to {{name}}",
     steps: "Steps",
     requirement: "Requirement",
     requirements: {

--- a/src/authentication/messages.ts
+++ b/src/authentication/messages.ts
@@ -41,6 +41,8 @@ export default {
     addExecution: "Add execution",
     addSubFlowTitle: "Add a sub-flow",
     addSubFlow: "Add sub-flow",
+    addCondition: "Add condition",
+    addStep: "Add step",
     steps: "Steps",
     requirement: "Requirement",
     requirements: {

--- a/src/clients/credentials/Credentials.tsx
+++ b/src/clients/credentials/Credentials.tsx
@@ -69,9 +69,7 @@ export const Credentials = ({ clientId, save }: CredentialsProps) => {
   useFetch(
     async () => {
       const providers =
-        await adminClient.authenticationManagement.getClientAuthenticatorProviders(
-          { id: clientId }
-        );
+        await adminClient.authenticationManagement.getClientAuthenticatorProviders();
 
       const secret = await adminClient.clients.getClientSecret({
         id: clientId,

--- a/src/clients/credentials/Credentials.tsx
+++ b/src/clients/credentials/Credentials.tsx
@@ -18,6 +18,7 @@ import {
   SplitItem,
 } from "@patternfly/react-core";
 import type CredentialRepresentation from "@keycloak/keycloak-admin-client/lib/defs/credentialRepresentation";
+import type { AuthenticationProviderRepresentation } from "@keycloak/keycloak-admin-client/lib/defs/authenticatorConfigRepresentation";
 
 import { useAlerts } from "../../components/alert/Alerts";
 import { useConfirmDialog } from "../../components/confirm-dialog/ConfirmDialog";
@@ -28,11 +29,6 @@ import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
 import { ClientSecret } from "./ClientSecret";
 import { SignedJWT } from "./SignedJWT";
 import { X509 } from "./X509";
-
-type ClientAuthenticatorProviders = {
-  id: string;
-  displayName: string;
-};
 
 type AccessToken = {
   registrationAccessToken: string;
@@ -48,9 +44,9 @@ export const Credentials = ({ clientId, save }: CredentialsProps) => {
   const adminClient = useAdminClient();
   const { addAlert, addError } = useAlerts();
 
-  const [providers, setProviders] = useState<ClientAuthenticatorProviders[]>(
-    []
-  );
+  const [providers, setProviders] = useState<
+    AuthenticationProviderRepresentation[]
+  >([]);
 
   const {
     control,


### PR DESCRIPTION
## Motivation
This adds the add button on the authetication flows [marvel](https://marvelapp.com/prototype/bh91013/screen/75676609)

## Brief Description
<!-- Add a short answer for: 
What was done in this PR? (e.g Fix to prevent users from accessing feature X.)
Why it was done? (e.g Feature X was deprecated.)
-->
Adding an execution or condition works, but subflow only shows a model that doesn't work, as it needs some clarification
on how to do that without type and provider.

## Verification Steps
<!--
Add the steps required to verify this change. Keep in mind that these steps should be written so groups unfamiliar with the 
new functionality can follow them, such as QE or documentation.

1. Go to `XX >> YY >> SS`.
2. Create a new item `N` with info `X`.
3. Right-click the item and select Delete.
4. Verify that the item is no longer present in the left navigation menu.
-->
1. Go to authentication copy one of the existing flows
1. Then go to the details of that flow
1. Now you'll see a `+` icon on the sub flows
1. use the "Add step" and "Add condition" dropdown items to add excutions to the sub flow

## Checklist:

- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [x] Help has been implemented

## Additional Notes
<!-- 
Add images and/or screen caps to illustrate what was changed if this pull request adds to or modifies existing user-visible appearance/output. 
-->