### PR TITLE
Prevent Dependabot from automatically rebasing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,7 @@ updates:
 - package-ecosystem: npm
   directory: "/"
   open-pull-requests-limit: 999
+  rebase-strategy: disabled
   schedule:
     interval: weekly
   ignore:


### PR DESCRIPTION
## Motivation
Dependabot can rebase open PRs very aggressively when another PR is merged, even if the HEAD is in a mergable state with master. This means that a lot of tasks such as the Cypress tests are kicked off unnecessarily causing the pipeline to get bogged down.

This change disables this behavior, which can instead by triggered manually by means of a comment on the respective PR.