### PR TITLE
Run jobs for CI in parallel

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [master]
 jobs:
-  build:
+  setup:
     runs-on: ubuntu-latest
     steps:
       - name: Check out Admin UI
@@ -18,7 +18,38 @@ jobs:
           check-latest: true
           cache: npm
 
-      - run: npm ci
-      - run: npm run lint
-      - run: npm run test
-      - run: npm run build
+      - name: Cache Node modules
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+
+      - name: Install dependencies
+        run: test -d node_modules || npm ci
+
+      - name: Cache setup
+        uses: actions/cache@v2
+        with:
+          path: ./*
+          key: ${{ github.sha }}
+
+  run:
+    needs: setup
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        command: [lint, test, build]
+    steps:
+      - name: Restore setup
+        uses: actions/cache@v2
+        with:
+          path: ./*
+          key: ${{ github.sha }}
+
+      - name: Set up Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16
+
+      - name: Run ${{ matrix.command }} task
+        run: npm run ${{ matrix.command }}


### PR DESCRIPTION
## Motivation
Runs the different tasks (test, build, lint) in parallel and adds an additional level of caching so the CI can pass faster. The intention is to apply the learnings from this on the Cypress workflow as well but I wanted to work on something smaller first to understand Github actions a bit better.