### PR TITLE
SAML ID provider cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "keycloak-admin-ui",
       "version": "0.0.1",
       "license": "Apache",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "keycloak-admin-ui",
       "version": "0.0.1",
       "license": "Apache",
       "dependencies": {

--- a/src/identity-providers/add/AdvancedSettings.tsx
+++ b/src/identity-providers/add/AdvancedSettings.tsx
@@ -30,7 +30,7 @@ const LoginFlow = ({
   useFetch(
     () => adminClient.authenticationManagement.getFlows(),
     (flows) =>
-      setFlows(flows?.filter((flow) => flow.providerId === "basic-flow")),
+      setFlows(flows.filter((flow) => flow.providerId === "basic-flow")),
     []
   );
 

--- a/src/identity-providers/add/AdvancedSettings.tsx
+++ b/src/identity-providers/add/AdvancedSettings.tsx
@@ -108,8 +108,9 @@ export const AdvancedSettings = ({ isOIDC, isSAML }: AdvancedSettingsProps) => {
       <SwitchField field="storeToken" label="storeTokens" fieldType="boolean" />
       {isSAML && (
         <SwitchField
-          field="config.addReadTokenRoleOnCreate"
+          field="addReadTokenRoleOnCreate"
           label="storedTokensReadable"
+          fieldType="boolean"
         />
       )}
       {!isOIDC && !isSAML && (

--- a/src/identity-providers/add/DescriptorSettings.tsx
+++ b/src/identity-providers/add/DescriptorSettings.tsx
@@ -101,6 +101,7 @@ const Fields = ({ readOnly }: DescriptorSettingsProps) => {
           type="text"
           id="single-logout-service-url"
           name="config.singleLogoutServiceUrl"
+          ref={register}
           isReadOnly={readOnly}
         />
       </FormGroup>
@@ -375,6 +376,7 @@ const Fields = ({ readOnly }: DescriptorSettingsProps) => {
           type="text"
           id="allowedClockSkew"
           name="config.allowedClockSkew"
+          ref={register}
           isReadOnly={readOnly}
         />
       </FormGroup>

--- a/src/identity-providers/add/DescriptorSettings.tsx
+++ b/src/identity-providers/add/DescriptorSettings.tsx
@@ -45,6 +45,12 @@ const Fields = ({ readOnly }: DescriptorSettingsProps) => {
     name: "config.validateSignature",
   });
 
+  const principalType = useWatch({
+    control: control,
+    name: "config.principalType",
+    defaultValue: "",
+  });
+
   return (
     <div className="pf-c-form pf-m-horizontal">
       <FormGroup
@@ -216,6 +222,27 @@ const Fields = ({ readOnly }: DescriptorSettingsProps) => {
         ></Controller>
       </FormGroup>
 
+      {principalType.includes("Attribute") && (
+        <FormGroup
+          label={t("principalAttribute")}
+          labelIcon={
+            <HelpItem
+              helpText={th("principalAttribute")}
+              forLabel={t("principalAttribute")}
+              forID="principalAttribute"
+            />
+          }
+          fieldId="principalAttribute"
+        >
+          <TextInput
+            type="text"
+            id="principalAttribute"
+            name="config.principalAttribute"
+            ref={register}
+            isReadOnly={readOnly}
+          />
+        </FormGroup>
+      )}
       <SwitchField
         field="config.postBindingResponse"
         label="httpPostBindingResponse"

--- a/src/identity-providers/add/DescriptorSettings.tsx
+++ b/src/identity-providers/add/DescriptorSettings.tsx
@@ -46,7 +46,7 @@ const Fields = ({ readOnly }: DescriptorSettingsProps) => {
   });
 
   const principalType = useWatch({
-    control: control,
+    control,
     name: "config.principalType",
     defaultValue: "",
   });

--- a/src/identity-providers/add/DescriptorSettings.tsx
+++ b/src/identity-providers/add/DescriptorSettings.tsx
@@ -294,7 +294,7 @@ const Fields = ({ readOnly }: DescriptorSettingsProps) => {
           >
             <Controller
               name="config.xmlSigKeyInfoKeyNameTransformer"
-              defaultValue="keyID-option"
+              defaultValue={t("keyID")}
               control={control}
               render={({ onChange, value }) => (
                 <Select

--- a/src/identity-providers/add/DescriptorSettings.tsx
+++ b/src/identity-providers/add/DescriptorSettings.tsx
@@ -85,7 +85,6 @@ const Fields = ({ readOnly }: DescriptorSettingsProps) => {
           isReadOnly={readOnly}
         />
       </FormGroup>
-
       <FormGroup
         label={t("singleLogoutServiceUrl")}
         labelIcon={
@@ -111,13 +110,11 @@ const Fields = ({ readOnly }: DescriptorSettingsProps) => {
           isReadOnly={readOnly}
         />
       </FormGroup>
-
       <SwitchField
         field="config.backchannelSupported"
         label="backchannelLogout"
         isReadOnly={readOnly}
       />
-
       <FormGroup
         label={t("nameIdPolicyFormat")}
         labelIcon={
@@ -148,27 +145,50 @@ const Fields = ({ readOnly }: DescriptorSettingsProps) => {
             >
               <SelectOption
                 data-testid="persistent-option"
-                value={t("persistent")}
+                value={"urn:oasis:names:tc:SAML:2.0:nameid-format:persistent"}
                 isPlaceholder
-              />
+              >
+                {t("persistent")}
+              </SelectOption>
               <SelectOption
                 data-testid="transient-option"
-                value={t("transient")}
-              />
-              <SelectOption data-testid="email-option" value={t("email")} />
+                value="urn:oasis:names:tc:SAML:2.0:nameid-format:transient"
+              >
+                {t("transient")}
+              </SelectOption>
+              <SelectOption
+                data-testid="email-option"
+                value="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"
+              >
+                {t("email")}
+              </SelectOption>
               <SelectOption
                 data-testid="kerberos-option"
-                value={t("kerberos")}
-              />
-              <SelectOption data-testid="x509-option" value={t("x509")} />
+                value="urn:oasis:names:tc:SAML:2.0:nameid-format:kerberos"
+              >
+                {t("kerberos")}
+              </SelectOption>
+
+              <SelectOption
+                data-testid="x509-option"
+                value="urn:oasis:names:tc:SAML:1.1:nameid-format:X509SubjectName"
+              >
+                {t("x509")}
+              </SelectOption>
+
               <SelectOption
                 data-testid="windowsDomainQN-option"
-                value={t("windowsDomainQN")}
-              />
+                value="urn:oasis:names:tc:SAML:1.1:nameid-format:WindowsDomainQualifiedName"
+              >
+                {t("windowsDomainQN")}
+              </SelectOption>
+
               <SelectOption
                 data-testid="unspecified-option"
-                value={t("unspecified")}
-              />
+                value={"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified"}
+              >
+                {t("unspecified")}
+              </SelectOption>
             </Select>
           )}
         ></Controller>

--- a/src/identity-providers/add/ReqAuthnConstraintsSettings.tsx
+++ b/src/identity-providers/add/ReqAuthnConstraintsSettings.tsx
@@ -11,12 +11,21 @@ import {
 import { TextField } from "../component/TextField";
 import { HelpItem } from "../../components/help-enabler/HelpItem";
 
-const comparisonValues = ["Exact", "Minimum", "Maximum", "Better"];
+const comparisonValues = ["exact", "minimum", "maximum", "better"];
+
+// nameIDPolicyFormat": THESE ARE THE VALID RETURN VALUES, DISPLAY IS SIMPLER THOUGH:
+// "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent
+// "urn:oasis:names:tc:SAML:2.0:nameid-format:transient
+// "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress
+// "urn:oasis:names:tc:SAML:2.0:nameid-format:kerberos
+// "urn:oasis:names:tc:SAML:1.1:nameid-format:X509SubjectName
+// "urn:oasis:names:tc:SAML:1.1:nameid-format:WindowsDomainQualifiedName
+// "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified
 
 export const ReqAuthnConstraints = () => {
   const { t } = useTranslation("identity-providers");
   const { control } = useFormContext();
-  const [syncModeOpen, setSyncModeOpen] = useState(false);
+  const [comparisonOpen, setComparisonOpen] = useState(false);
   return (
     <>
       <FormGroup
@@ -31,7 +40,7 @@ export const ReqAuthnConstraints = () => {
         fieldId="comparison"
       >
         <Controller
-          name="config.comparison"
+          name="config.authnContextComparisonType"
           defaultValue={comparisonValues[0]}
           control={control}
           render={({ onChange, value }) => (
@@ -39,15 +48,15 @@ export const ReqAuthnConstraints = () => {
               toggleId="comparison"
               required
               direction="up"
-              onToggle={() => setSyncModeOpen(!syncModeOpen)}
+              onToggle={() => setComparisonOpen(!comparisonOpen)}
               onSelect={(_, value) => {
                 onChange(value.toString());
-                setSyncModeOpen(false);
+                setComparisonOpen(false);
               }}
               selections={value}
               variant={SelectVariant.single}
-              aria-label={t("syncMode")}
-              isOpen={syncModeOpen}
+              aria-label={t("comparison")}
+              isOpen={comparisonOpen}
             >
               {comparisonValues.map((option) => (
                 <SelectOption

--- a/src/identity-providers/add/ReqAuthnConstraintsSettings.tsx
+++ b/src/identity-providers/add/ReqAuthnConstraintsSettings.tsx
@@ -39,7 +39,7 @@ export const ReqAuthnConstraints = () => {
               toggleId="comparison"
               required
               direction="up"
-              onToggle={() => setComparisonOpen(!comparisonOpen)}
+              onToggle={(isExpanded) => setComparisonOpen(isExpanded)}
               onSelect={(_, value) => {
                 onChange(value.toString());
                 setComparisonOpen(false);

--- a/src/identity-providers/add/ReqAuthnConstraintsSettings.tsx
+++ b/src/identity-providers/add/ReqAuthnConstraintsSettings.tsx
@@ -13,15 +13,6 @@ import { HelpItem } from "../../components/help-enabler/HelpItem";
 
 const comparisonValues = ["exact", "minimum", "maximum", "better"];
 
-// nameIDPolicyFormat": THESE ARE THE VALID RETURN VALUES, DISPLAY IS SIMPLER THOUGH:
-// "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent
-// "urn:oasis:names:tc:SAML:2.0:nameid-format:transient
-// "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress
-// "urn:oasis:names:tc:SAML:2.0:nameid-format:kerberos
-// "urn:oasis:names:tc:SAML:1.1:nameid-format:X509SubjectName
-// "urn:oasis:names:tc:SAML:1.1:nameid-format:WindowsDomainQualifiedName
-// "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified
-
 export const ReqAuthnConstraints = () => {
   const { t } = useTranslation("identity-providers");
   const { control } = useFormContext();

--- a/src/identity-providers/help.ts
+++ b/src/identity-providers/help.ts
@@ -73,6 +73,8 @@ export default {
       "Specifies the URI reference corresponding to a name identifier format.",
     principalType:
       "Way to identify and track external users from the assertion. Default is using Subject NameID, alternatively you can set up identifying attribute.",
+    principalAttribute:
+      "Name or Friendly Name of the attribute used to identify external users.",
     httpPostBindingResponse:
       "Indicates whether to respond to requests using HTTP-POST binding. If false, HTTP-REDIRECT binding will be used.",
     httpPostBindingAuthnRequest:

--- a/src/identity-providers/messages.ts
+++ b/src/identity-providers/messages.ts
@@ -66,6 +66,7 @@ export default {
     windowsDomainQN: "Windows Domain Qualified Name",
     unspecified: "Unspecified",
     principalType: "Principal type",
+    principalAttribute: "Principal attribute",
     subjectNameId: "Subject NameID",
     attributeName: "Attribute [Name]",
     attributeFriendlyName: "Attribute [Friendly Name]",


### PR DESCRIPTION
## Motivation
Several fields in the original SAML identity provider were not working in the first pass, to be fixed later. 

## Brief Description
This fixes it so all SAML fields should be working as expected. Any fields that are not working from here on should be filed as issues.

## Verification Steps
Verify that the following fields now work as expected in the SAML ID provider config, as they worked in the old console (set the value in the old console and verify that the new console reads the value, etc):
Single logout service URL
NameID policy format
Principal type
Principal attribute
Want AuthnRequests signed
Signature algorithm
SAML signature key name
Validating X509 certificates
Pass subject
Allowed clock skew
Comparison
AuthnContext ClassRefs
AuthnContext DeclRefs
Stored tokens readable
Hide on login page

## Checklist:
- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [x] Help has been implemented

## Additional Notes
Cypress tests coming in separate PR.