### PR TITLE
Prevent publish from running on forked repositories

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,7 @@ defaults:
     working-directory: keycloak-theme
 jobs:
   publish:
+    if: github.repository_owner == 'keycloak'
     runs-on: ubuntu-latest
     permissions: 
       contents: read


### PR DESCRIPTION
## Motivation
Prevents Github Actions from starting a job to publish the package on forked repositories.
