### PR TITLE
Identity Providers(mappers): fix help text

### DIFF
--- a/src/identity-providers/add/AddMapper.tsx
+++ b/src/identity-providers/add/AddMapper.tsx
@@ -26,7 +26,6 @@ import {
 } from "../../components/attribute-form/AttributeForm";
 import { FormAccess } from "../../components/form-access/FormAccess";
 import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
-import type IdentityProviderMapperRepresentation from "@keycloak/keycloak-admin-client/lib/defs/identityProviderMapperRepresentation";
 import type { IdentityProviderAddMapperParams } from "../routes/AddMapper";
 import _ from "lodash";
 import { AssociatedRolesModal } from "../../realm-roles/AssociatedRolesModal";
@@ -35,6 +34,7 @@ import { useAlerts } from "../../components/alert/Alerts";
 import type { IdentityProviderEditMapperParams } from "../routes/EditMapper";
 import { convertToFormValues } from "../../util";
 import { toIdentityProvider } from "../routes/IdentityProvider";
+import type IdentityProviderMapperRepresentation from "@keycloak/keycloak-admin-client/lib/defs/identityProviderMapperRepresentation";
 
 type IdPMapperRepresentationWithAttributes =
   IdentityProviderMapperRepresentation & {
@@ -58,6 +58,7 @@ export const AddMapper = () => {
 
   const [mapperTypes, setMapperTypes] =
     useState<Record<string, IdentityProviderMapperRepresentation>>();
+  const [mapperType, setMapperType] = useState("advancedAttributeToRole");
   const [currentMapper, setCurrentMapper] =
     useState<IdentityProviderMapperRepresentation>();
   const [roles, setRoles] = useState<RoleRepresentation[]>([]);
@@ -294,7 +295,7 @@ export const AddMapper = () => {
           label={t("mapperType")}
           labelIcon={
             <HelpItem
-              helpText="identity-providers-help:mapperType"
+              helpText={`identity-providers-help:${mapperType}`}
               forLabel={t("mapperType")}
               forID={t(`common:helpLabel`, { label: t("mapperType") })}
             />
@@ -326,6 +327,7 @@ export const AddMapper = () => {
                         value.toString().toLowerCase()
                     );
 
+                  setMapperType(_.camelCase(value.toString()));
                   onChange(theMapper?.id);
                   setMapperTypeOpen(false);
                 }}

--- a/src/identity-providers/add/AddMapper.tsx
+++ b/src/identity-providers/add/AddMapper.tsx
@@ -304,9 +304,10 @@ export const AddMapper = () => {
           labelIcon={
             <HelpItem
               helpText={
-                mapperType === "attributeImporter" && providerId === "saml"
-                  ? `identity-providers-help:${mapperType}`
-                  : `identity-providers-help:oidcAttributeImporter`
+                mapperType === "attributeImporter" &&
+                (providerId === "oidc" || providerId === "keycloak-oidc")
+                  ? `identity-providers-help:oidcAttributeImporter`
+                  : `identity-providers-help:${mapperType}`
               }
               forLabel={t("mapperType")}
               forID={t(`common:helpLabel`, { label: t("mapperType") })}

--- a/src/identity-providers/add/AddMapper.tsx
+++ b/src/identity-providers/add/AddMapper.tsx
@@ -175,7 +175,15 @@ export const AddMapper = () => {
     <PageSection variant="light">
       <ViewHeader
         className="kc-add-mapper-title"
-        titleKey={id ? t("editIdPMapper") : t("addIdPMapper")}
+        titleKey={
+          id
+            ? t("editIdPMapper", {
+                providerId: providerId.toUpperCase(),
+              })
+            : t("addIdPMapper", {
+                providerId: providerId.toUpperCase(),
+              })
+        }
         divider
       />
       <AssociatedRolesModal
@@ -295,7 +303,11 @@ export const AddMapper = () => {
           label={t("mapperType")}
           labelIcon={
             <HelpItem
-              helpText={`identity-providers-help:${mapperType}`}
+              helpText={
+                mapperType === "attributeImporter" && providerId === "saml"
+                  ? `identity-providers-help:${mapperType}`
+                  : `identity-providers-help:oidcAttributeImporter`
+              }
               forLabel={t("mapperType")}
               forID={t(`common:helpLabel`, { label: t("mapperType") })}
             />
@@ -370,19 +382,10 @@ export const AddMapper = () => {
               }
               fieldId="kc-gui-order"
             >
-              <Controller
-                name="config.attributes"
-                defaultValue={"[]"}
-                control={control}
-                render={() => {
-                  return (
-                    <AttributesForm
-                      form={form}
-                      inConfig
-                      array={{ fields, append, remove }}
-                    />
-                  );
-                }}
+              <AttributesForm
+                form={form}
+                inConfig
+                array={{ fields, append, remove }}
               />
             </FormGroup>
             <FormGroup

--- a/src/identity-providers/add/AddMapper.tsx
+++ b/src/identity-providers/add/AddMapper.tsx
@@ -221,7 +221,7 @@ export const AddMapper = () => {
           labelIcon={
             <HelpItem
               id="name-help-icon"
-              helpText="identity-providers-help:name"
+              helpText="identity-providers-help:addIdpMapperName"
               forLabel={t("common:name")}
               forID={t(`common:helpLabel`, { label: t("common:name") })}
             />

--- a/src/identity-providers/help.ts
+++ b/src/identity-providers/help.ts
@@ -109,9 +109,17 @@ export default {
       "Overrides the default sync mode of the IDP for this mapper. Values are: 'legacy' to keep the behaviour before this option was introduced, 'import' to only import the user once during first login of the user with this identity provider, 'force' to always update the user during every login with this identity provider and 'inherit' to use the sync mode defined in the identity provider for this mapper.",
     advancedAttributeToRole:
       "If the set of attributes exists and can be matched, grant the user the specified realm or client role.",
-    usernameTemplateImporter: "Format the username to import",
+    usernameTemplateImporter: "Format the username to import.",
     hardcodedUserSessionAttribute:
       "When a user is imported from a provider, hardcode a value to a specific user session attribute.",
+    externalRoleToRole:
+      "Looks for an external role in a keycloak access token. If external role exists, grant the user the specified realm or client role.",
+    advancedClaimToRole:
+      "If all claims exist, grant the user the specified realm or client role.",
+    claimToRole:
+      "If a claim exists, grant the user the specified realm or client role.",
+    oidcAttributeImporter:
+      "Import declared claim if it exists in ID, access token, or the claim set returned by the user profile endpoint into the specified user property or attribute.",
     attributeImporter:
       "Import declared SAML attribute if it exists in assertion into the specified user property or attribute.",
     hardcodedRole:

--- a/src/identity-providers/help.ts
+++ b/src/identity-providers/help.ts
@@ -107,8 +107,19 @@ export default {
     addIdpMapperName: "Name of the mapper.",
     syncModeOverride:
       "Overrides the default sync mode of the IDP for this mapper. Values are: 'legacy' to keep the behaviour before this option was introduced, 'import' to only import the user once during first login of the user with this identity provider, 'force' to always update the user during every login with this identity provider and 'inherit' to use the sync mode defined in the identity provider for this mapper.",
-    mapperType:
+    advancedAttributeToRole:
       "If the set of attributes exists and can be matched, grant the user the specified realm or client role.",
+    usernameTemplateImporter: "Format the username to import",
+    hardcodedUserSessionAttribute:
+      "When a user is imported from a provider, hardcode a value to a specific user session attribute.",
+    attributeImporter:
+      "Import declared SAML attribute if it exists in assertion into the specified user property or attribute.",
+    hardcodedRole:
+      "When user is imported from provider, hardcode a role mapping for it.",
+    hardcodedAttribute:
+      "When user is imported from provider, hardcode a value to a specific user attribute.",
+    samlAttributeToRole:
+      "If an attribute exists, grant the user the specified realm or client role.",
     attributes:
       "Name and (regex) value of the attributes to search for in token. The configured name of an attribute is searched in SAML attribute name and attribute friendly name fields. Every given attribute description must be met to set the role. If the attribute is an array, then the value must be contained in the array. If an attribute can be found several times, then one match is sufficient.",
     regexAttributeValues:

--- a/src/identity-providers/messages.ts
+++ b/src/identity-providers/messages.ts
@@ -6,8 +6,8 @@ export default {
     providerDetails: "Provider details",
     addProvider: "Add provider",
     addMapper: "Add mapper",
-    addIdPMapper: "Add Identity Provider Mapper",
-    editIdPMapper: "Edit Identity Provider Mapper",
+    addIdPMapper: "Add {{providerId}} Identity Provider Mapper",
+    editIdPMapper: "Edit {{providerId}} Identity Provider Mapper",
     mappersList: "Mappers list",
     noMappers: "No Mappers",
     noMappersInstructions:
@@ -148,6 +148,9 @@ export default {
     },
     mapperTypes: {
       advancedAttributeToRole: "Advanced Attribute To Role",
+      advancedClaimToRole: "Advanced Claim To Role",
+      externalRoleToRole: "External Role To Role",
+      claimToRole: "Claim To Role",
       usernameTemplateImporter: "Username Template Importer",
       hardcodedUserSessionAttribute: "Hardcoded User Session Attribute",
       attributeImporter: "Attribute Importer",


### PR DESCRIPTION
## Motivation
<!-- Add references to relevant tickets, issues, design specs and/or a short description of what motivated you to do it. -->
Closes #1205 

## Brief Description
<!-- Add a short answer for: 
What was done in this PR? (e.g Fix to prevent users from accessing feature X.)
Why it was done? (e.g Feature X was deprecated.)
-->

## Verification Steps
<!--
Add the steps required to verify this change. Keep in mind that these steps should be written so groups unfamiliar with the 
new functionality can follow them, such as QE or documentation.-->

1. Go to Identity Providers -> Select a Provider -> Click Mappers tab
2. Add a mapper
3. Verify that the help text for the "Name" field is correct.
4. Verify that the help text for all mapper types changes with the selected mapper type. 


## Checklist:

- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [x] Help has been implemented
- [x] axe report has been run and resulting a11y issues have been resolved
- [x] Unit tests have been created/updated

## Additional Notes
<!-- 
Add images and/or screen caps to illustrate what was changed if this pull request adds to or modifies existing user-visible appearance/output. 
-->
