### PR TITLE
Realm Settings(Client Policies): Add policies list

### DIFF
--- a/cypress/integration/realm_settings_test.spec.ts
+++ b/cypress/integration/realm_settings_test.spec.ts
@@ -129,8 +129,6 @@ describe("Realm settings", () => {
     sidebarPage.goToRealmSettings();
     cy.findByTestId("rs-email-tab").click();
 
-    cy.wait(1000);
-
     realmSettingsPage.addSenderEmail("example@example.com");
 
     realmSettingsPage.toggleCheck(realmSettingsPage.enableSslCheck);

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "Apache",
       "dependencies": {
-        "@keycloak/keycloak-admin-client": "^16.0.0-dev.18",
+        "@keycloak/keycloak-admin-client": "^16.0.0-dev.19",
         "@patternfly/patternfly": "^4.135.2",
         "@patternfly/react-code-editor": "^4.3.61",
         "@patternfly/react-core": "4.157.3",
@@ -3334,9 +3334,9 @@
       }
     },
     "node_modules/@keycloak/keycloak-admin-client": {
-      "version": "16.0.0-dev.18",
-      "resolved": "https://registry.npmjs.org/@keycloak/keycloak-admin-client/-/keycloak-admin-client-16.0.0-dev.18.tgz",
-      "integrity": "sha512-xGriGt20ZuSr4RNs0zS+EwGqfaL7ivKhHw1p3Y56sKtqmxu5+T8/KxxmAcQkqPu8qeUNL9e/8CqYwM4jqF95Jg==",
+      "version": "16.0.0-dev.19",
+      "resolved": "https://registry.npmjs.org/@keycloak/keycloak-admin-client/-/keycloak-admin-client-16.0.0-dev.19.tgz",
+      "integrity": "sha512-sR2v/BK28jvTFvRbxWfeTcENnKTe80oGw1uqA95xFt5neYrFuote+KneFlBNMNSah9B+40QQ8D7D4VAG27q2mw==",
       "dependencies": {
         "axios": "^0.21.0",
         "camelize": "^1.0.0",
@@ -22472,9 +22472,9 @@
       }
     },
     "@keycloak/keycloak-admin-client": {
-      "version": "16.0.0-dev.18",
-      "resolved": "https://registry.npmjs.org/@keycloak/keycloak-admin-client/-/keycloak-admin-client-16.0.0-dev.18.tgz",
-      "integrity": "sha512-xGriGt20ZuSr4RNs0zS+EwGqfaL7ivKhHw1p3Y56sKtqmxu5+T8/KxxmAcQkqPu8qeUNL9e/8CqYwM4jqF95Jg==",
+      "version": "16.0.0-dev.19",
+      "resolved": "https://registry.npmjs.org/@keycloak/keycloak-admin-client/-/keycloak-admin-client-16.0.0-dev.19.tgz",
+      "integrity": "sha512-sR2v/BK28jvTFvRbxWfeTcENnKTe80oGw1uqA95xFt5neYrFuote+KneFlBNMNSah9B+40QQ8D7D4VAG27q2mw==",
       "requires": {
         "axios": "^0.21.0",
         "camelize": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -24,11 +24,7 @@
     "prepare": "husky install"
   },
   "dependencies": {
-<<<<<<< HEAD
-    "@keycloak/keycloak-admin-client": "^16.0.0-dev.18",
-=======
     "@keycloak/keycloak-admin-client": "^16.0.0-dev.19",
->>>>>>> wip client policies: policies tab
     "@patternfly/patternfly": "^4.135.2",
     "@patternfly/react-code-editor": "^4.3.61",
     "@patternfly/react-core": "4.157.3",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,11 @@
     "prepare": "husky install"
   },
   "dependencies": {
+<<<<<<< HEAD
     "@keycloak/keycloak-admin-client": "^16.0.0-dev.18",
+=======
+    "@keycloak/keycloak-admin-client": "^16.0.0-dev.19",
+>>>>>>> wip client policies: policies tab
     "@patternfly/patternfly": "^4.135.2",
     "@patternfly/react-code-editor": "^4.3.61",
     "@patternfly/react-core": "4.157.3",

--- a/src/realm-settings/PoliciesTab.tsx
+++ b/src/realm-settings/PoliciesTab.tsx
@@ -134,7 +134,7 @@ export const PoliciesTab = () => {
             },
             {
               name: "enabled",
-              displayKey: "realm-settings:status",
+              displayKey: "common:enabled",
               cellFormatters: [upperCaseFormatter()],
             },
             {

--- a/src/realm-settings/PoliciesTab.tsx
+++ b/src/realm-settings/PoliciesTab.tsx
@@ -2,11 +2,71 @@ import React from "react";
 import { PageSection } from "@patternfly/react-core";
 
 import "./RealmSettingsSection.css";
+import { ListEmptyState } from "../components/list-empty-state/ListEmptyState";
+import { KeycloakDataTable } from "../components/table-toolbar/KeycloakDataTable";
+import { useTranslation } from "react-i18next";
+import { useAdminClient } from "../context/auth/AdminClient";
+import { getBaseUrl, upperCaseFormatter } from "../util";
+import { useRealm } from "../context/realm-context/RealmContext";
 
 export const PoliciesTab = () => {
+  const { t } = useTranslation("identity-providers");
+  const adminClient = useAdminClient();
+  const { realm } = useRealm();
+
+  const loader = async () => {
+    //TODO: remove when clientPolicies.listPolicies() endpoint is merged
+    const response = await fetch(
+      `${getBaseUrl(
+        adminClient
+      )}admin/realms/${realm}/client-policies/policies`,
+      {
+        method: "GET",
+        headers: {
+          Authorization: `bearer ${await adminClient.getAccessToken()}`,
+        },
+      }
+    );
+
+    const result = await response.json();
+    console.log(result?.policies);
+    return result?.policies;
+
+    // TODO: use this call once the code above can be removed
+    // const profiles = await adminClient.clientPolicies.listPolicies();
+    // return profiles?.profiles
+  };
+
   return (
     <PageSection variant="light" padding={{ default: "noPadding" }}>
-      <h1>Policies Tab</h1>
+      <KeycloakDataTable
+        emptyState={
+          <ListEmptyState
+            message={t("identity-providers:noMappers")}
+            instructions={t("identity-providers:noMappersInstructions")}
+            primaryActionText={t("identity-providers:addMapper")}
+          />
+        }
+        loader={loader}
+        isPaginated
+        ariaLabelKey="identity-providers:mappersList"
+        searchPlaceholderKey="identity-providers:searchForMapper"
+        columns={[
+          {
+            name: "name",
+            displayKey: "common:name",
+          },
+          {
+            name: "enabled",
+            displayKey: "common:enabled",
+            cellFormatters: [upperCaseFormatter()],
+          },
+          {
+            name: "description",
+            displayKey: "common:description",
+          },
+        ]}
+      />
     </PageSection>
   );
 };

--- a/src/realm-settings/PoliciesTab.tsx
+++ b/src/realm-settings/PoliciesTab.tsx
@@ -1,69 +1,170 @@
-import React from "react";
-import { PageSection, Switch } from "@patternfly/react-core";
+import React, { useMemo, useState } from "react";
+import {
+  AlertVariant,
+  Button,
+  ButtonVariant,
+  Divider,
+  Flex,
+  FlexItem,
+  PageSection,
+  Radio,
+  Title,
+  ToolbarItem,
+} from "@patternfly/react-core";
 
 import "./RealmSettingsSection.css";
 import { ListEmptyState } from "../components/list-empty-state/ListEmptyState";
 import { KeycloakDataTable } from "../components/table-toolbar/KeycloakDataTable";
 import { useTranslation } from "react-i18next";
 import { useAdminClient } from "../context/auth/AdminClient";
+import { upperCaseFormatter } from "../util";
+import { CodeEditor, Language } from "@patternfly/react-code-editor";
+import { Link } from "react-router-dom";
+import type ClientPolicyRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientPolicyRepresentation";
+import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
+import { useAlerts } from "../components/alert/Alerts";
 
 export const PoliciesTab = () => {
-  const { t } = useTranslation("identity-providers");
+  const { t } = useTranslation("realm-settings");
   const adminClient = useAdminClient();
+  const { addAlert, addError } = useAlerts();
 
-  // const form = useForm<ClientPolicyRepresentation>({ mode: "onChange" });
-
-  const EnabledRenderer = () => {
-    return (
-      <>
-        {" "}
-        <Switch
-          id="multiValued"
-          label={t("common:on")}
-          labelOff={t("common:off")}
-          isChecked={true}
-          // onChange={(value) => onChange(!value)}
-        />
-      </>
-    );
-  };
+  const [show, setShow] = useState(false);
+  const [policies, setPolicies] = useState<ClientPolicyRepresentation[]>([]);
+  const [selectedPolicy, setSelectedPolicy] =
+    useState<ClientPolicyRepresentation>();
 
   const loader = async () => {
     const policies = await adminClient.clientPolicies.listPolicies();
+
+    setPolicies(policies.policies!);
+
     return policies.policies!;
   };
 
+  const code = useMemo(() => JSON.stringify(policies, null, 2), [policies]);
+
+  const [toggleDeleteDialog, DeleteConfirm] = useConfirmDialog({
+    titleKey: t("deleteClientPolicyConfirmTitle"),
+    messageKey: t("deleteClientPolicyConfirm", {
+      policyName: selectedPolicy?.name,
+    }),
+    continueButtonLabel: t("delete"),
+    continueButtonVariant: ButtonVariant.danger,
+    onConfirm: async () => {
+      try {
+        // delete client policy here
+        addAlert(t("deleteClientPolicySuccess"), AlertVariant.success);
+      } catch (error) {
+        addError(t("deleteClientPolicyError"), error);
+      }
+    },
+  });
+
   return (
-    <PageSection variant="light" padding={{ default: "noPadding" }}>
-      <KeycloakDataTable
-        emptyState={
-          <ListEmptyState
-            message={t("identity-providers:noMappers")}
-            instructions={t("identity-providers:noMappersInstructions")}
-            primaryActionText={t("identity-providers:addMapper")}
-          />
-        }
-        loader={loader}
-        isPaginated
-        ariaLabelKey="identity-providers:mappersList"
-        searchPlaceholderKey="identity-providers:searchForMapper"
-        columns={[
-          {
-            name: "name",
-            displayKey: "common:name",
-          },
-          {
-            name: "enabled",
-            displayKey: "realm-settings:status",
-            // cellFormatters: [upperCaseFormatter()],
-            cellRenderer: EnabledRenderer,
-          },
-          {
-            name: "description",
-            displayKey: "common:description",
-          },
-        ]}
-      />
-    </PageSection>
+    <>
+      <DeleteConfirm />
+      <PageSection>
+        <Flex className="kc-policies-config-section">
+          <FlexItem>
+            <Title headingLevel="h1" size="md">
+              {t("policiesConfigType")}
+            </Title>
+          </FlexItem>
+          <FlexItem>
+            <Radio
+              isChecked={!show}
+              name="formView"
+              onChange={() => setShow(false)}
+              label={t("policiesConfigTypes.formView")}
+              id="formView-radioBtn"
+              className="kc-form-radio-btn pf-u-mr-sm pf-u-ml-sm"
+            />
+          </FlexItem>
+          <FlexItem>
+            <Radio
+              isChecked={show}
+              name="jsonEditor"
+              onChange={() => setShow(true)}
+              label={t("policiesConfigTypes.jsonEditor")}
+              id="jsonEditor-radioBtn"
+              className="kc-editor-radio-btn"
+            />
+          </FlexItem>
+        </Flex>
+      </PageSection>
+      <Divider />
+      {!show ? (
+        <KeycloakDataTable
+          emptyState={
+            <ListEmptyState
+              message={t("realm-settings:noClientPolicies")}
+              instructions={t("realm-settings:noClientPoliciesInstructions")}
+              primaryActionText={t("realm-settings:createClientPolicy")}
+            />
+          }
+          ariaLabelKey="identity-providers:mappersList"
+          searchPlaceholderKey="realm-settings:clientPolicySearch"
+          isPaginated
+          loader={loader}
+          toolbarItem={
+            <ToolbarItem>
+              <Button
+                id="createPolicy"
+                component={Link}
+                data-testid="createPolicy"
+              >
+                {t("createClientPolicy")}
+              </Button>
+            </ToolbarItem>
+          }
+          actions={[
+            {
+              title: t("common:delete"),
+              onRowClick: (item) => {
+                toggleDeleteDialog();
+                setSelectedPolicy(item);
+              },
+            },
+          ]}
+          columns={[
+            {
+              name: "name",
+              displayKey: "common:name",
+            },
+            {
+              name: "enabled",
+              displayKey: "realm-settings:status",
+              cellFormatters: [upperCaseFormatter()],
+            },
+            {
+              name: "description",
+              displayKey: "common:description",
+            },
+          ]}
+        />
+      ) : (
+        <>
+          <div className="pf-u-mt-md pf-u-ml-lg">
+            <CodeEditor
+              isLineNumbersVisible
+              isLanguageLabelVisible
+              code={code}
+              language={Language.json}
+              height="30rem"
+            />
+          </div>
+          <div className="pf-u-mt-md">
+            <Button
+              variant={ButtonVariant.primary}
+              className="pf-u-mr-md pf-u-ml-lg"
+            >
+              {t("save")}
+            </Button>
+            <Button variant={ButtonVariant.secondary}> {t("reload")}</Button>
+          </div>
+        </>
+      )}
+    </>
   );
 };

--- a/src/realm-settings/PoliciesTab.tsx
+++ b/src/realm-settings/PoliciesTab.tsx
@@ -1,40 +1,36 @@
 import React from "react";
-import { PageSection } from "@patternfly/react-core";
+import { PageSection, Switch } from "@patternfly/react-core";
 
 import "./RealmSettingsSection.css";
 import { ListEmptyState } from "../components/list-empty-state/ListEmptyState";
 import { KeycloakDataTable } from "../components/table-toolbar/KeycloakDataTable";
 import { useTranslation } from "react-i18next";
 import { useAdminClient } from "../context/auth/AdminClient";
-import { getBaseUrl, upperCaseFormatter } from "../util";
-import { useRealm } from "../context/realm-context/RealmContext";
 
 export const PoliciesTab = () => {
   const { t } = useTranslation("identity-providers");
   const adminClient = useAdminClient();
-  const { realm } = useRealm();
+
+  // const form = useForm<ClientPolicyRepresentation>({ mode: "onChange" });
+
+  const EnabledRenderer = () => {
+    return (
+      <>
+        {" "}
+        <Switch
+          id="multiValued"
+          label={t("common:on")}
+          labelOff={t("common:off")}
+          isChecked={true}
+          // onChange={(value) => onChange(!value)}
+        />
+      </>
+    );
+  };
 
   const loader = async () => {
-    //TODO: remove when clientPolicies.listPolicies() endpoint is merged
-    const response = await fetch(
-      `${getBaseUrl(
-        adminClient
-      )}admin/realms/${realm}/client-policies/policies`,
-      {
-        method: "GET",
-        headers: {
-          Authorization: `bearer ${await adminClient.getAccessToken()}`,
-        },
-      }
-    );
-
-    const result = await response.json();
-    console.log(result?.policies);
-    return result?.policies;
-
-    // TODO: use this call once the code above can be removed
-    // const profiles = await adminClient.clientPolicies.listPolicies();
-    // return profiles?.profiles
+    const policies = await adminClient.clientPolicies.listPolicies();
+    return policies.policies!;
   };
 
   return (
@@ -58,8 +54,9 @@ export const PoliciesTab = () => {
           },
           {
             name: "enabled",
-            displayKey: "common:enabled",
-            cellFormatters: [upperCaseFormatter()],
+            displayKey: "realm-settings:status",
+            // cellFormatters: [upperCaseFormatter()],
+            cellRenderer: EnabledRenderer,
           },
           {
             name: "description",

--- a/src/realm-settings/messages.ts
+++ b/src/realm-settings/messages.ts
@@ -230,6 +230,7 @@ export default {
     tokens: "Tokens",
     key: "Key",
     value: "Value",
+    status: "Status",
     convertedToYearsValue: "{{convertedToYears}}",
     convertedToDaysValue: "{{convertedToDays}}",
     convertedToHoursValue: "{{convertedToHours}}",

--- a/src/realm-settings/messages.ts
+++ b/src/realm-settings/messages.ts
@@ -195,6 +195,7 @@ export default {
     noClientPoliciesInstructions:
       "There are no client policies. Select 'Create client policy' to create a new client policy.",
     createClientPolicy: "Create client policy",
+    clientPolicySearch: "Search client policy",
     policiesConfigType: "Configure via:",
     policiesConfigTypes: {
       formView: "Form view",

--- a/src/realm-settings/messages.ts
+++ b/src/realm-settings/messages.ts
@@ -191,6 +191,20 @@ export default {
     idpAccountEmailVerification: "IdP account email verification",
     executeActions: "Execute actions",
     clientPolicies: "Client policies",
+    noClientPolicies: "No client policies",
+    noClientPoliciesInstructions:
+      "There are no client policies. Select 'Create client policy' to create a new client policy.",
+    createClientPolicy: "Create client policy",
+    policiesConfigType: "Configure via:",
+    policiesConfigTypes: {
+      formView: "Form view",
+      jsonEditor: "JSON editor",
+    },
+    deleteClientPolicyConfirmTitle: "Delete policy?",
+    deleteClientPolicyConfirm:
+      "This action will permanently delete the policy {{policyName}}. This cannot be undone.",
+    deleteClientPolicySuccess: "Client policy deleted",
+    deleteClientPolicyError: "Could not delete policy: {{error}}",
     profiles: "Profiles",
     policies: "Policies",
     clientPoliciesProfilesHelpText:


### PR DESCRIPTION
## Motivation
<!-- Add references to relevant tickets, issues, design specs and/or a short description of what motivated you to do it. -->

https://issues.redhat.com/browse/CLUX-262

## Brief Description
<!-- Add a short answer for: 
What was done in this PR? (e.g Fix to prevent users from accessing feature X.)
Why it was done? (e.g Feature X was deprecated.)
-->

Add policies list to client policies

## Verification Steps
<!--
Add the steps required to verify this change. Keep in mind that these steps should be written so groups unfamiliar with the 
new functionality can follow them, such as QE or documentation.-->


1. Go to old admin console.
2. Go to Realm settings -> Client policies -> policies subtab
3. Click "Create" and fill out the form fields. 
4. Save the new policies.
5. Go to the new admin console
6. Go to Realm settings -> Client policies -> policies subtab
7. Verify the policies you created are listed in the table correctly.

## Checklist:

- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [x] Help has been implemented
- [x] axe report has been run and resulting a11y issues have been resolved
- [x] Unit tests have been created/updated

## Additional Notes
<!-- 
Add images and/or screen caps to illustrate what was changed if this pull request adds to or modifies existing user-visible appearance/output. 
-->

- Enabled/disabled switches, and create/update/delete functionality will be implemented once https://github.com/keycloak/keycloak-nodejs-admin-client/pull/258 is merged
- Tests will be written once CRUD functionality can be implemented for policies (also dependent on https://github.com/keycloak/keycloak-nodejs-admin-client/pull/258)
