### PR TITLE
Identity Providers(Mappers): Add create/edit functionality for mappers of type Username Template Importer

### DIFF
--- a/cypress/integration/identity_providers.spec.ts
+++ b/cypress/integration/identity_providers.spec.ts
@@ -165,9 +165,25 @@ describe("Identity provider test", () => {
 
       addMapperPage.clickAdd();
 
-      addMapperPage.fillSAMLorOIDCMapper("SAML mapper 2");
+      addMapperPage.addUsernameTemplateImporterMapper(
+        "SAML Username Template Importer Mapper"
+      );
 
       masthead.checkNotificationMessage(createMapperSuccessMsg);
+    });
+
+    it("should edit Username Template Importer mapper", () => {
+      sidebarPage.goToIdentityProviders();
+
+      listingPage.goToItemDetails("saml");
+
+      addMapperPage.goToMappersTab();
+
+      listingPage.goToItemDetails("SAML Username Template Importer Mapper");
+
+      addMapperPage.editUsernameTemplateImporterMapper();
+
+      masthead.checkNotificationMessage(saveMapperSuccessMsg);
     });
 
     it("should edit facebook mapper", () => {

--- a/cypress/integration/identity_providers.spec.ts
+++ b/cypress/integration/identity_providers.spec.ts
@@ -156,6 +156,20 @@ describe("Identity provider test", () => {
       masthead.checkNotificationMessage(createMapperSuccessMsg);
     });
 
+    it("should add SAML mapper of type Username Template Importer", () => {
+      sidebarPage.goToIdentityProviders();
+
+      listingPage.goToItemDetails("saml");
+
+      addMapperPage.goToMappersTab();
+
+      addMapperPage.clickAdd();
+
+      addMapperPage.fillSAMLorOIDCMapper("SAML mapper 2");
+
+      masthead.checkNotificationMessage(createMapperSuccessMsg);
+    });
+
     it("should edit facebook mapper", () => {
       sidebarPage.goToIdentityProviders();
 

--- a/cypress/integration/identity_providers.spec.ts
+++ b/cypress/integration/identity_providers.spec.ts
@@ -133,7 +133,7 @@ describe("Identity provider test", () => {
 
       addMapperPage.goToMappersTab();
 
-      addMapperPage.clickAdd();
+      addMapperPage.emptyStateAddMapper();
 
       addMapperPage.fillSocialMapper("facebook mapper");
 
@@ -149,7 +149,7 @@ describe("Identity provider test", () => {
 
       addMapperPage.goToMappersTab();
 
-      addMapperPage.clickAdd();
+      addMapperPage.emptyStateAddMapper();
 
       addMapperPage.fillSAMLorOIDCMapper("SAML mapper");
 
@@ -163,7 +163,7 @@ describe("Identity provider test", () => {
 
       addMapperPage.goToMappersTab();
 
-      addMapperPage.clickAdd();
+      addMapperPage.addMapper();
 
       addMapperPage.addUsernameTemplateImporterMapper(
         "SAML Username Template Importer Mapper"

--- a/cypress/support/pages/admin_console/manage/identity_providers/AddMapperPage.ts
+++ b/cypress/support/pages/admin_console/manage/identity_providers/AddMapperPage.ts
@@ -97,7 +97,7 @@ export default class AddMapperPage {
     cy.get(this.idpMapperSelectToggle).click();
 
     cy.findByTestId(this.idpMapperSelect)
-      .contains("Hardcoded User Session Attribute")
+      .contains("Advanced Attribute To Role")
       .click();
 
     cy.get(this.attributesKeyInput).clear();

--- a/cypress/support/pages/admin_console/manage/identity_providers/AddMapperPage.ts
+++ b/cypress/support/pages/admin_console/manage/identity_providers/AddMapperPage.ts
@@ -114,6 +114,38 @@ export default class AddMapperPage {
     return this;
   }
 
+  addUsernameTemplateImporterMapper(name: string) {
+    cy.get(this.mapperNameInput).clear();
+
+    cy.get(this.mapperNameInput).clear().type(name);
+
+    cy.get(this.syncmodeSelectToggle).click();
+
+    cy.findByTestId("inherit").click();
+
+    cy.get(this.idpMapperSelectToggle).click();
+
+    cy.findByTestId(this.idpMapperSelect)
+      .contains("Username Template Importer")
+      .click();
+
+    cy.get(this.attributesKeyInput).clear();
+    cy.get(this.attributesKeyInput).type("key");
+
+    cy.get(this.attributesValueInput).clear();
+    cy.get(this.attributesValueInput).type("value");
+
+    this.toggleSwitch(this.regexAttributeValuesSwitch);
+
+    cy.findByTestId(this.selectRoleButton).click();
+
+    this.addRoleToMapperForm();
+
+    this.saveNewMapper();
+
+    return this;
+  }
+
   editSocialMapper() {
     cy.get(this.syncmodeSelectToggle).click();
 

--- a/cypress/support/pages/admin_console/manage/identity_providers/AddMapperPage.ts
+++ b/cypress/support/pages/admin_console/manage/identity_providers/AddMapperPage.ts
@@ -13,6 +13,9 @@ export default class AddMapperPage {
   private syncmodeSelectToggle = "#syncMode";
   private attributesKeyInput = 'input[name="config.attributes[0].key"]';
   private attributesValueInput = 'input[name="config.attributes[0].value"]';
+  private template = "template";
+  private target = "#target";
+  private targetDropdown = "#target-dropdown";
   private selectRoleButton = "select-role-button";
   private radio = "[type=radio]";
   private addAssociatedRolesModalButton = "add-associated-roles-button";
@@ -129,17 +132,28 @@ export default class AddMapperPage {
       .contains("Username Template Importer")
       .click();
 
-    cy.get(this.attributesKeyInput).clear();
-    cy.get(this.attributesKeyInput).type("key");
+    cy.findByTestId(this.template).clear();
+    cy.findByTestId(this.template).type("Template");
 
-    cy.get(this.attributesValueInput).clear();
-    cy.get(this.attributesValueInput).type("value");
+    cy.get(this.target).click();
 
-    this.toggleSwitch(this.regexAttributeValuesSwitch);
+    cy.get(this.targetDropdown).contains("LOCAL").click();
 
-    cy.findByTestId(this.selectRoleButton).click();
+    this.saveNewMapper();
 
-    this.addRoleToMapperForm();
+    return this;
+  }
+
+  editUsernameTemplateImporterMapper() {
+    cy.get(this.syncmodeSelectToggle).click();
+
+    cy.findByTestId("legacy").click();
+
+    cy.findByTestId(this.template).type("_edited");
+
+    cy.get(this.target).click();
+
+    cy.get(this.targetDropdown).contains("BROKER_ID").click();
 
     this.saveNewMapper();
 

--- a/cypress/support/pages/admin_console/manage/identity_providers/AddMapperPage.ts
+++ b/cypress/support/pages/admin_console/manage/identity_providers/AddMapperPage.ts
@@ -3,6 +3,7 @@ export default class AddMapperPage {
   private noMappersAddMapperButton = "no-mappers-empty-action";
   private idpMapperSelectToggle = "#identityProviderMapper";
   private idpMapperSelect = "idp-mapper-select";
+  private addMapperButton = "#add-mapper-button";
 
   private mapperNameInput = "#kc-name";
   private mapperRoleInput = "mapper-role-input";
@@ -25,8 +26,13 @@ export default class AddMapperPage {
     return this;
   }
 
-  clickAdd() {
+  emptyStateAddMapper() {
     cy.findByTestId(this.noMappersAddMapperButton).click();
+    return this;
+  }
+
+  addMapper() {
+    cy.get(this.addMapperButton).click();
     return this;
   }
 

--- a/src/identity-providers/add/AddMapper.tsx
+++ b/src/identity-providers/add/AddMapper.tsx
@@ -486,6 +486,7 @@ export const AddMapper = () => {
                       <Select
                         toggleId="target"
                         datatest-id="target-select"
+                        id="target-dropdown"
                         placeholderText={t("realm-settings:placeholderText")}
                         direction="down"
                         onToggle={() =>

--- a/src/identity-providers/add/AddMapper.tsx
+++ b/src/identity-providers/add/AddMapper.tsx
@@ -155,6 +155,14 @@ export const AddMapper = () => {
           form.setValue("config.role", value.role[0]);
         }
 
+        if (mapper.config?.template) {
+          form.setValue("config.template", value.template);
+        }
+
+        if (mapper.config?.target) {
+          form.setValue("config.target", value.target);
+        }
+
         convertToFormValues(value, "config", form.setValue);
       }
 
@@ -173,21 +181,11 @@ export const AddMapper = () => {
     setRolesModalOpen(!rolesModalOpen);
   };
 
-  console.log("mapperType", mapperType);
-
   return (
     <PageSection variant="light">
       <ViewHeader
         className="kc-add-mapper-title"
-        titleKey={
-          id
-            ? t("editIdPMapper", {
-                providerId: providerId.toUpperCase(),
-              })
-            : t("addIdPMapper", {
-                providerId: providerId.toUpperCase(),
-              })
-        }
+        titleKey={id ? t("editIdPMapper") : t("addIdPMapper")}
         divider
       />
       <AssociatedRolesModal
@@ -307,12 +305,7 @@ export const AddMapper = () => {
           label={t("mapperType")}
           labelIcon={
             <HelpItem
-              helpText={
-                mapperType === "attributeImporter" &&
-                (providerId === "oidc" || providerId === "keycloak-oidc")
-                  ? `identity-providers-help:oidcAttributeImporter`
-                  : `identity-providers-help:${mapperType}`
-              }
+              helpText={`identity-providers-help:${mapperType}`}
               forLabel={t("mapperType")}
               forID={t(`common:helpLabel`, { label: t("mapperType") })}
             />
@@ -376,48 +369,25 @@ export const AddMapper = () => {
         {isSAMLorOIDC ? (
           <>
             {" "}
-            <FormGroup
-              label={t("common:attributes")}
-              labelIcon={
-                <HelpItem
-                  helpText="identity-providers-help:attributes"
-                  forLabel={t("attributes")}
-                  forID={t(`common:helpLabel`, { label: t("attributes") })}
-                />
-              }
-              fieldId="kc-gui-order"
-            >
-              <AttributesForm
-                form={form}
-                inConfig
-                array={{ fields, append, remove }}
-              />
-            </FormGroup>
-            <FormGroup
-              label={t("regexAttributeValues")}
-              labelIcon={
-                <HelpItem
-                  helpText="identity-providers-help:regexAttributeValues"
-                  forLabel={t("regexAttributeValues")}
-                  forID={t(`common:helpLabel`, {
-                    label: t("regexAttributeValues"),
-                  })}
-                />
-              }
-              fieldId="regexAttributeValues"
-            >
-              <Controller
-                name="config.are-attribute-values-regex"
-                control={control}
-                defaultValue="false"
-                render={({ onChange, value }) => (
-                  <Switch
-                    id="regexAttributeValues"
-                    data-testid="regex-attribute-values-switch"
-                    label={t("common:on")}
-                    labelOff={t("common:off")}
-                    isChecked={value === "true"}
-                    onChange={(value) => onChange("" + value)}
+            {form.getValues().identityProviderMapper ===
+              "saml-advanced-role-idp-mapper" && (
+              <>
+                {" "}
+                <FormGroup
+                  label={t("common:attributes")}
+                  labelIcon={
+                    <HelpItem
+                      helpText="identity-providers-help:attributes"
+                      forLabel={t("attributes")}
+                      forID={t(`common:helpLabel`, { label: t("attributes") })}
+                    />
+                  }
+                  fieldId="kc-gui-order"
+                >
+                  <AttributesForm
+                    form={form}
+                    inConfig
+                    array={{ fields, append, remove }}
                   />
                 </FormGroup>
                 <FormGroup
@@ -451,7 +421,8 @@ export const AddMapper = () => {
                 </FormGroup>{" "}
               </>
             )}
-            {mapperType == "usernameTemplateImporter" && (
+            {form.getValues().identityProviderMapper ===
+              "saml-username-idp-mapper" && (
               <>
                 <FormGroup
                   label={t("template")}
@@ -479,6 +450,7 @@ export const AddMapper = () => {
                     id="kc-template"
                     data-testid="template"
                     name="config.template"
+                    defaultValue={currentMapper?.config.template}
                     validated={
                       errors.name
                         ? ValidatedOptions.error
@@ -508,7 +480,7 @@ export const AddMapper = () => {
                 >
                   <Controller
                     name="config.target"
-                    defaultValue={""}
+                    defaultValue={currentMapper?.config.target}
                     control={control}
                     render={({ onChange, value }) => (
                       <Select
@@ -544,9 +516,12 @@ export const AddMapper = () => {
                 </FormGroup>
               </>
             )}
-            {(mapperType === "advancedAttributeToRole" ||
-              mapperType === "hardcodedRole" ||
-              mapperType === "samlAttributeToRole") && (
+            {(form.getValues().identityProviderMapper ===
+              "saml-advanced-role-idp-mapper" ||
+              form.getValues().identityProviderMapper ===
+                "oidc-hardcoded-role-idp-mapper" ||
+              form.getValues().identityProviderMapper ===
+                "saml-role-idp-mapper") && (
               <FormGroup
                 label={t("common:role")}
                 labelIcon={

--- a/src/identity-providers/add/AddMapper.tsx
+++ b/src/identity-providers/add/AddMapper.tsx
@@ -159,14 +159,6 @@ export const AddMapper = () => {
           form.setValue("config.role", value.role[0]);
         }
 
-        if (mapper.config?.template) {
-          form.setValue("config.template", value.template);
-        }
-
-        if (mapper.config?.target) {
-          form.setValue("config.target", value.target);
-        }
-
         convertToFormValues(value, "config", form.setValue);
       }
 
@@ -184,10 +176,6 @@ export const AddMapper = () => {
   const toggleModal = () => {
     setRolesModalOpen(!rolesModalOpen);
   };
-
-  // console.log("mapperType", mapperType);
-
-  console.log("lalala", form.getValues().identityProviderMapper);
 
   return (
     <PageSection variant="light">
@@ -389,11 +377,9 @@ export const AddMapper = () => {
         </FormGroup>
         {isSAMLorOIDC ? (
           <>
-            {" "}
             {form.getValues().identityProviderMapper ===
               "saml-advanced-role-idp-mapper" && (
               <>
-                {" "}
                 <FormGroup
                   label={t("common:attributes")}
                   labelIcon={
@@ -439,7 +425,7 @@ export const AddMapper = () => {
                       />
                     )}
                   />
-                </FormGroup>{" "}
+                </FormGroup>
               </>
             )}
             {form.getValues().identityProviderMapper ===
@@ -538,12 +524,11 @@ export const AddMapper = () => {
                 </FormGroup>
               </>
             )}
-            {(form.getValues().identityProviderMapper ===
-              "saml-advanced-role-idp-mapper" ||
-              form.getValues().identityProviderMapper ===
-                "oidc-hardcoded-role-idp-mapper" ||
-              form.getValues().identityProviderMapper ===
-                "saml-role-idp-mapper") && (
+            {[
+              "saml-advanced-role-idp-mapper",
+              "oidc-hardcoded-role-idp-mapper",
+              "saml-role-idp-mapper",
+            ].includes(form.getValues().identityProviderMapper!) && (
               <FormGroup
                 label={t("common:role")}
                 labelIcon={
@@ -584,11 +569,11 @@ export const AddMapper = () => {
                   {t("selectRole")}
                 </Button>
               </FormGroup>
-            )}{" "}
-            {(form.getValues().identityProviderMapper ===
-              "hardcoded-user-session-attribute-idp-mapper" ||
-              form.getValues().identityProviderMapper ===
-                "hardcoded-attribute-idp-mapper") && (
+            )}
+            {[
+              "hardcoded-user-session-attribute-idp-mapper",
+              "hardcoded-attribute-idp-mapper",
+            ].includes(form.getValues().identityProviderMapper!) && (
               <>
                 <FormGroup
                   label={

--- a/src/identity-providers/add/AddMapper.tsx
+++ b/src/identity-providers/add/AddMapper.tsx
@@ -164,12 +164,16 @@ export const AddMapper = () => {
 
   const syncModes = ["inherit", "import", "legacy", "force"];
   const [syncModeOpen, setSyncModeOpen] = useState(false);
+  const targetOptions = ["local", "brokerId", "brokerUsername"];
+  const [targetOptionsOpen, setTargetOptionsOpen] = useState(false);
   const [mapperTypeOpen, setMapperTypeOpen] = useState(false);
   const [selectedRole, setSelectedRole] = useState<RoleRepresentation[]>([]);
 
   const toggleModal = () => {
     setRolesModalOpen(!rolesModalOpen);
   };
+
+  console.log("mapperType", mapperType);
 
   return (
     <PageSection variant="light">
@@ -415,49 +419,175 @@ export const AddMapper = () => {
                     isChecked={value === "true"}
                     onChange={(value) => onChange("" + value)}
                   />
-                )}
-              />
-            </FormGroup>
-            <FormGroup
-              label={t("common:role")}
-              labelIcon={
-                <HelpItem
-                  id="name-help-icon"
-                  helpText="identity-providers-help:role"
-                  forLabel={t("identity-providers-help:role")}
-                  forID={t(`identity-providers:helpLabel`, {
-                    label: t("role"),
-                  })}
-                />
-              }
-              fieldId="kc-role"
-              validated={
-                errors.config?.role
-                  ? ValidatedOptions.error
-                  : ValidatedOptions.default
-              }
-              helperTextInvalid={t("common:required")}
-            >
-              <TextInput
-                ref={register()}
-                type="text"
-                id="kc-role"
-                data-testid="mapper-role-input"
-                name="config.role"
-                value={selectedRole[0]?.name}
+                </FormGroup>
+                <FormGroup
+                  label={t("regexAttributeValues")}
+                  labelIcon={
+                    <HelpItem
+                      helpText="identity-providers-help:regexAttributeValues"
+                      forLabel={t("regexAttributeValues")}
+                      forID={t(`common:helpLabel`, {
+                        label: t("regexAttributeValues"),
+                      })}
+                    />
+                  }
+                  fieldId="regexAttributeValues"
+                >
+                  <Controller
+                    name="config.are-attribute-values-regex"
+                    control={control}
+                    defaultValue="false"
+                    render={({ onChange, value }) => (
+                      <Switch
+                        id="regexAttributeValues"
+                        data-testid="regex-attribute-values-switch"
+                        label={t("common:on")}
+                        labelOff={t("common:off")}
+                        isChecked={value === "true"}
+                        onChange={(value) => onChange("" + value)}
+                      />
+                    )}
+                  />
+                </FormGroup>{" "}
+              </>
+            )}
+            {mapperType == "usernameTemplateImporter" && (
+              <>
+                <FormGroup
+                  label={t("template")}
+                  labelIcon={
+                    <HelpItem
+                      id="target-help-icon"
+                      helpText="identity-providers-help:template"
+                      forLabel={t("template")}
+                      forID={t(`common:helpLabel`, {
+                        label: t("template"),
+                      })}
+                    />
+                  }
+                  fieldId="kc-user-session-attribute"
+                  validated={
+                    errors.name
+                      ? ValidatedOptions.error
+                      : ValidatedOptions.default
+                  }
+                  helperTextInvalid={t("common:required")}
+                >
+                  <TextInput
+                    ref={register()}
+                    type="text"
+                    id="kc-template"
+                    data-testid="template"
+                    name="config.template"
+                    validated={
+                      errors.name
+                        ? ValidatedOptions.error
+                        : ValidatedOptions.default
+                    }
+                  />
+                </FormGroup>
+                <FormGroup
+                  label={t("target")}
+                  labelIcon={
+                    <HelpItem
+                      id="user-session-attribute-help-icon"
+                      helpText="identity-providers-help:target"
+                      forLabel={t("target")}
+                      forID={t(`common:helpLabel`, {
+                        label: t("target"),
+                      })}
+                    />
+                  }
+                  fieldId="kc-target"
+                  validated={
+                    errors.name
+                      ? ValidatedOptions.error
+                      : ValidatedOptions.default
+                  }
+                  helperTextInvalid={t("common:required")}
+                >
+                  <Controller
+                    name="config.target"
+                    defaultValue={""}
+                    control={control}
+                    render={({ onChange, value }) => (
+                      <Select
+                        toggleId="target"
+                        datatest-id="target-select"
+                        placeholderText={t("realm-settings:placeholderText")}
+                        direction="down"
+                        onToggle={() =>
+                          setTargetOptionsOpen(!targetOptionsOpen)
+                        }
+                        onSelect={(_, value) => {
+                          onChange(t(`targetOptions.${value}`));
+                          setTargetOptionsOpen(false);
+                        }}
+                        selections={value}
+                        variant={SelectVariant.single}
+                        aria-label={t("target")}
+                        isOpen={targetOptionsOpen}
+                      >
+                        {targetOptions.map((option) => (
+                          <SelectOption
+                            selected={option === value}
+                            key={option}
+                            data-testid={option}
+                            value={option}
+                          >
+                            {t(`targetOptions.${option}`)}
+                          </SelectOption>
+                        ))}
+                      </Select>
+                    )}
+                  />
+                </FormGroup>
+              </>
+            )}
+            {(mapperType === "advancedAttributeToRole" ||
+              mapperType === "hardcodedRole" ||
+              mapperType === "samlAttributeToRole") && (
+              <FormGroup
+                label={t("common:role")}
+                labelIcon={
+                  <HelpItem
+                    id="name-help-icon"
+                    helpText="identity-providers-help:role"
+                    forLabel={t("identity-providers-help:role")}
+                    forID={t(`identity-providers:helpLabel`, {
+                      label: t("role"),
+                    })}
+                  />
+                }
+                fieldId="kc-role"
                 validated={
                   errors.config?.role
                     ? ValidatedOptions.error
                     : ValidatedOptions.default
                 }
-              />
-              <Button
-                data-testid="select-role-button"
-                onClick={() => toggleModal()}
+                helperTextInvalid={t("common:required")}
               >
-                {t("selectRole")}
-              </Button>
-            </FormGroup>{" "}
+                <TextInput
+                  ref={register()}
+                  type="text"
+                  id="kc-role"
+                  data-testid="mapper-role-input"
+                  name="config.role"
+                  value={selectedRole[0]?.name}
+                  validated={
+                    errors.config?.role
+                      ? ValidatedOptions.error
+                      : ValidatedOptions.default
+                  }
+                />
+                <Button
+                  data-testid="select-role-button"
+                  onClick={() => toggleModal()}
+                >
+                  {t("selectRole")}
+                </Button>
+              </FormGroup>
+            )}{" "}
           </>
         ) : (
           <>

--- a/src/identity-providers/add/AddMapper.tsx
+++ b/src/identity-providers/add/AddMapper.tsx
@@ -177,6 +177,8 @@ export const AddMapper = () => {
     setRolesModalOpen(!rolesModalOpen);
   };
 
+  const formValues = form.getValues();
+
   return (
     <PageSection variant="light">
       <ViewHeader
@@ -377,7 +379,7 @@ export const AddMapper = () => {
         </FormGroup>
         {isSAMLorOIDC ? (
           <>
-            {form.getValues().identityProviderMapper ===
+            {formValues.identityProviderMapper ===
               "saml-advanced-role-idp-mapper" && (
               <>
                 <FormGroup
@@ -428,7 +430,7 @@ export const AddMapper = () => {
                 </FormGroup>
               </>
             )}
-            {form.getValues().identityProviderMapper ===
+            {formValues.identityProviderMapper ===
               "saml-username-idp-mapper" && (
               <>
                 <FormGroup
@@ -528,7 +530,7 @@ export const AddMapper = () => {
               "saml-advanced-role-idp-mapper",
               "oidc-hardcoded-role-idp-mapper",
               "saml-role-idp-mapper",
-            ].includes(form.getValues().identityProviderMapper!) && (
+            ].includes(formValues.identityProviderMapper!) && (
               <FormGroup
                 label={t("common:role")}
                 labelIcon={
@@ -573,11 +575,11 @@ export const AddMapper = () => {
             {[
               "hardcoded-user-session-attribute-idp-mapper",
               "hardcoded-attribute-idp-mapper",
-            ].includes(form.getValues().identityProviderMapper!) && (
+            ].includes(formValues.identityProviderMapper!) && (
               <>
                 <FormGroup
                   label={
-                    form.getValues().identityProviderMapper ===
+                    formValues.identityProviderMapper ===
                     "hardcoded-user-session-attribute-idp-mapper"
                       ? t("userSessionAttribute")
                       : t("userAttribute")

--- a/src/identity-providers/add/AddMapper.tsx
+++ b/src/identity-providers/add/AddMapper.tsx
@@ -185,7 +185,15 @@ export const AddMapper = () => {
     <PageSection variant="light">
       <ViewHeader
         className="kc-add-mapper-title"
-        titleKey={id ? t("editIdPMapper") : t("addIdPMapper")}
+        titleKey={
+          id
+            ? t("editIdPMapper", {
+                providerId: providerId.toUpperCase(),
+              })
+            : t("addIdPMapper", {
+                providerId: providerId.toUpperCase(),
+              })
+        }
         divider
       />
       <AssociatedRolesModal
@@ -305,7 +313,12 @@ export const AddMapper = () => {
           label={t("mapperType")}
           labelIcon={
             <HelpItem
-              helpText={`identity-providers-help:${mapperType}`}
+              helpText={
+                mapperType === "attributeImporter" &&
+                (providerId === "oidc" || providerId === "keycloak-oidc")
+                  ? `identity-providers-help:oidcAttributeImporter`
+                  : `identity-providers-help:${mapperType}`
+              }
               forLabel={t("mapperType")}
               forID={t(`common:helpLabel`, { label: t("mapperType") })}
             />

--- a/src/identity-providers/add/AddMapper.tsx
+++ b/src/identity-providers/add/AddMapper.tsx
@@ -181,6 +181,8 @@ export const AddMapper = () => {
     setRolesModalOpen(!rolesModalOpen);
   };
 
+  console.log("mapperType", mapperType);
+
   return (
     <PageSection variant="light">
       <ViewHeader

--- a/src/identity-providers/add/AddMapper.tsx
+++ b/src/identity-providers/add/AddMapper.tsx
@@ -147,6 +147,10 @@ export const AddMapper = () => {
           );
         }
 
+        if (mapper.config?.attribute) {
+          form.setValue("config.attributes", value.attribute);
+        }
+
         if (mapper.config?.attributes) {
           form.setValue("config.attributes", JSON.parse(value.attributes));
         }
@@ -181,7 +185,9 @@ export const AddMapper = () => {
     setRolesModalOpen(!rolesModalOpen);
   };
 
-  console.log("mapperType", mapperType);
+  // console.log("mapperType", mapperType);
+
+  console.log("lalala", form.getValues().identityProviderMapper);
 
   return (
     <PageSection variant="light">
@@ -579,6 +585,86 @@ export const AddMapper = () => {
                 </Button>
               </FormGroup>
             )}{" "}
+            {(form.getValues().identityProviderMapper ===
+              "hardcoded-user-session-attribute-idp-mapper" ||
+              form.getValues().identityProviderMapper ===
+                "hardcoded-attribute-idp-mapper") && (
+              <>
+                <FormGroup
+                  label={
+                    form.getValues().identityProviderMapper ===
+                    "hardcoded-user-session-attribute-idp-mapper"
+                      ? t("userSessionAttribute")
+                      : t("userAttribute")
+                  }
+                  labelIcon={
+                    <HelpItem
+                      id="user-session-attribute-help-icon"
+                      helpText="identity-providers-help:userSessionAttribute"
+                      forLabel={t("userSessionAttribute")}
+                      forID={t(`common:helpLabel`, {
+                        label: t("userSessionAttribute"),
+                      })}
+                    />
+                  }
+                  fieldId="kc-user-session-attribute"
+                  validated={
+                    errors.name
+                      ? ValidatedOptions.error
+                      : ValidatedOptions.default
+                  }
+                  helperTextInvalid={t("common:required")}
+                >
+                  <TextInput
+                    ref={register()}
+                    type="text"
+                    defaultValue={currentMapper?.config.attribute}
+                    id="kc-attribute"
+                    data-testid="user-session-attribute"
+                    name="config.attribute"
+                    validated={
+                      errors.name
+                        ? ValidatedOptions.error
+                        : ValidatedOptions.default
+                    }
+                  />
+                </FormGroup>
+                <FormGroup
+                  label={t("userSessionAttributeValue")}
+                  labelIcon={
+                    <HelpItem
+                      id="user-session-attribute-value-help-icon"
+                      helpText="identity-providers-help:userAttributeValue"
+                      forLabel={t("userSessionAttributeValue")}
+                      forID={t(`common:helpLabel`, {
+                        label: t("userSessionAttributeValue"),
+                      })}
+                    />
+                  }
+                  fieldId="kc-user-session-attribute-value"
+                  validated={
+                    errors.name
+                      ? ValidatedOptions.error
+                      : ValidatedOptions.default
+                  }
+                  helperTextInvalid={t("common:required")}
+                >
+                  <TextInput
+                    ref={register()}
+                    type="text"
+                    defaultValue={currentMapper?.config["attribute-value"]}
+                    data-testid="user-session-attribute-value"
+                    id="kc-user-session-attribute-value"
+                    name="config.attribute-value"
+                    validated={
+                      errors.name
+                        ? ValidatedOptions.error
+                        : ValidatedOptions.default
+                    }
+                  />
+                </FormGroup>
+              </>
+            )}
           </>
         ) : (
           <>
@@ -648,6 +734,7 @@ export const AddMapper = () => {
             </FormGroup>
           </>
         )}
+
         <ActionGroup>
           <Button
             data-testid="new-mapper-save-button"

--- a/src/identity-providers/add/DetailSettings.tsx
+++ b/src/identity-providers/add/DetailSettings.tsx
@@ -324,7 +324,7 @@ export const DetailSettings = () => {
                         providerId: provider.providerId!,
                         tab: "mappers",
                       })}
-                      datatest-id="add-mapper-button"
+                      id="add-mapper-button"
                     >
                       {t("addMapper")}
                     </Link>

--- a/src/identity-providers/help.ts
+++ b/src/identity-providers/help.ts
@@ -109,6 +109,7 @@ export default {
       "Overrides the default sync mode of the IDP for this mapper. Values are: 'legacy' to keep the behaviour before this option was introduced, 'import' to only import the user once during first login of the user with this identity provider, 'force' to always update the user during every login with this identity provider and 'inherit' to use the sync mode defined in the identity provider for this mapper.",
     advancedAttributeToRole:
       "If the set of attributes exists and can be matched, grant the user the specified realm or client role.",
+<<<<<<< HEAD
     usernameTemplateImporter: "Format the username to import.",
     hardcodedUserSessionAttribute:
       "When a user is imported from a provider, hardcode a value to a specific user session attribute.",
@@ -120,6 +121,11 @@ export default {
       "If a claim exists, grant the user the specified realm or client role.",
     oidcAttributeImporter:
       "Import declared claim if it exists in ID, access token, or the claim set returned by the user profile endpoint into the specified user property or attribute.",
+=======
+    usernameTemplateImporter: "Format the username to import",
+    hardcodedUserSessionAttribute:
+      "When a user is imported from a provider, hardcode a value to a specific user session attribute.",
+>>>>>>> fix help text for mapper types
     attributeImporter:
       "Import declared SAML attribute if it exists in assertion into the specified user property or attribute.",
     hardcodedRole:

--- a/src/identity-providers/help.ts
+++ b/src/identity-providers/help.ts
@@ -128,12 +128,26 @@ export default {
       "When user is imported from provider, hardcode a value to a specific user attribute.",
     samlAttributeToRole:
       "If an attribute exists, grant the user the specified realm or client role.",
+    template:
+      "Template to use to format the username to import.  Substitutions are enclosed in ${}.  For example: '${ALIAS}.${CLAIM.sub}'.  ALIAS is the provider alias.  CLAIM.<NAME> references an ID or Access token claim. The substitution can be converted to upper or lower case by appending |uppercase or |lowercase to the substituted value, e.g. '${CLAIM.sub | lowercase}",
+    target:
+      "Destination field for the mapper. LOCAL (default) means that the changes are applied to the username stored in local database upon user import. BROKER_ID and BROKER_USERNAME means that the changes are stored into the ID or username used for federation user lookup, respectively.",
+    userSessionAttribute: "Name of user session attribute you want to hardcode",
+    userAttribute: "Name of user attribute you want to hardcode",
+
+    userAttributeValue: "Value you want to hardcode",
+    attributeName:
+      "Name of attribute to search for in assertion. You can leave this blank and specify a friendly name instead.",
+    friendlyName:
+      "Friendly name of attribute to search for in assertion. You can leave this blank and specify a name instead.",
+    userAttributeName:
+      "User attribute name to store SAML attribute. Use email, lastName, and firstName to map to those predefined user properties.",
+    attributeValue:
+      "Value the attribute must have. If the attribute is a list, then the value must be contained in the list.",
     attributes:
       "Name and (regex) value of the attributes to search for in token. The configured name of an attribute is searched in SAML attribute name and attribute friendly name fields. Every given attribute description must be met to set the role. If the attribute is an array, then the value must be contained in the array. If an attribute can be found several times, then one match is sufficient.",
     regexAttributeValues:
       "If enabled attribute values are interpreted as regular expressions.",
     role: "Role to grant to user if all attributes are present. Click 'Select Role' button to browse roles, or just type it in the textbox. To reference a client role the syntax is clientname.clientrole, i.e. myclient.myrole",
-    userSessionAttribute: "Name of user session attribute you want to hardcode",
-    userSessionAttributeValue: "Value you want to hardcode",
   },
 };

--- a/src/identity-providers/help.ts
+++ b/src/identity-providers/help.ts
@@ -109,7 +109,6 @@ export default {
       "Overrides the default sync mode of the IDP for this mapper. Values are: 'legacy' to keep the behaviour before this option was introduced, 'import' to only import the user once during first login of the user with this identity provider, 'force' to always update the user during every login with this identity provider and 'inherit' to use the sync mode defined in the identity provider for this mapper.",
     advancedAttributeToRole:
       "If the set of attributes exists and can be matched, grant the user the specified realm or client role.",
-<<<<<<< HEAD
     usernameTemplateImporter: "Format the username to import.",
     hardcodedUserSessionAttribute:
       "When a user is imported from a provider, hardcode a value to a specific user session attribute.",
@@ -121,11 +120,6 @@ export default {
       "If a claim exists, grant the user the specified realm or client role.",
     oidcAttributeImporter:
       "Import declared claim if it exists in ID, access token, or the claim set returned by the user profile endpoint into the specified user property or attribute.",
-=======
-    usernameTemplateImporter: "Format the username to import",
-    hardcodedUserSessionAttribute:
-      "When a user is imported from a provider, hardcode a value to a specific user session attribute.",
->>>>>>> fix help text for mapper types
     attributeImporter:
       "Import declared SAML attribute if it exists in assertion into the specified user property or attribute.",
     hardcodedRole:

--- a/src/identity-providers/messages.ts
+++ b/src/identity-providers/messages.ts
@@ -166,6 +166,8 @@ export default {
     mapperCreateError: "Error creating mapper.",
     mapperSaveSuccess: "Mapper saved successfully.",
     mapperSaveError: "Error saving mapper: {{error}}",
+    userAttribute: "User Attribute",
+    userAttributeValue: "User Attribute Value",
     userSessionAttribute: "User Session Attribute",
     userSessionAttributeValue: "User Session Attribute Value",
     template: "Template",

--- a/src/identity-providers/messages.ts
+++ b/src/identity-providers/messages.ts
@@ -168,5 +168,12 @@ export default {
     mapperSaveError: "Error saving mapper: {{error}}",
     userSessionAttribute: "User Session Attribute",
     userSessionAttributeValue: "User Session Attribute Value",
+    template: "Template",
+    target: "Target",
+    targetOptions: {
+      local: "LOCAL",
+      brokerId: "BROKER_ID",
+      brokerUsername: "BROKER_USERNAME",
+    },
   },
 };


### PR DESCRIPTION
## Motivation
<!-- Add references to relevant tickets, issues, design specs and/or a short description of what motivated you to do it. -->
Towards #1206

## Verification Steps
<!--
Add the steps required to verify this change. Keep in mind that these steps should be written so groups unfamiliar with the 
new functionality can follow them, such as QE or documentation.-->

1. Go to Identity Providers
2. Create a SAML provider
3. Go to the "mappers" tab
4. Create a new mapper
5. In the "Mapper Type" dropdown, select "Username Template Importer"
6. Verify that the correct fields in the form are shown -- you should see new form fields for "Target" and "Template".
7. Fill out the fields and save. 
8. Verify the save is successful.
9. Go back to mappers and select the new mapper you just created.
10. Edit the mapper, save, and verify the mapper has been updated successfully.

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated
