### PR TITLE
Add missing help for client login fields

### DIFF
--- a/src/clients/ClientSettings.tsx
+++ b/src/clients/ClientSettings.tsx
@@ -176,7 +176,7 @@ export const ClientSettings = ({ save, reset }: ClientSettingsProps) => {
                 {/* The type for the children of Select are incorrect, so we need a fragment here. */}
                 {/* eslint-disable-next-line react/jsx-no-useless-fragment */}
                 <>
-                  {loginThemes?.map((theme) => (
+                  {loginThemes.map((theme) => (
                     <SelectOption
                       selected={theme.name === value}
                       key={theme.name}
@@ -190,6 +190,13 @@ export const ClientSettings = ({ save, reset }: ClientSettingsProps) => {
         </FormGroup>
         <FormGroup
           label={t("consentRequired")}
+          labelIcon={
+            <HelpItem
+              helpText="clients-help:consentRequired"
+              forLabel={t("consentRequired")}
+              forID="kc-consent-switch"
+            />
+          }
           fieldId="kc-consent"
           hasNoPaddingTop
         >
@@ -210,6 +217,13 @@ export const ClientSettings = ({ save, reset }: ClientSettingsProps) => {
         </FormGroup>
         <FormGroup
           label={t("displayOnClient")}
+          labelIcon={
+            <HelpItem
+              helpText="clients-help:displayOnClient"
+              forLabel={t("displayOnClient")}
+              forID="kc-display-on-client-switch"
+            />
+          }
           fieldId="kc-display-on-client"
           hasNoPaddingTop
         >
@@ -231,6 +245,13 @@ export const ClientSettings = ({ save, reset }: ClientSettingsProps) => {
         </FormGroup>
         <FormGroup
           label={t("consentScreenText")}
+          labelIcon={
+            <HelpItem
+              helpText="clients-help:consentScreenText"
+              forLabel={t("consentScreenText")}
+              forID="kc-consent-screen-text"
+            />
+          }
           fieldId="kc-consent-screen-text"
         >
           <TextArea

--- a/src/clients/help.ts
+++ b/src/clients/help.ts
@@ -124,5 +124,10 @@ export default {
     keyAlias: "Archive alias for your private key and certificate.",
     keyPassword: "Password to access the private key in the archive",
     storePassword: "Password to access the archive itself",
+    consentRequired: "If enabled, users have to consent to client access.",
+    displayOnClient:
+      "Applicable only if 'Consent Required' is on for this client. If this switch is off, the consent screen will contain just the consents corresponding to configured client scopes. If on, there will be also one item on the consent screen about this client itself.",
+    consentScreenText:
+      "Applicable only if 'Display Client On Consent Screen' is on for this client. Contains the text which will be on the consent screen about permissions specific just for this client.",
   },
 };


### PR DESCRIPTION
## Motivation
Fixes https://github.com/keycloak/keycloak-admin-ui/issues/997.

## Brief Description
Adds missing tooltips/help for the 3 fields in Login settings noted in Issue https://github.com/keycloak/keycloak-admin-ui/issues/997: `Consent required`, `Display client on screen`, and `Client consent screen text`. Used text from the same fields that existed in the legacy admin console.

## Verification Steps
1. Go to `Clients`.
2. Scroll down to `Login settings.`
3. Verify that the `Consent required`, `Display client on screen`, and `Client consent screen text` fields now have a clickable help tooltip icon (?).
4. Verify that, when clicked, each of the above field's tooltip displays the correct help.

## Checklist:
- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [x] Help has been implemented

## Additional Notes
None