### PR TITLE
Make 'stored tokens readable' field applicable to OIDC providers

### DIFF
--- a/src/identity-providers/add/AdvancedSettings.tsx
+++ b/src/identity-providers/add/AdvancedSettings.tsx
@@ -106,7 +106,7 @@ export const AdvancedSettings = ({ isOIDC, isSAML }: AdvancedSettingsProps) => {
         <TextField field="config.defaultScope" label="scopes" />
       )}
       <SwitchField field="storeToken" label="storeTokens" fieldType="boolean" />
-      {isSAML && (
+      {(isSAML || isOIDC) && (
         <SwitchField
           field="addReadTokenRoleOnCreate"
           label="storedTokensReadable"


### PR DESCRIPTION
## Motivation
Fixes https://github.com/keycloak/keycloak-admin-ui/issues/1202.

## Brief Description
Saw this issue and knew that i had already added the `Stored tokens readable` field for SAML, so just a very quick code change to make it applicable to OIDC and Keycloak OIDC as well.

## Verification Steps
In the old admin console:
1. Create an OIDC provider. 
2. Edit the OIDC provider and enable `Stored tokens readable`.

In the new admin console:
3. Edit the OIDC provider created in step 1.
4. Verify that the `Stored tokens readable` field is enabled.
5. Verify that you can change the setting in the new console and it persists on save.

Repeat steps 1-5 for a Keycloak OIDC provider.

## Checklist:
- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [x] Help has been implemented
- [x] Unit tests have been created/updated

## Additional Notes
None