### PR TITLE
Identity Providers: sets alias to read-only in settings form

### DIFF
--- a/src/identity-providers/IdentityProvidersSection.tsx
+++ b/src/identity-providers/IdentityProvidersSection.tsx
@@ -77,6 +77,7 @@ export const IdentityProvidersSection = () => {
         realm,
         providerId: identityProvider.providerId,
         alias: identityProvider.alias!,
+        tab: "settings",
       })}
     >
       {identityProvider.displayName
@@ -140,7 +141,7 @@ export const IdentityProvidersSection = () => {
       {manageDisplayDialog && (
         <ManageOderDialog
           onClose={() => setManageDisplayDialog(false)}
-          providers={providers?.filter((p) => p.enabled)}
+          providers={providers.filter((p) => p.enabled)}
         />
       )}
       <ViewHeader

--- a/src/identity-providers/add/OIDCGeneralSettings.tsx
+++ b/src/identity-providers/add/OIDCGeneralSettings.tsx
@@ -7,10 +7,13 @@ import { HelpItem } from "../../components/help-enabler/HelpItem";
 import { RedirectUrl } from "../component/RedirectUrl";
 import { TextField } from "../component/TextField";
 import { DisplayOrder } from "../component/DisplayOrder";
+import type { IdentityProviderTabParams } from "../routes/IdentityProviderTab";
+import { useParams } from "react-router-dom";
 
 export const OIDCGeneralSettings = ({ id }: { id: string }) => {
   const { t } = useTranslation("identity-providers");
   const { t: th } = useTranslation("identity-providers-help");
+  const { tab } = useParams<IdentityProviderTabParams>();
 
   const { register, errors } = useFormContext();
 
@@ -35,6 +38,7 @@ export const OIDCGeneralSettings = ({ id }: { id: string }) => {
         helperTextInvalid={t("common:required")}
       >
         <TextInput
+          isReadOnly={tab === "settings"}
           isRequired
           type="text"
           id="alias"

--- a/src/identity-providers/add/SamlGeneralSettings.tsx
+++ b/src/identity-providers/add/SamlGeneralSettings.tsx
@@ -7,10 +7,13 @@ import { HelpItem } from "../../components/help-enabler/HelpItem";
 import { RedirectUrl } from "../component/RedirectUrl";
 import { TextField } from "../component/TextField";
 import { DisplayOrder } from "../component/DisplayOrder";
+import { useParams } from "react-router";
+import type { IdentityProviderTabParams } from "../routes/IdentityProviderTab";
 
 export const SamlGeneralSettings = ({ id }: { id: string }) => {
   const { t } = useTranslation("identity-providers");
   const { t: th } = useTranslation("identity-providers-help");
+  const { tab } = useParams<IdentityProviderTabParams>();
 
   const { register, errors } = useFormContext();
 
@@ -40,6 +43,7 @@ export const SamlGeneralSettings = ({ id }: { id: string }) => {
           id="alias"
           data-testid="alias"
           name="alias"
+          isReadOnly={tab === "settings"}
           validated={
             errors.alias ? ValidatedOptions.error : ValidatedOptions.default
           }


### PR DESCRIPTION
## Motivation
<!-- Add references to relevant tickets, issues, design specs and/or a short description of what motivated you to do it. -->

Closes #1116 

## Verification Steps
<!--
Add the steps required to verify this change. Keep in mind that these steps should be written so groups unfamiliar with the 
new functionality can follow them, such as QE or documentation. 
-->

1. Go Identity Providers
2. Create an identity provider for each of the three "User-defined" options, and verify that the "alias" field is editable in the "create" form.
4. Save and go to the settings screen for an identity provider. 
5. Verify the alias is read-only in the settings screen.
6. Repeat for all the user-defined providers you added.

## Checklist:

- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [x] Help has been implemented
- [x] axe report has been run and resulting a11y issues have been resolved
- [x] Unit tests have been created/updated

## Additional Notes
<!-- 
Add images and/or screen caps to illustrate what was changed if this pull request adds to or modifies existing user-visible appearance/output. 
-->
