### PR TITLE
Use type-safe alternative for links

### DIFF
--- a/src/PageHeader.tsx
+++ b/src/PageHeader.tsx
@@ -56,9 +56,9 @@ export const Header = () => {
     return (
       <DropdownItem
         key="server info"
-        component={Link}
-        // @ts-ignore
-        to={toDashboard({ realm })}
+        component={(props: any) => (
+          <Link {...props} to={toDashboard({ realm })} />
+        )}
       >
         {t("realmInfo")}
       </DropdownItem>

--- a/src/authentication/AuthenticationSection.tsx
+++ b/src/authentication/AuthenticationSection.tsx
@@ -223,9 +223,9 @@ export const AuthenticationSection = () => {
               toolbarItem={
                 <ToolbarItem>
                   <Button
-                    component={Link}
-                    // @ts-ignore
-                    to={toCreateFlow({ realm })}
+                    component={(props) => (
+                      <Link {...props} to={toCreateFlow({ realm })} />
+                    )}
                   >
                     {t("createFlow")}
                   </Button>

--- a/src/client-scopes/ClientScopesSection.tsx
+++ b/src/client-scopes/ClientScopesSection.tsx
@@ -204,8 +204,11 @@ export const ClientScopesSection = () => {
               />
 
               <ToolbarItem>
-                {/* @ts-ignore */}
-                <Button component={Link} to={toNewClientScope({ realm })}>
+                <Button
+                  component={(props) => (
+                    <Link {...props} to={toNewClientScope({ realm })} />
+                  )}
+                >
                   {t("createClientScope")}
                 </Button>
               </ToolbarItem>

--- a/src/client-scopes/details/MappingDetails.tsx
+++ b/src/client-scopes/details/MappingDetails.tsx
@@ -242,9 +242,12 @@ export const MappingDetails = () => {
             </Button>
             <Button
               variant="link"
-              component={Link}
-              // @ts-ignore
-              to={toClientScope({ realm, id, type, tab: "mappers" })}
+              component={(props) => (
+                <Link
+                  {...props}
+                  to={toClientScope({ realm, id, type, tab: "mappers" })}
+                />
+              )}
             >
               {t("common:cancel")}
             </Button>

--- a/src/clients/ClientsSection.tsx
+++ b/src/clients/ClientsSection.tsx
@@ -113,16 +113,19 @@ export const ClientsSection = () => {
               toolbarItem={
                 <>
                   <ToolbarItem>
-                    {/* @ts-ignore */}
-                    <Button component={Link} to={toAddClient({ realm })}>
+                    <Button
+                      component={(props) => (
+                        <Link {...props} to={toAddClient({ realm })} />
+                      )}
+                    >
                       {t("createClient")}
                     </Button>
                   </ToolbarItem>
                   <ToolbarItem>
                     <Button
-                      component={Link}
-                      // @ts-ignore
-                      to={toImportClient({ realm })}
+                      component={(props) => (
+                        <Link {...props} to={toImportClient({ realm })} />
+                      )}
                       variant="link"
                     >
                       {t("importClient")}

--- a/src/clients/import/ImportForm.tsx
+++ b/src/clients/import/ImportForm.tsx
@@ -97,8 +97,12 @@ export const ImportForm = () => {
               <Button variant="primary" type="submit">
                 {t("common:save")}
               </Button>
-              {/* @ts-ignore */}
-              <Button variant="link" component={Link} to={toClients({ realm })}>
+              <Button
+                variant="link"
+                component={(props) => (
+                  <Link {...props} to={toClients({ realm })} />
+                )}
+              >
                 {t("common:cancel")}
               </Button>
             </ActionGroup>

--- a/src/clients/initial-access/CreateInitialAccessToken.tsx
+++ b/src/clients/initial-access/CreateInitialAccessToken.tsx
@@ -130,9 +130,12 @@ export const CreateInitialAccessToken = () => {
             <Button
               data-testid="cancel"
               variant="link"
-              component={Link}
-              // @ts-ignore
-              to={toClients({ realm, tab: "initialAccessToken" })}
+              component={(props) => (
+                <Link
+                  {...props}
+                  to={toClients({ realm, tab: "initialAccessToken" })}
+                />
+              )}
             >
               {t("common:cancel")}
             </Button>

--- a/src/clients/initial-access/InitialAccessTokenList.tsx
+++ b/src/clients/initial-access/InitialAccessTokenList.tsx
@@ -55,12 +55,13 @@ export const InitialAccessTokenList = () => {
         searchPlaceholderKey="clients:searchInitialAccessToken"
         loader={loader}
         toolbarItem={
-          <>
-            {/* @ts-ignore */}
-            <Button component={Link} to={toCreateInitialAccessToken({ realm })}>
-              {t("common:create")}
-            </Button>
-          </>
+          <Button
+            component={(props) => (
+              <Link {...props} to={toCreateInitialAccessToken({ realm })} />
+            )}
+          >
+            {t("common:create")}
+          </Button>
         }
         actions={[
           {

--- a/src/identity-providers/add/DetailSettings.tsx
+++ b/src/identity-providers/add/DetailSettings.tsx
@@ -321,7 +321,6 @@ export const DetailSettings = () => {
                 toolbarItem={
                   <ToolbarItem>
                     <Link
-                      // @ts-ignore
                       to={toIdentityProviderAddMapper({
                         realm,
                         alias: alias!,

--- a/src/realm-settings/NewClientProfileForm.tsx
+++ b/src/realm-settings/NewClientProfileForm.tsx
@@ -125,9 +125,12 @@ export const NewClientProfileForm = () => {
             </Button>
             <Button
               id="cancelCreateProfile"
-              component={Link}
-              // @ts-ignore
-              to={`/${realm}/realm-settings/clientPolicies`}
+              component={(props) => (
+                <Link
+                  {...props}
+                  to={`/${realm}/realm-settings/clientPolicies`}
+                />
+              )}
               data-testid="cancelCreateProfile"
             >
               {t("common:cancel")}

--- a/src/realm-settings/ProfilesTab.tsx
+++ b/src/realm-settings/ProfilesTab.tsx
@@ -157,9 +157,9 @@ export const ProfilesTab = () => {
             <ToolbarItem>
               <Button
                 id="createProfile"
-                component={Link}
-                // @ts-ignore
-                to={toNewClientProfile({ realm })}
+                component={(props) => (
+                  <Link {...props} to={toNewClientProfile({ realm })} />
+                )}
                 data-testid="createProfile"
               >
                 {t("createClientProfile")}


### PR DESCRIPTION
## Motivation
This allows us to properly type-check the link functions which can catch regressions.
