### PR TITLE
Remove ability to delete a realm client from the overview

### DIFF
--- a/src/clients/ClientDetails.tsx
+++ b/src/clients/ClientDetails.tsx
@@ -52,8 +52,7 @@ import { toClients } from "./routes/Clients";
 import { ClientScopes } from "./scopes/ClientScopes";
 import { EvaluateScopes } from "./scopes/EvaluateScopes";
 import { ServiceAccount } from "./service-account/ServiceAccount";
-
-const isRealmClient = (client: ClientRepresentation) => !client.protocol;
+import { isRealmClient } from "./utils";
 
 type ClientDetailHeaderProps = {
   onChange: (value: boolean) => void;

--- a/src/clients/ClientsSection.tsx
+++ b/src/clients/ClientsSection.tsx
@@ -117,11 +117,8 @@ export const ClientsSection = () => {
               toolbarItem={
                 <>
                   <ToolbarItem>
-                    <Button
-                      component={(props) => (
-                        <Link {...props} to={toAddClient({ realm })} />
-                      )}
-                    >
+                    {/* @ts-ignore */}
+                    <Button component={Link} to={toAddClient({ realm })}>
                       {t("createClient")}
                     </Button>
                   </ToolbarItem>

--- a/src/clients/ClientsSection.tsx
+++ b/src/clients/ClientsSection.tsx
@@ -8,7 +8,7 @@ import {
   TabTitleText,
   ToolbarItem,
 } from "@patternfly/react-core";
-import { cellWidth, TableText } from "@patternfly/react-table";
+import { cellWidth, IRowData, TableText } from "@patternfly/react-table";
 import type ClientRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientRepresentation";
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -17,7 +17,10 @@ import { useAlerts } from "../components/alert/Alerts";
 import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
 import { formattedLinkTableCell } from "../components/external-link/FormattedLink";
 import { KeycloakTabs } from "../components/keycloak-tabs/KeycloakTabs";
-import { KeycloakDataTable } from "../components/table-toolbar/KeycloakDataTable";
+import {
+  Action,
+  KeycloakDataTable,
+} from "../components/table-toolbar/KeycloakDataTable";
 import { ViewHeader } from "../components/view-header/ViewHeader";
 import { useAdminClient } from "../context/auth/AdminClient";
 import { useRealm } from "../context/realm-context/RealmContext";
@@ -26,6 +29,7 @@ import { InitialAccessTokenList } from "./initial-access/InitialAccessTokenList"
 import { toAddClient } from "./routes/AddClient";
 import { toClient } from "./routes/Client";
 import { toImportClient } from "./routes/ImportClient";
+import { isRealmClient } from "./utils";
 
 export const ClientsSection = () => {
   const { t } = useTranslation("clients");
@@ -113,8 +117,11 @@ export const ClientsSection = () => {
               toolbarItem={
                 <>
                   <ToolbarItem>
-                    {/* @ts-ignore */}
-                    <Button component={Link} to={toAddClient({ realm })}>
+                    <Button
+                      component={(props) => (
+                        <Link {...props} to={toAddClient({ realm })} />
+                      )}
+                    >
                       {t("createClient")}
                     </Button>
                   </ToolbarItem>
@@ -130,21 +137,29 @@ export const ClientsSection = () => {
                   </ToolbarItem>
                 </>
               }
-              actions={[
-                {
-                  title: t("common:export"),
-                  onRowClick: (client) => {
-                    exportClient(client);
+              actionResolver={(rowData: IRowData) => {
+                const client: ClientRepresentation = rowData.data;
+                const actions: Action<ClientRepresentation>[] = [
+                  {
+                    title: t("common:export"),
+                    onRowClick: (client) => {
+                      exportClient(client);
+                    },
                   },
-                },
-                {
-                  title: t("common:delete"),
-                  onRowClick: (client) => {
-                    setSelectedClient(client);
-                    toggleDeleteDialog();
-                  },
-                },
-              ]}
+                ];
+
+                if (!isRealmClient(client)) {
+                  actions.push({
+                    title: t("common:delete"),
+                    onRowClick: (client) => {
+                      setSelectedClient(client);
+                      toggleDeleteDialog();
+                    },
+                  });
+                }
+
+                return actions;
+              }}
               columns={[
                 {
                   name: "clientId",

--- a/src/clients/ClientsSection.tsx
+++ b/src/clients/ClientsSection.tsx
@@ -139,7 +139,7 @@ export const ClientsSection = () => {
                 const actions: Action<ClientRepresentation>[] = [
                   {
                     title: t("common:export"),
-                    onRowClick: (client) => {
+                    onClick() {
                       exportClient(client);
                     },
                   },
@@ -148,7 +148,7 @@ export const ClientsSection = () => {
                 if (!isRealmClient(client)) {
                   actions.push({
                     title: t("common:delete"),
-                    onRowClick: (client) => {
+                    onClick() {
                       setSelectedClient(client);
                       toggleDeleteDialog();
                     },

--- a/src/clients/utils.ts
+++ b/src/clients/utils.ts
@@ -1,0 +1,6 @@
+import type ClientRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientRepresentation";
+
+/**
+ * Checks if a client is intended to be used for authenticating a to a realm.
+ */
+export const isRealmClient = (client: ClientRepresentation) => !client.protocol;


### PR DESCRIPTION
## Motivation
Clients that are intended to be used for authenticating a realm are not allowed to be deleted.