### PR TITLE
Add tests for bearer-only client details

### DIFF
--- a/cypress/integration/clients_test.spec.ts
+++ b/cypress/integration/clients_test.spec.ts
@@ -258,4 +258,33 @@ describe("Clients test", function () {
       cy.findByTestId("delete-client").should("not.exist");
     });
   });
+
+  describe("Bearer only", () => {
+    const clientId = "bearer-only";
+
+    before(() => {
+      new AdminClient().createClient({
+        clientId,
+        protocol: "openid-connect",
+        publicClient: false,
+        bearerOnly: true,
+      });
+    });
+
+    after(() => {
+      new AdminClient().deleteClient(clientId);
+    });
+
+    beforeEach(() => {
+      keycloakBefore();
+      loginPage.logIn();
+      sidebarPage.goToClients();
+      listingPage.searchItem(clientId).goToItemDetails(clientId);
+    });
+
+    it("shows an explainer text for bearer only clients", () => {
+      cy.findByTestId("bearer-only-explainer-label").trigger("mouseenter");
+      cy.findByTestId("bearer-only-explainer-tooltip").should("exist");
+    });
+  });
 });

--- a/src/clients/ClientDetails.tsx
+++ b/src/clients/ClientDetails.tsx
@@ -89,8 +89,16 @@ const ClientDetailHeader = ({
     }
 
     const text = client.bearerOnly ? (
-      <Tooltip content={t("explainBearerOnly")}>
-        <Label icon={<InfoCircleIcon />}>{client.protocol}</Label>
+      <Tooltip
+        data-testid="bearer-only-explainer-tooltip"
+        content={t("explainBearerOnly")}
+      >
+        <Label
+          data-testid="bearer-only-explainer-label"
+          icon={<InfoCircleIcon />}
+        >
+          {client.protocol}
+        </Label>
       </Tooltip>
     ) : (
       <Label>{client.protocol}</Label>


### PR DESCRIPTION
## Motivation
I added some logic to show a tooltip for bearer-only clients that was not yet tested, this PR adds the missing tests.