### PR TITLE
Realm selector: fix create realm btn

### DIFF
--- a/src/components/realm-selector/RealmSelector.tsx
+++ b/src/components/realm-selector/RealmSelector.tsx
@@ -62,20 +62,6 @@ export const RealmSelector = () => {
     </Split>
   );
 
-  const AddRealm = () => (
-    <Button
-      data-testid="add-realm"
-      component="div"
-      isBlock
-      onClick={() => {
-        history.push(toAddRealm({ realm }));
-        setOpen(!open);
-      }}
-    >
-      {t("createRealm")}
-    </Button>
-  );
-
   const selectRealm = (realm: string) => {
     setOpen(!open);
     history.push(toDashboard({ realm }));
@@ -98,7 +84,17 @@ export const RealmSelector = () => {
         <>
           <Divider key="divider" />
           <DropdownItem key="add">
-            <AddRealm />
+            <Button
+              data-testid="add-realm"
+              component="div"
+              isBlock
+              onClick={() => {
+                history.push(toAddRealm({ realm }));
+                setOpen(!open);
+              }}
+            >
+              {t("createRealm")}
+            </Button>
           </DropdownItem>
         </>
       )}
@@ -131,7 +127,17 @@ export const RealmSelector = () => {
           className="keycloak__realm_selector__context_selector"
           footer={
             <ContextSelectorItem key="add">
-              <AddRealm />
+              <Button
+                data-testid="add-realm"
+                component="div"
+                isBlock
+                onClick={() => {
+                  history.push(toAddRealm({ realm }));
+                  setOpen(!open);
+                }}
+              >
+                {t("createRealm")}
+              </Button>{" "}
             </ContextSelectorItem>
           }
         >


### PR DESCRIPTION
## Motivation
<!-- Add references to relevant tickets, issues, design specs and/or a short description of what motivated you to do it. -->
Fixes + closes #1165 
## Brief Description
<!-- Add a short answer for: 
What was done in this PR? (e.g Fix to prevent users from accessing feature X.)
Why it was done? (e.g Feature X was deprecated.)
-->

## Verification Steps
<!--
Add the steps required to verify this change. Keep in mind that these steps should be written so groups unfamiliar with the 
new functionality can follow them, such as QE or documentation.-->

1. Click on "Create realm" button in the realm selector
2. Verify the button is clickable and that you are navigated to the "create realm" page.


## Checklist:

- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [x] Help has been implemented
- [x] axe report has been run and resulting a11y issues have been resolved
- [x] Unit tests have been created/updated

## Additional Notes
<!-- 
Add images and/or screen caps to illustrate what was changed if this pull request adds to or modifies existing user-visible appearance/output. 
-->
