### PR TITLE
Disable vendor for existing LDAP providers

### DIFF
--- a/src/user-federation/UserFederationLdapSettings.tsx
+++ b/src/user-federation/UserFederationLdapSettings.tsx
@@ -299,7 +299,7 @@ export const UserFederationLdapSettings = () => {
             t("advancedSettings"),
           ]}
         >
-          <LdapSettingsGeneral form={form} />
+          <LdapSettingsGeneral form={form} vendorEdit={!!id} />
           <LdapSettingsConnection form={form} edit={!!id} />
           <LdapSettingsSearching form={form} />
           <LdapSettingsSynchronization form={form} />

--- a/src/user-federation/ldap/LdapSettingsGeneral.tsx
+++ b/src/user-federation/ldap/LdapSettingsGeneral.tsx
@@ -19,12 +19,14 @@ export type LdapSettingsGeneralProps = {
   form: UseFormMethods;
   showSectionHeading?: boolean;
   showSectionDescription?: boolean;
+  vendorEdit?: boolean;
 };
 
 export const LdapSettingsGeneral = ({
   form,
   showSectionHeading = false,
   showSectionDescription = false,
+  vendorEdit = false,
 }: LdapSettingsGeneralProps) => {
   const { t } = useTranslation("user-federation");
   const helpText = useTranslation("user-federation-help").t;
@@ -174,6 +176,7 @@ export const LdapSettingsGeneral = ({
             control={form.control}
             render={({ onChange, value }) => (
               <Select
+                isDisabled={!!vendorEdit}
                 toggleId="kc-vendor"
                 required
                 onToggle={() => setIsVendorDropdownOpen(!isVendorDropdownOpen)}


### PR DESCRIPTION
## Motivation
Fixes https://github.com/keycloak/keycloak-admin-ui/issues/1392.

## Brief Description
Changed the LDAP user fed provider's form so that it only allows editing of the Vendor field when it is being created as new, otherwise aka on existing LDAP providers, it will be disabled.

## Verification Steps
1. Create a new LDAP user fed provider.
2. Verify that you can select a vendor type e.g. Active Directory.
3. Add values for all of the required fields and save the provider.
4. Open the main User Fed provider screen, click the card of the provider you saved in step 3.
5. Verify that the Vendor field is now disabled.

## Checklist:
- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [x] Help has been implemented
- [x] Unit tests have been created/updated

## Additional Notes
None