### PR TITLE
Identity providers(mappers): update form fields for all Social mapper types

### DIFF
--- a/cypress/integration/identity_providers.spec.ts
+++ b/cypress/integration/identity_providers.spec.ts
@@ -163,7 +163,7 @@ describe("Identity provider test", () => {
 
       addMapperPage.goToMappersTab();
 
-      addMapperPage.emptyStateAddMapper();
+      addMapperPage.addMapper();
 
       addMapperPage.addUsernameTemplateImporterMapper(
         "SAML Username Template Importer Mapper"
@@ -279,7 +279,7 @@ describe("Identity provider test", () => {
 
       addMapperPage.goToMappersTab();
 
-      addMapperPage.emptyStateAddMapper();
+      addMapperPage.addMapper();
 
       addMapperPage.fillSocialMapper("facebook attribute importer");
 

--- a/cypress/integration/identity_providers.spec.ts
+++ b/cypress/integration/identity_providers.spec.ts
@@ -272,6 +272,20 @@ describe("Identity provider test", () => {
       masthead.checkNotificationMessage(createMapperSuccessMsg);
     });
 
+    it("should add Social mapper of type Attribute Importer", () => {
+      sidebarPage.goToIdentityProviders();
+
+      listingPage.goToItemDetails("facebook");
+
+      addMapperPage.goToMappersTab();
+
+      addMapperPage.addMapper();
+
+      addMapperPage.fillSocialMapper("facebook attribute importer");
+
+      masthead.checkNotificationMessage(createMapperSuccessMsg);
+    });
+
     it("should edit Username Template Importer mapper", () => {
       sidebarPage.goToIdentityProviders();
 

--- a/cypress/integration/identity_providers.spec.ts
+++ b/cypress/integration/identity_providers.spec.ts
@@ -163,7 +163,7 @@ describe("Identity provider test", () => {
 
       addMapperPage.goToMappersTab();
 
-      addMapperPage.addMapper();
+      addMapperPage.emptyStateAddMapper();
 
       addMapperPage.addUsernameTemplateImporterMapper(
         "SAML Username Template Importer Mapper"
@@ -279,7 +279,7 @@ describe("Identity provider test", () => {
 
       addMapperPage.goToMappersTab();
 
-      addMapperPage.addMapper();
+      addMapperPage.emptyStateAddMapper();
 
       addMapperPage.fillSocialMapper("facebook attribute importer");
 
@@ -307,7 +307,7 @@ describe("Identity provider test", () => {
 
       addMapperPage.goToMappersTab();
 
-      listingPage.goToItemDetails("facebook mapper");
+      listingPage.goToItemDetails("facebook attribute importer");
 
       addMapperPage.editSocialMapper();
     });

--- a/cypress/support/pages/admin_console/manage/identity_providers/AddMapperPage.ts
+++ b/cypress/support/pages/admin_console/manage/identity_providers/AddMapperPage.ts
@@ -342,11 +342,15 @@ export default class AddMapperPage {
     cy.findByTestId(this.userSessionAttribute).type(
       "user session attribute_edited"
     );
-    cy.findByTestId(this.userSessionAttributeValue).clear();
+    cy.findByTestId(this.socialProfileJSONfieldPath).clear();
 
-    cy.findByTestId(this.userSessionAttributeValue).type(
-      "user session attribute value_edited"
+    cy.findByTestId(this.socialProfileJSONfieldPath).type(
+      "social profile JSON field path edited"
     );
+
+    cy.findByTestId(this.userAttributeName).clear();
+
+    cy.findByTestId(this.userAttributeName).type("user attribute name edited");
 
     this.saveNewMapper();
 

--- a/cypress/support/pages/admin_console/manage/identity_providers/AddMapperPage.ts
+++ b/cypress/support/pages/admin_console/manage/identity_providers/AddMapperPage.ts
@@ -338,10 +338,6 @@ export default class AddMapperPage {
 
     cy.findByTestId("inherit").click();
 
-    cy.findByTestId(this.userSessionAttribute).clear();
-    cy.findByTestId(this.userSessionAttribute).type(
-      "user session attribute_edited"
-    );
     cy.findByTestId(this.socialProfileJSONfieldPath).clear();
 
     cy.findByTestId(this.socialProfileJSONfieldPath).type(

--- a/cypress/support/pages/admin_console/manage/identity_providers/AddMapperPage.ts
+++ b/cypress/support/pages/admin_console/manage/identity_providers/AddMapperPage.ts
@@ -9,7 +9,10 @@ export default class AddMapperPage {
   private mapperRoleInput = "mapper-role-input";
   private attributeName = "attribute-name";
   private attributeFriendlyName = "attribute-friendly-name";
+  private attributeValue = "attribute-value";
   private claimInput = "claim";
+  private claimValueInput = "claim-value-input";
+  private socialProfileJSONfieldPath = "social-profile-JSON-field-path";
   private userAttribute = "user-attribute";
   private userAttributeName = "user-attribute-name";
   private userAttributeValue = "user-attribute-value";
@@ -73,13 +76,14 @@ export default class AddMapperPage {
       .contains("Attribute Importer")
       .click();
 
-    cy.findByTestId(this.userSessionAttribute).clear();
-    cy.findByTestId(this.userSessionAttribute).type("user session attribute");
-    cy.findByTestId(this.userSessionAttributeValue).clear();
-
-    cy.findByTestId(this.userSessionAttributeValue).type(
-      "user session attribute value"
+    cy.findByTestId(this.socialProfileJSONfieldPath).clear();
+    cy.findByTestId(this.socialProfileJSONfieldPath).type(
+      "social profile JSON field path"
     );
+
+    cy.findByTestId(this.userAttributeName).clear();
+
+    cy.findByTestId(this.userAttributeName).type("user attribute name");
 
     return this;
   }

--- a/cypress/support/pages/admin_console/manage/identity_providers/AddMapperPage.ts
+++ b/cypress/support/pages/admin_console/manage/identity_providers/AddMapperPage.ts
@@ -85,6 +85,8 @@ export default class AddMapperPage {
 
     cy.findByTestId(this.userAttributeName).type("user attribute name");
 
+    this.saveNewMapper();
+
     return this;
   }
 

--- a/src/identity-providers/add/AddMapper.tsx
+++ b/src/identity-providers/add/AddMapper.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { Controller, useFieldArray, useForm } from "react-hook-form";

--- a/src/identity-providers/add/AddMapper.tsx
+++ b/src/identity-providers/add/AddMapper.tsx
@@ -35,6 +35,8 @@ import { convertToFormValues } from "../../util";
 import { toIdentityProvider } from "../routes/IdentityProvider";
 import type IdentityProviderMapperRepresentation from "@keycloak/keycloak-admin-client/lib/defs/identityProviderMapperRepresentation";
 import { AddMapperForm } from "./AddMapperForm";
+import { useServerInfo } from "../../context/server-info/ServerInfoProvider";
+import _ from "lodash";
 
 export type IdPMapperRepresentationWithAttributes =
   IdentityProviderMapperRepresentation & {
@@ -54,11 +56,21 @@ export const AddMapper = () => {
   const { providerId, alias } = useParams<IdentityProviderAddMapperParams>();
   const { id } = useParams<IdentityProviderEditMapperParams>();
 
-  const isSAMLorOIDC = providerId === "saml" || providerId === "oidc";
+  const identityProviders = _.groupBy(
+    useServerInfo().identityProviders,
+    "groupName"
+  );
+
+  const isSocialIdP = identityProviders["Social"]
+    .map((item) => item.id)
+    .includes(providerId.toLowerCase());
 
   const [mapperTypes, setMapperTypes] =
     useState<Record<string, IdentityProviderMapperRepresentation>>();
-  const [mapperType, setMapperType] = useState("advancedAttributeToRole");
+  const [mapperType, setMapperType] = useState(
+    !isSocialIdP ? "hardcodedRole" : "attributeImporter"
+  );
+
   const [currentMapper, setCurrentMapper] =
     useState<IdentityProviderMapperRepresentation>();
   const [roles, setRoles] = useState<RoleRepresentation[]>([]);
@@ -207,6 +219,10 @@ export const AddMapper = () => {
   const isOIDCUsernameTemplateImporter =
     formValues.identityProviderMapper === "oidc-username-idp-mapper";
 
+  const isSocialAttributeImporter = formValues.identityProviderMapper?.includes(
+    "user-attribute-mapper"
+  );
+
   const toggleModal = () => {
     setRolesModalOpen(!rolesModalOpen);
   };
@@ -218,10 +234,12 @@ export const AddMapper = () => {
         titleKey={
           id
             ? t("editIdPMapper", {
-                providerId: providerId.toUpperCase(),
+                providerId:
+                  providerId[0].toUpperCase() + providerId.substring(1),
               })
             : t("addIdPMapper", {
-                providerId: providerId.toUpperCase(),
+                providerId:
+                  providerId[0].toUpperCase() + providerId.substring(1),
               })
         }
         divider
@@ -267,362 +285,321 @@ export const AddMapper = () => {
         <AddMapperForm
           form={form}
           id={id}
-          providerId={providerId}
           mapperTypes={mapperTypes}
           updateMapperType={setMapperType}
           formValues={formValues}
           mapperType={mapperType}
+          isSocialIdP={isSocialIdP}
         />
-        {isSAMLorOIDC ? (
-          <>
-            {(isSAMLAdvancedAttrToRole || isOIDCAdvancedClaimToRole) && (
-              <>
-                <FormGroup
-                  label={
-                    isSAMLAdvancedAttrToRole
-                      ? t("common:attributes")
-                      : t("claims")
-                  }
-                  labelIcon={
-                    <HelpItem
-                      helpText={
-                        isSAMLAdvancedAttrToRole
-                          ? "identity-providers-help:attributes"
-                          : "identity-providers-help:claims"
-                      }
-                      forLabel={
-                        isSAMLAdvancedAttrToRole
-                          ? t("common:attributes")
-                          : t("common:claims")
-                      }
-                      forID={
-                        isSAMLAdvancedAttrToRole
-                          ? t(`common:helpLabel`, {
-                              label: t("attributes"),
-                            })
-                          : t(`common:helpLabel`, {
-                              label: t("claim"),
-                            })
-                      }
-                    />
-                  }
-                  fieldId="kc-gui-order"
-                >
-                  <AttributesForm
-                    form={form}
-                    inConfig
-                    array={{ fields, append, remove }}
-                  />
-                </FormGroup>
-                <FormGroup
-                  label={t("regexAttributeValues")}
-                  labelIcon={
-                    <HelpItem
-                      helpText="identity-providers-help:regexAttributeValues"
-                      forLabel={t("regexAttributeValues")}
-                      forID={t(`common:helpLabel`, {
-                        label: t("regexAttributeValues"),
-                      })}
-                    />
-                  }
-                  fieldId="regexAttributeValues"
-                >
-                  <Controller
-                    name="config.are-attribute-values-regex"
-                    control={control}
-                    defaultValue="false"
-                    render={({ onChange, value }) => (
-                      <Switch
-                        id="regexAttributeValues"
-                        data-testid="regex-attribute-values-switch"
-                        label={t("common:on")}
-                        labelOff={t("common:off")}
-                        isChecked={value === "true"}
-                        onChange={(value) => onChange("" + value)}
-                      />
-                    )}
-                  />
-                </FormGroup>
-              </>
-            )}
-            {(isSAMLUsernameTemplateImporter ||
-              isOIDCUsernameTemplateImporter) && (
-              <>
-                <FormGroup
-                  label={t("template")}
-                  labelIcon={
-                    <HelpItem
-                      id="target-help-icon"
-                      helpText="identity-providers-help:template"
-                      forLabel={t("template")}
-                      forID={t(`common:helpLabel`, {
-                        label: t("template"),
-                      })}
-                    />
-                  }
-                  fieldId="kc-user-session-attribute"
-                  validated={
-                    errors.name
-                      ? ValidatedOptions.error
-                      : ValidatedOptions.default
-                  }
-                  helperTextInvalid={t("common:required")}
-                >
-                  <TextInput
-                    ref={register()}
-                    type="text"
-                    id="kc-template"
-                    data-testid="template"
-                    name="config.template"
-                    defaultValue={currentMapper?.config.template}
-                    validated={
-                      errors.name
-                        ? ValidatedOptions.error
-                        : ValidatedOptions.default
+        <>
+          {(isSAMLAdvancedAttrToRole || isOIDCAdvancedClaimToRole) && (
+            <>
+              <FormGroup
+                label={
+                  isSAMLAdvancedAttrToRole
+                    ? t("common:attributes")
+                    : t("claims")
+                }
+                labelIcon={
+                  <HelpItem
+                    helpText={
+                      isSAMLAdvancedAttrToRole
+                        ? "identity-providers-help:attributes"
+                        : "identity-providers-help:claims"
+                    }
+                    forLabel={
+                      isSAMLAdvancedAttrToRole
+                        ? t("common:attributes")
+                        : t("common:claims")
+                    }
+                    forID={
+                      isSAMLAdvancedAttrToRole
+                        ? t(`common:helpLabel`, {
+                            label: t("attributes"),
+                          })
+                        : t(`common:helpLabel`, {
+                            label: t("claim"),
+                          })
                     }
                   />
-                </FormGroup>
-                <FormGroup
-                  label={t("target")}
-                  labelIcon={
-                    <HelpItem
-                      id="user-session-attribute-help-icon"
-                      helpText="identity-providers-help:target"
-                      forLabel={t("target")}
-                      forID={t(`common:helpLabel`, {
-                        label: t("target"),
-                      })}
+                }
+                fieldId="kc-gui-order"
+              >
+                <AttributesForm
+                  form={form}
+                  inConfig
+                  array={{ fields, append, remove }}
+                />
+              </FormGroup>
+              <FormGroup
+                label={t("regexAttributeValues")}
+                labelIcon={
+                  <HelpItem
+                    helpText="identity-providers-help:regexAttributeValues"
+                    forLabel={t("regexAttributeValues")}
+                    forID={t(`common:helpLabel`, {
+                      label: t("regexAttributeValues"),
+                    })}
+                  />
+                }
+                fieldId="regexAttributeValues"
+              >
+                <Controller
+                  name="config.are-attribute-values-regex"
+                  control={control}
+                  defaultValue="false"
+                  render={({ onChange, value }) => (
+                    <Switch
+                      id="regexAttributeValues"
+                      data-testid="regex-attribute-values-switch"
+                      label={t("common:on")}
+                      labelOff={t("common:off")}
+                      isChecked={value === "true"}
+                      onChange={(value) => onChange("" + value)}
                     />
-                  }
-                  fieldId="kc-target"
+                  )}
+                />
+              </FormGroup>
+            </>
+          )}
+          {(isSAMLUsernameTemplateImporter ||
+            isOIDCUsernameTemplateImporter) && (
+            <>
+              <FormGroup
+                label={t("template")}
+                labelIcon={
+                  <HelpItem
+                    id="target-help-icon"
+                    helpText="identity-providers-help:template"
+                    forLabel={t("template")}
+                    forID={t(`common:helpLabel`, {
+                      label: t("template"),
+                    })}
+                  />
+                }
+                fieldId="kc-user-session-attribute"
+                validated={
+                  errors.name
+                    ? ValidatedOptions.error
+                    : ValidatedOptions.default
+                }
+                helperTextInvalid={t("common:required")}
+              >
+                <TextInput
+                  ref={register()}
+                  type="text"
+                  id="kc-template"
+                  data-testid="template"
+                  name="config.template"
+                  defaultValue={currentMapper?.config.template}
                   validated={
                     errors.name
                       ? ValidatedOptions.error
                       : ValidatedOptions.default
                   }
-                  helperTextInvalid={t("common:required")}
-                >
-                  <Controller
-                    name="config.target"
-                    defaultValue={currentMapper?.config.target}
-                    control={control}
-                    render={({ onChange, value }) => (
-                      <Select
-                        toggleId="target"
-                        datatest-id="target-select"
-                        id="target-dropdown"
-                        placeholderText={t("realm-settings:placeholderText")}
-                        direction="down"
-                        onToggle={() =>
-                          setTargetOptionsOpen(!targetOptionsOpen)
-                        }
-                        onSelect={(_, value) => {
-                          onChange(t(`targetOptions.${value}`));
-                          setTargetOptionsOpen(false);
-                        }}
-                        selections={value}
-                        variant={SelectVariant.single}
-                        aria-label={t("target")}
-                        isOpen={targetOptionsOpen}
-                      >
-                        {targetOptions.map((option) => (
-                          <SelectOption
-                            selected={option === value}
-                            key={option}
-                            data-testid={option}
-                            value={option}
-                          >
-                            {t(`targetOptions.${option}`)}
-                          </SelectOption>
-                        ))}
-                      </Select>
-                    )}
+                />
+              </FormGroup>
+              <FormGroup
+                label={t("target")}
+                labelIcon={
+                  <HelpItem
+                    id="user-session-attribute-help-icon"
+                    helpText="identity-providers-help:target"
+                    forLabel={t("target")}
+                    forID={t(`common:helpLabel`, {
+                      label: t("target"),
+                    })}
                   />
-                </FormGroup>
-              </>
-            )}
+                }
+                fieldId="kc-target"
+                validated={
+                  errors.name
+                    ? ValidatedOptions.error
+                    : ValidatedOptions.default
+                }
+                helperTextInvalid={t("common:required")}
+              >
+                <Controller
+                  name="config.target"
+                  defaultValue={currentMapper?.config.target}
+                  control={control}
+                  render={({ onChange, value }) => (
+                    <Select
+                      toggleId="target"
+                      datatest-id="target-select"
+                      id="target-dropdown"
+                      placeholderText={t("realm-settings:placeholderText")}
+                      direction="down"
+                      onToggle={() => setTargetOptionsOpen(!targetOptionsOpen)}
+                      onSelect={(_, value) => {
+                        onChange(t(`targetOptions.${value}`));
+                        setTargetOptionsOpen(false);
+                      }}
+                      selections={value}
+                      variant={SelectVariant.single}
+                      aria-label={t("target")}
+                      isOpen={targetOptionsOpen}
+                    >
+                      {targetOptions.map((option) => (
+                        <SelectOption
+                          selected={option === value}
+                          key={option}
+                          data-testid={option}
+                          value={option}
+                        >
+                          {t(`targetOptions.${option}`)}
+                        </SelectOption>
+                      ))}
+                    </Select>
+                  )}
+                />
+              </FormGroup>
+            </>
+          )}
 
-            {(isHardcodedAttribute || isHardcodedUserSessionAttribute) && (
-              <>
-                <FormGroup
-                  label={
+          {(isHardcodedAttribute || isHardcodedUserSessionAttribute) && (
+            <>
+              <FormGroup
+                label={
+                  isHardcodedUserSessionAttribute
+                    ? t("userSessionAttribute")
+                    : t("userAttribute")
+                }
+                labelIcon={
+                  <HelpItem
+                    id="user-session-attribute-help-icon"
+                    helpText="identity-providers-help:userSessionAttribute"
+                    forLabel={t("userSessionAttribute")}
+                    forID={t(`common:helpLabel`, {
+                      label: t("userSessionAttribute"),
+                    })}
+                  />
+                }
+                fieldId="kc-user-session-attribute"
+                validated={
+                  errors.name
+                    ? ValidatedOptions.error
+                    : ValidatedOptions.default
+                }
+                helperTextInvalid={t("common:required")}
+              >
+                <TextInput
+                  ref={register()}
+                  type="text"
+                  defaultValue={currentMapper?.config.attribute}
+                  id="kc-attribute"
+                  data-testid={
                     isHardcodedUserSessionAttribute
-                      ? t("userSessionAttribute")
-                      : t("userAttribute")
+                      ? "user-session-attribute"
+                      : "user-attribute"
                   }
-                  labelIcon={
-                    <HelpItem
-                      id="user-session-attribute-help-icon"
-                      helpText="identity-providers-help:userSessionAttribute"
-                      forLabel={t("userSessionAttribute")}
-                      forID={t(`common:helpLabel`, {
-                        label: t("userSessionAttribute"),
-                      })}
-                    />
-                  }
-                  fieldId="kc-user-session-attribute"
+                  name="config.attribute"
                   validated={
                     errors.name
                       ? ValidatedOptions.error
                       : ValidatedOptions.default
                   }
-                  helperTextInvalid={t("common:required")}
-                >
-                  <TextInput
-                    ref={register()}
-                    type="text"
-                    defaultValue={currentMapper?.config.attribute}
-                    id="kc-attribute"
-                    data-testid={
+                />
+              </FormGroup>
+              <FormGroup
+                label={
+                  isHardcodedUserSessionAttribute
+                    ? t("userSessionAttributeValue")
+                    : t("userAttributeValue")
+                }
+                labelIcon={
+                  <HelpItem
+                    id="user-session-attribute-value-help-icon"
+                    helpText="identity-providers-help:userAttributeValue"
+                    forLabel={
                       isHardcodedUserSessionAttribute
-                        ? "user-session-attribute"
-                        : "user-attribute"
+                        ? t("userSessionAttributeValue")
+                        : t("userAttributeValue")
                     }
-                    name="config.attribute"
-                    validated={
-                      errors.name
-                        ? ValidatedOptions.error
-                        : ValidatedOptions.default
-                    }
+                    forID={t(`common:helpLabel`, {
+                      label: isHardcodedUserSessionAttribute
+                        ? t("userSessionAttributeValue")
+                        : t("userAttributeValue"),
+                    })}
                   />
-                </FormGroup>
-                <FormGroup
-                  label={
+                }
+                fieldId="kc-user-session-attribute-value"
+                validated={
+                  errors.name
+                    ? ValidatedOptions.error
+                    : ValidatedOptions.default
+                }
+                helperTextInvalid={t("common:required")}
+              >
+                <TextInput
+                  ref={register()}
+                  type="text"
+                  defaultValue={currentMapper?.config["attribute-value"]}
+                  data-testid={
                     isHardcodedUserSessionAttribute
-                      ? t("userSessionAttributeValue")
-                      : t("userAttributeValue")
+                      ? "user-session-attribute-value"
+                      : "user-attribute-value"
                   }
-                  labelIcon={
-                    <HelpItem
-                      id="user-session-attribute-value-help-icon"
-                      helpText="identity-providers-help:userAttributeValue"
-                      forLabel={
-                        isHardcodedUserSessionAttribute
-                          ? t("userSessionAttributeValue")
-                          : t("userAttributeValue")
-                      }
-                      forID={t(`common:helpLabel`, {
-                        label: isHardcodedUserSessionAttribute
-                          ? t("userSessionAttributeValue")
-                          : t("userAttributeValue"),
-                      })}
-                    />
-                  }
-                  fieldId="kc-user-session-attribute-value"
+                  id="kc-user-session-attribute-value"
+                  name="config.attribute-value"
                   validated={
                     errors.name
                       ? ValidatedOptions.error
                       : ValidatedOptions.default
                   }
-                  helperTextInvalid={t("common:required")}
-                >
-                  <TextInput
-                    ref={register()}
-                    type="text"
-                    defaultValue={currentMapper?.config["attribute-value"]}
-                    data-testid={
-                      isHardcodedUserSessionAttribute
-                        ? "user-session-attribute-value"
-                        : "user-attribute-value"
-                    }
-                    id="kc-user-session-attribute-value"
-                    name="config.attribute-value"
-                    validated={
-                      errors.name
-                        ? ValidatedOptions.error
-                        : ValidatedOptions.default
-                    }
-                  />
-                </FormGroup>
-              </>
-            )}
-            {(isSAMLAttributeImporter ||
-              isOIDCAttributeImporter ||
-              isOIDCclaimToRole) && (
-              <>
-                {isSAMLAttributeImporter ? (
-                  <>
-                    <FormGroup
-                      label={t("mapperAttributeName")}
-                      labelIcon={
-                        <HelpItem
-                          id="user-session-attribute-help-icon"
-                          helpText="identity-providers-help:attributeName"
-                          forLabel={t("mapperAttributeName")}
-                          forID={t(`common:helpLabel`, {
-                            label: t("mapperAttributeName"),
-                          })}
-                        />
-                      }
-                      fieldId="kc-attribute-name"
-                      validated={
-                        errors.name
-                          ? ValidatedOptions.error
-                          : ValidatedOptions.default
-                      }
-                      helperTextInvalid={t("common:required")}
-                    >
-                      <TextInput
-                        ref={register()}
-                        type="text"
-                        defaultValue={currentMapper?.config["attribute-name"]}
-                        id="kc-attribute-name"
-                        data-testid="attribute-name"
-                        name="config.attribute-name"
-                        validated={
-                          errors.name
-                            ? ValidatedOptions.error
-                            : ValidatedOptions.default
-                        }
-                      />
-                    </FormGroup>
-                    <FormGroup
-                      label={t("mapperAttributeFriendlyName")}
-                      labelIcon={
-                        <HelpItem
-                          id="mapper-attribute-friendly-name"
-                          helpText="identity-providers-help:friendlyName"
-                          forLabel={t("mapperAttributeFriendlyName")}
-                          forID={t(`common:helpLabel`, {
-                            label: t("mapperAttributeFriendlyName"),
-                          })}
-                        />
-                      }
-                      fieldId="kc-friendly-name"
-                      validated={
-                        errors.name
-                          ? ValidatedOptions.error
-                          : ValidatedOptions.default
-                      }
-                      helperTextInvalid={t("common:required")}
-                    >
-                      <TextInput
-                        ref={register()}
-                        type="text"
-                        defaultValue={
-                          currentMapper?.config["attribute-friendly-name"]
-                        }
-                        data-testid="attribute-friendly-name"
-                        id="kc-attribute-friendly-name"
-                        name="config.attribute-friendly-name"
-                        validated={
-                          errors.name
-                            ? ValidatedOptions.error
-                            : ValidatedOptions.default
-                        }
-                      />
-                    </FormGroup>
-                  </>
-                ) : (
+                />
+              </FormGroup>
+            </>
+          )}
+          {(isSAMLAttributeImporter ||
+            isOIDCAttributeImporter ||
+            isOIDCclaimToRole) && (
+            <>
+              {isSAMLAttributeImporter ? (
+                <>
                   <FormGroup
-                    label={t("claim")}
+                    label={t("mapperAttributeName")}
                     labelIcon={
                       <HelpItem
-                        id="claim"
-                        helpText="identity-providers-help:claim"
-                        forLabel={t("claim")}
+                        id="user-session-attribute-help-icon"
+                        helpText="identity-providers-help:attributeName"
+                        forLabel={t("mapperAttributeName")}
                         forID={t(`common:helpLabel`, {
-                          label: t("claim"),
+                          label: t("mapperAttributeName"),
+                        })}
+                      />
+                    }
+                    fieldId="kc-attribute-name"
+                    validated={
+                      errors.name
+                        ? ValidatedOptions.error
+                        : ValidatedOptions.default
+                    }
+                    helperTextInvalid={t("common:required")}
+                  >
+                    <TextInput
+                      ref={register()}
+                      type="text"
+                      defaultValue={currentMapper?.config["attribute-name"]}
+                      id="kc-attribute-name"
+                      data-testid="attribute-name"
+                      name="config.attribute-name"
+                      validated={
+                        errors.name
+                          ? ValidatedOptions.error
+                          : ValidatedOptions.default
+                      }
+                    />
+                  </FormGroup>
+                  <FormGroup
+                    label={t("mapperAttributeFriendlyName")}
+                    labelIcon={
+                      <HelpItem
+                        id="mapper-attribute-friendly-name"
+                        helpText="identity-providers-help:friendlyName"
+                        forLabel={t("mapperAttributeFriendlyName")}
+                        forID={t(`common:helpLabel`, {
+                          label: t("mapperAttributeFriendlyName"),
                         })}
                       />
                     }
@@ -637,10 +614,12 @@ export const AddMapper = () => {
                     <TextInput
                       ref={register()}
                       type="text"
-                      defaultValue={currentMapper?.config["claim"]}
-                      data-testid="claim"
-                      id="kc-claim"
-                      name={"config.claim"}
+                      defaultValue={
+                        currentMapper?.config["attribute-friendly-name"]
+                      }
+                      data-testid="attribute-friendly-name"
+                      id="kc-attribute-friendly-name"
+                      name="config.attribute-friendly-name"
                       validated={
                         errors.name
                           ? ValidatedOptions.error
@@ -648,32 +627,21 @@ export const AddMapper = () => {
                       }
                     />
                   </FormGroup>
-                )}
+                </>
+              ) : (
                 <FormGroup
-                  label={
-                    isOIDCclaimToRole
-                      ? t("claimValue")
-                      : t("mapperUserAttributeName")
-                  }
+                  label={t("claim")}
                   labelIcon={
                     <HelpItem
-                      id={
-                        isOIDCclaimToRole
-                          ? "claim-value-help-icon"
-                          : "user-attribute-name-help-icon"
-                      }
-                      helpText={
-                        isOIDCclaimToRole
-                          ? "identity-providers-help:claimValue"
-                          : "identity-providers-help:userAttributeName"
-                      }
-                      forLabel={t("mapperUserAttributeName")}
+                      id="claim"
+                      helpText="identity-providers-help:claim"
+                      forLabel={t("claim")}
                       forID={t(`common:helpLabel`, {
-                        label: t("mapperUserAttributeName"),
+                        label: t("claim"),
                       })}
                     />
                   }
-                  fieldId="kc-user-attribute-name"
+                  fieldId="kc-friendly-name"
                   validated={
                     errors.name
                       ? ValidatedOptions.error
@@ -684,24 +652,10 @@ export const AddMapper = () => {
                   <TextInput
                     ref={register()}
                     type="text"
-                    defaultValue={
-                      isOIDCclaimToRole
-                        ? currentMapper?.config["claim-value"]
-                        : currentMapper?.config["attribute-value"]
-                    }
-                    data-testid={
-                      isOIDCclaimToRole ? "claim-value" : "user-attribute-name"
-                    }
-                    id={
-                      isOIDCclaimToRole
-                        ? "kc-claim-value"
-                        : "kc-user-attribute-name"
-                    }
-                    name={
-                      isOIDCclaimToRole
-                        ? "config.claim"
-                        : "config.user-attribute"
-                    }
+                    defaultValue={currentMapper?.config["claim"]}
+                    data-testid="claim"
+                    id="kc-claim"
+                    name={"config.claim"}
                     validated={
                       errors.name
                         ? ValidatedOptions.error
@@ -709,28 +663,34 @@ export const AddMapper = () => {
                     }
                   />
                 </FormGroup>
-              </>
-            )}
-            {(isSAMLAdvancedAttrToRole ||
-              isHardcodedRole ||
-              isSAMLAttributeToRole ||
-              isOIDCAdvancedClaimToRole ||
-              isOIDCclaimToRole) && (
+              )}
               <FormGroup
-                label={t("common:role")}
+                label={
+                  isOIDCclaimToRole
+                    ? t("claimValue")
+                    : t("mapperUserAttributeName")
+                }
                 labelIcon={
                   <HelpItem
-                    id="name-help-icon"
-                    helpText="identity-providers-help:role"
-                    forLabel={t("identity-providers-help:role")}
-                    forID={t(`identity-providers:helpLabel`, {
-                      label: t("role"),
+                    id={
+                      isOIDCclaimToRole
+                        ? "claim-value-help-icon"
+                        : "user-attribute-name-help-icon"
+                    }
+                    helpText={
+                      isOIDCclaimToRole
+                        ? "identity-providers-help:claimValue"
+                        : "identity-providers-help:userAttributeName"
+                    }
+                    forLabel={t("mapperUserAttributeName")}
+                    forID={t(`common:helpLabel`, {
+                      label: t("mapperUserAttributeName"),
                     })}
                   />
                 }
-                fieldId="kc-role"
+                fieldId="kc-user-attribute-name"
                 validated={
-                  errors.config?.role
+                  errors.name
                     ? ValidatedOptions.error
                     : ValidatedOptions.default
                 }
@@ -739,94 +699,151 @@ export const AddMapper = () => {
                 <TextInput
                   ref={register()}
                   type="text"
-                  id="kc-role"
-                  data-testid="mapper-role-input"
-                  name="config.role"
-                  value={selectedRole[0]?.name}
+                  defaultValue={
+                    isOIDCclaimToRole
+                      ? currentMapper?.config["claim-value"]
+                      : currentMapper?.config["attribute-value"]
+                  }
+                  data-testid={
+                    isOIDCclaimToRole ? "claim-value" : "user-attribute-name"
+                  }
+                  id={
+                    isOIDCclaimToRole
+                      ? "kc-claim-value"
+                      : "kc-user-attribute-name"
+                  }
+                  name={
+                    isOIDCclaimToRole ? "config.claim" : "config.user-attribute"
+                  }
+                  validated={
+                    errors.name
+                      ? ValidatedOptions.error
+                      : ValidatedOptions.default
+                  }
+                />
+              </FormGroup>
+            </>
+          )}
+
+          {isSocialAttributeImporter && (
+            <>
+              <FormGroup
+                label={t("socialProfileJSONFieldPath")}
+                labelIcon={
+                  <HelpItem
+                    id="social-profile-JSON-field-path-help-icon"
+                    helpText="identity-providers-help:socialProfileJSONFieldPath"
+                    forLabel={t("socialProfileJSONFieldPath")}
+                    forID={t(`common:helpLabel`, {
+                      label: t("socialProfileJSONFieldPath"),
+                    })}
+                  />
+                }
+                fieldId="kc-social-profile-JSON-field-path"
+                validated={
+                  errors.name
+                    ? ValidatedOptions.error
+                    : ValidatedOptions.default
+                }
+                helperTextInvalid={t("common:required")}
+              >
+                <TextInput
+                  ref={register()}
+                  type="text"
+                  defaultValue={currentMapper?.config.attribute}
+                  id="kc-social-profile-JSON-field-path"
+                  data-testid={"social-profile-JSON-field-path"}
+                  name="config.jsonField"
                   validated={
                     errors.config?.role
                       ? ValidatedOptions.error
                       : ValidatedOptions.default
                   }
                 />
-                <Button
-                  data-testid="select-role-button"
-                  onClick={() => toggleModal()}
-                >
-                  {t("selectRole")}
-                </Button>
               </FormGroup>
-            )}
-          </>
-        ) : (
-          <>
-            <FormGroup
-              label={t("userSessionAttribute")}
-              labelIcon={
-                <HelpItem
-                  id="user-session-attribute-help-icon"
-                  helpText="identity-providers-help:userSessionAttribute"
-                  forLabel={t("userSessionAttribute")}
-                  forID={t(`common:helpLabel`, {
-                    label: t("userSessionAttribute"),
-                  })}
-                />
-              }
-              fieldId="kc-user-session-attribute"
-              isRequired
-              validated={
-                errors.name ? ValidatedOptions.error : ValidatedOptions.default
-              }
-              helperTextInvalid={t("common:required")}
-            >
-              <TextInput
-                ref={register({ required: true })}
-                type="text"
-                id="kc-attribute"
-                data-testid="user-session-attribute"
-                name="config.attribute"
+              <FormGroup
+                label={t("mapperUserAttributeName")}
+                labelIcon={
+                  <HelpItem
+                    id="user-attribute-name-help-icon"
+                    helpText="identity-providers-help:socialUserAttributeName"
+                    forLabel={t("mapperUserAttributeName")}
+                    forID={t(`common:helpLabel`, {
+                      label: t("mapperUserAttributeName"),
+                    })}
+                  />
+                }
+                fieldId="kc-user-session-attribute-value"
                 validated={
                   errors.name
                     ? ValidatedOptions.error
                     : ValidatedOptions.default
                 }
-              />
-            </FormGroup>
+                helperTextInvalid={t("common:required")}
+              >
+                <TextInput
+                  ref={register()}
+                  type="text"
+                  defaultValue={currentMapper?.config.userAttribute}
+                  data-testid={"user-attribute-name"}
+                  id="kc-user-session-attribute-name"
+                  name="config.userAttribute"
+                  validated={
+                    errors.name
+                      ? ValidatedOptions.error
+                      : ValidatedOptions.default
+                  }
+                />
+              </FormGroup>
+            </>
+          )}
+          {(isSAMLAdvancedAttrToRole ||
+            isHardcodedRole ||
+            isSAMLAttributeToRole ||
+            isOIDCAdvancedClaimToRole ||
+            isOIDCclaimToRole) && (
             <FormGroup
-              label={t("userSessionAttributeValue")}
+              label={t("common:role")}
               labelIcon={
                 <HelpItem
-                  id="user-session-attribute-value-help-icon"
-                  helpText="identity-providers-help:userSessionAttributeValue"
-                  forLabel={t("userSessionAttributeValue")}
-                  forID={t(`common:helpLabel`, {
-                    label: t("userSessionAttributeValue"),
+                  id="name-help-icon"
+                  helpText="identity-providers-help:role"
+                  forLabel={t("identity-providers-help:role")}
+                  forID={t(`identity-providers:helpLabel`, {
+                    label: t("role"),
                   })}
                 />
               }
-              fieldId="kc-user-session-attribute-value"
-              isRequired
+              fieldId="kc-role"
               validated={
-                errors.name ? ValidatedOptions.error : ValidatedOptions.default
+                errors.config?.role
+                  ? ValidatedOptions.error
+                  : ValidatedOptions.default
               }
               helperTextInvalid={t("common:required")}
             >
               <TextInput
-                ref={register({ required: true })}
+                ref={register()}
                 type="text"
-                data-testid="user-session-attribute-value"
-                id="kc-user-session-attribute-value"
-                name="config.attribute-value"
+                id="kc-role"
+                data-testid="mapper-role-input"
+                name="config.role"
+                value={selectedRole[0]?.name}
                 validated={
-                  errors.name
+                  errors.config?.role
                     ? ValidatedOptions.error
                     : ValidatedOptions.default
                 }
               />
+              <Button
+                data-testid="select-role-button"
+                onClick={() => toggleModal()}
+              >
+                {t("selectRole")}
+              </Button>
             </FormGroup>
-          </>
-        )}
-
+          )}
+        </>
         <ActionGroup>
           <Button
             data-testid="new-mapper-save-button"

--- a/src/identity-providers/add/AddMapperForm.tsx
+++ b/src/identity-providers/add/AddMapperForm.tsx
@@ -20,11 +20,11 @@ import type { IdPMapperRepresentationWithAttributes } from "./AddMapper";
 type AddMapperFormProps = {
   mapperTypes?: Record<string, IdentityProviderMapperRepresentation>;
   mapperType: string;
-  providerId: string;
   id: string;
   updateMapperType: (mapperType: string) => void;
   form: UseFormMethods<IdPMapperRepresentationWithAttributes>;
   formValues: IdPMapperRepresentationWithAttributes;
+  isSocialIdP: boolean;
 };
 
 export const AddMapperForm = ({
@@ -34,6 +34,7 @@ export const AddMapperForm = ({
   id,
   updateMapperType,
   formValues,
+  isSocialIdP,
 }: AddMapperFormProps) => {
   const { t } = useTranslation("identity-providers");
 
@@ -129,7 +130,9 @@ export const AddMapperForm = ({
             helpText={
               formValues.identityProviderMapper ===
                 "saml-user-attribute-idp-mapper" &&
-              (providerId === "oidc" || providerId === "keycloak-oidc")
+              (providerId === "oidc" ||
+                providerId === "keycloak-oidc" ||
+                isSocialIdP)
                 ? `identity-providers-help:oidcAttributeImporter`
                 : `identity-providers-help:${mapperType}`
             }
@@ -142,7 +145,9 @@ export const AddMapperForm = ({
         <Controller
           name="identityProviderMapper"
           defaultValue={
-            providerId === "saml"
+            isSocialIdP
+              ? `${providerId.toLowerCase()}-user-attribute-mapper`
+              : providerId === "saml"
               ? "saml-advanced-role-idp-mapper"
               : "oidc-advanced-role-idp-mapper"
           }

--- a/src/identity-providers/help.ts
+++ b/src/identity-providers/help.ts
@@ -136,6 +136,8 @@ export default {
     userAttribute: "Name of user attribute you want to hardcode",
     claim:
       "Name of claim to search for in token. You can reference nested claims by using a '.', i.e. 'address.locality'. To use dot (.) literally, escape it with backslash. (\\.)",
+    socialProfileJSONFieldPath:
+      "Path of field in Social Provider User Profile JSON data to get value from. You can use dot notation for nesting and square brackets for array index. E.g. 'contact.address[0].country'.",
     userAttributeValue: "Value you want to hardcode",
     attributeName:
       "Name of attribute to search for in assertion. You can leave this blank and specify a friendly name instead.",
@@ -143,6 +145,7 @@ export default {
       "Friendly name of attribute to search for in assertion. You can leave this blank and specify a name instead.",
     userAttributeName:
       "User attribute name to store SAML attribute. Use email, lastName, and firstName to map to those predefined user properties.",
+    socialUserAttributeName: "User attribute name to store information.",
     attributeValue:
       "Value the attribute must have. If the attribute is a list, then the value must be contained in the list.",
     attributes:

--- a/src/identity-providers/messages.ts
+++ b/src/identity-providers/messages.ts
@@ -74,6 +74,7 @@ export default {
     claim: "Claim",
     claimValue: "Claim Value",
     claims: "Claims",
+    socialProfileJSONFieldPath: "Social Profile JSON Field Path",
     mapperAttributeName: "Attribute Name",
     mapperUserAttributeName: "User Attribute Name",
     mapperAttributeFriendlyName: "Friendly name",


### PR DESCRIPTION
## Motivation
<!-- Add references to relevant tickets, issues, design specs and/or a short description of what motivated you to do it. -->
Closes #1206 

## Verification Steps
<!--
Add the steps required to verify this change. Keep in mind that these steps should be written so groups unfamiliar with the 
new functionality can follow them, such as QE or documentation.-->

1. Go to Identity Providers
2. Create a provider and select a "Social" identity provider from the . 
3. Go to the "Mappers" tab
4. Click "Create a new mapper."
5. Verify that when a new mapper type is selected in the "Mapper Type" menu, the fields in the form change corresponding to the mapper type. 
6. Create a mapper for every type and verify the save is successful.

## Checklist:

- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [x] Help has been implemented
- [x] axe report has been run and resulting a11y issues have been resolved
- [x] Unit tests have been created/updated

## Additional Notes
<!-- 
Add images and/or screen caps to illustrate what was changed if this pull request adds to or modifies existing user-visible appearance/output. 
-->
