### PR TITLE
Add editMode as a required field

### DIFF
--- a/cypress/integration/user_fed_ldap_mapper_test.spec.ts
+++ b/cypress/integration/user_fed_ldap_mapper_test.spec.ts
@@ -29,6 +29,7 @@ const firstBindType = "simple";
 const firstBindDn = "user-1";
 const firstBindCreds = "password1";
 
+const firstEditMode = "READ_ONLY";
 const firstUsersDn = "user-dn-1";
 const firstUserLdapAtt = "uid";
 const firstRdnLdapAtt = "uid";
@@ -102,6 +103,7 @@ describe("User Fed LDAP mapper tests", () => {
       firstBindCreds
     );
     providersPage.fillLdapRequiredSearchingData(
+      firstEditMode,
       firstUsersDn,
       firstUserLdapAtt,
       firstRdnLdapAtt,

--- a/cypress/integration/user_fed_ldap_test.spec.ts
+++ b/cypress/integration/user_fed_ldap_test.spec.ts
@@ -22,6 +22,7 @@ const firstBindType = "simple";
 const firstBindDn = "user-1";
 const firstBindCreds = "password1";
 
+const firstEditMode = "READ_ONLY";
 const firstUsersDn = "user-dn-1";
 const firstUserLdapAtt = "uid";
 const firstRdnLdapAtt = "uid";
@@ -33,6 +34,7 @@ const secondLdapVendor = "Other";
 
 const secondBindType = "none";
 
+const secondEditMode = "WRITABLE";
 const secondUsersDn = "user-dn-2";
 const secondUserLdapAtt = "cn";
 const secondRdnLdapAtt = "cn";
@@ -80,6 +82,7 @@ describe("User Fed LDAP tests", () => {
       firstBindCreds
     );
     providersPage.fillLdapRequiredSearchingData(
+      firstEditMode,
       firstUsersDn,
       firstUserLdapAtt,
       firstRdnLdapAtt,
@@ -162,6 +165,7 @@ describe("User Fed LDAP tests", () => {
     providersPage.fillLdapRequiredGeneralData(secondLdapName, secondLdapVendor);
     providersPage.fillLdapRequiredConnectionData(connectionUrl, secondBindType);
     providersPage.fillLdapRequiredSearchingData(
+      secondEditMode,
       secondUsersDn,
       secondUserLdapAtt,
       secondRdnLdapAtt,

--- a/cypress/support/pages/admin_console/manage/providers/ProviderPage.ts
+++ b/cypress/support/pages/admin_console/manage/providers/ProviderPage.ts
@@ -18,6 +18,8 @@ export default class ProviderPage {
   private ldapBindCredsInput = "data-testid=ldap-bind-credentials";
 
   // LdapSettingsSearching required input values
+  private ldapEditModeInput = "#kc-edit-mode";
+  private ldapEditModeList = "#kc-edit-mode + ul";
   private ldapUsersDnInput = "data-testid=ldap-users-dn";
   private ldapUserLdapAttInput = "data-testid=ldap-username-attribute";
   private ldapRdnLdapAttInput = "data-testid=ldap-rdn-attribute";
@@ -167,12 +169,18 @@ export default class ProviderPage {
   }
 
   fillLdapRequiredSearchingData(
+    editMode: string,
     usersDn: string,
     userLdapAtt: string,
     rdnLdapAtt: string,
     uuidLdapAtt: string,
     userObjClasses: string
   ) {
+    if (editMode) {
+      cy.get(this.ldapEditModeInput).click();
+      cy.get(this.ldapEditModeList).contains(editMode).click();
+    }
+
     if (usersDn) {
       cy.get(`[${this.ldapUsersDnInput}]`).type(usersDn);
     }

--- a/src/user-federation/ldap/LdapSettingsSearching.tsx
+++ b/src/user-federation/ldap/LdapSettingsSearching.tsx
@@ -52,11 +52,15 @@ export const LdapSettingsSearching = ({
             />
           }
           fieldId="kc-edit-mode"
+          isRequired
         >
           <Controller
             name="config.editMode[0]"
             defaultValue=""
             control={form.control}
+            rules={{
+              required: { value: true, message: t("validateEditMode") },
+            }}
             render={({ onChange, value }) => (
               <Select
                 toggleId="kc-edit-mode"
@@ -66,19 +70,24 @@ export const LdapSettingsSearching = ({
                 }
                 isOpen={isEditModeDropdownOpen}
                 onSelect={(_, value) => {
-                  onChange(value as string);
+                  onChange(value.toString());
                   setIsEditModeDropdownOpen(false);
                 }}
                 selections={value}
                 variant={SelectVariant.single}
               >
-                <SelectOption key={0} value="" isPlaceholder />
-                <SelectOption key={1} value="READ_ONLY" />
-                <SelectOption key={2} value="WRITABLE" />
-                <SelectOption key={3} value="UNSYNCED" />
+                <SelectOption value="" isPlaceholder />
+                <SelectOption value="READ_ONLY" />
+                <SelectOption value="WRITABLE" />
+                <SelectOption value="UNSYNCED" />
               </Select>
             )}
-          ></Controller>
+          />
+          {form.errors.config?.editMode?.[0] && (
+            <div className="error">
+              {form.errors.config.editMode[0].message}
+            </div>
+          )}
         </FormGroup>
         <FormGroup
           label={t("usersDN")}

--- a/src/user-federation/messages.ts
+++ b/src/user-federation/messages.ts
@@ -127,6 +127,7 @@ export default {
     validateBindCredentials: "You must enter the password of the LDAP admin",
     validateUuidLDAPAttribute: "You must enter a UUID LDAP attribute",
     validateUserObjectClasses: "You must enter one or more user object classes",
+    validateEditMode: "You must select an edit mode",
     validateUsersDn: "You must enter users DN",
     validateUsernameLDAPAttribute: "You must enter a username LDAP attribute",
     validateRdnLdapAttribute: "You must enter an RDN LDAP attribute",


### PR DESCRIPTION
## Motivation
In the in-development version of Keycloak the 'Edit mode' field for the LDAP provider is required. In order for the tests to pass in #1207 this will have to be merged.