### PR TITLE
Stop running unit tests on commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,4 +2,3 @@
 . "$(dirname "$0")/_/husky.sh"
 
 npx lint-staged
-npm test


### PR DESCRIPTION
## Motivation
Running the unit tests on every commit is a tad annoying, since the CI already takes care of this let's drop it.
