### PR TITLE
Client policies(policies): Add support for editing client policy data

### DIFF
--- a/cypress/integration/realm_settings_test.spec.ts
+++ b/cypress/integration/realm_settings_test.spec.ts
@@ -537,7 +537,7 @@ describe("Realm settings tests", () => {
     });
   });
 
-  describe.skip("Realm settings client policies tab tests", () => {
+  describe("Realm settings client policies tab tests", () => {
     beforeEach(() => {
       keycloakBefore();
       loginPage.logIn();

--- a/cypress/support/pages/admin_console/manage/realm_settings/RealmSettingsPage.ts
+++ b/cypress/support/pages/admin_console/manage/realm_settings/RealmSettingsPage.ts
@@ -171,6 +171,7 @@ export default class RealmSettingsPage {
   private jsonEditorReloadBtn = "jsonEditor-reloadBtn";
   private jsonEditor = ".monaco-scrollable-element.editor-scrollable.vs";
   private createClientDrpDwn = ".pf-c-dropdown.pf-m-align-right";
+  private clientPolicyDrpDwn = "action-dropdown";
   private searchFld = "[id^=realm-settings][id$=profilesinput]";
   private searchFldPolicies = "[id^=realm-settings][id$=clientPoliciesinput]";
   private clientProfileOne = 'a[href*="realm-settings/clientPolicies/Test"]';
@@ -855,7 +856,7 @@ export default class RealmSettingsPage {
     );
     cy.findByTestId(this.saveNewClientPolicyBtn).click();
     cy.get(this.alertMessage).should("be.visible", "New client policy created");
-    cy.get(this.createClientDrpDwn).contains("Action").click();
+    cy.findByTestId(this.clientPolicyDrpDwn).contains("Action").click();
     cy.findByTestId("deleteClientPolicyDropdown").click();
     cy.findByTestId("modalConfirm").contains("Delete").click();
     cy.get(this.alertMessage).should("be.visible", "Client profile deleted");

--- a/src/realm-settings/ClientProfileForm.tsx
+++ b/src/realm-settings/ClientProfileForm.tsx
@@ -35,7 +35,7 @@ import "./RealmSettingsSection.css";
 import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
 import { toAddExecutor } from "./routes/AddExecutor";
 import { useServerInfo } from "../context/server-info/ServerInfoProvider";
-import type { ClientProfileParams } from "./routes/ClientProfile";
+import { ClientProfileParams, toClientProfile } from "./routes/ClientProfile";
 
 type ClientProfileForm = Required<ClientProfileRepresentation>;
 
@@ -106,7 +106,7 @@ export default function ClientProfileForm() {
         AlertVariant.success
       );
 
-      history.push(`/${realm}/realm-settings/clientPolicies/${form.name}`);
+      history.push(toClientProfile({ realm, profileName: form.name }));
     } catch (error) {
       addError(
         editMode
@@ -159,9 +159,7 @@ export default function ClientProfileForm() {
             globalProfiles,
           });
           addAlert(t("deleteExecutorSuccess"), AlertVariant.success);
-          history.push(
-            `/${realm}/realm-settings/clientPolicies/${profileName}/edit-profile`
-          );
+          history.push(toClientProfile({ realm, profileName }));
         } catch (error) {
           addError(t("deleteExecutorError"), error);
         }

--- a/src/realm-settings/ExecutorForm.tsx
+++ b/src/realm-settings/ExecutorForm.tsx
@@ -21,7 +21,7 @@ import { useAdminClient, useFetch } from "../context/auth/AdminClient";
 import type ComponentTypeRepresentation from "@keycloak/keycloak-admin-client/lib/defs/componentTypeRepresentation";
 import type { ConfigPropertyRepresentation } from "@keycloak/keycloak-admin-client/lib/defs/authenticatorConfigInfoRepresentation";
 import type ClientProfileRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientProfileRepresentation";
-import type { ClientProfileParams } from "./routes/ClientProfile";
+import { ClientProfileParams, toClientProfile } from "./routes/ClientProfile";
 import {
   COMPONENTS,
   isValidComponentType,
@@ -94,9 +94,7 @@ export default function ExecutorForm() {
         globalProfiles: globalProfiles,
       });
       addAlert(t("realm-settings:addExecutorSuccess"), AlertVariant.success);
-      history.push(
-        `/${realm}/realm-settings/clientPolicies/${profileName}/edit-profile`
-      );
+      history.push(toClientProfile({ realm, profileName }));
     } catch (error) {
       addError("realm-settings:addExecutorError", error);
     }
@@ -192,10 +190,7 @@ export default function ExecutorForm() {
             <Button
               variant="link"
               component={(props) => (
-                <Link
-                  {...props}
-                  to={`/${realm}/realm-settings/clientPolicies/${profileName}/edit-profile`}
-                />
+                <Link {...props} to={toClientProfile({ realm, profileName })} />
               )}
               data-testid="addExecutor-cancelBtn"
             >

--- a/src/realm-settings/NewClientPolicyForm.tsx
+++ b/src/realm-settings/NewClientPolicyForm.tsx
@@ -93,6 +93,8 @@ export default function NewClientPolicyForm() {
   const [key, setKey] = useState(0);
   const refresh = () => setKey(new Date().getTime());
 
+  const formValues = form.getValues();
+
   useFetch(
     async () => {
       const [policies, profiles] = await Promise.all([
@@ -143,8 +145,6 @@ export default function NewClientPolicyForm() {
       "org.keycloak.services.clientpolicy.condition.ClientPolicyConditionProvider"
     ];
 
-  const formValues = form.getValues();
-
   const save = async () => {
     const createdForm = form.getValues();
     const createdPolicy = {
@@ -153,19 +153,26 @@ export default function NewClientPolicyForm() {
       conditions: [],
     };
 
-    const policyNameExists = policies.find(
-      (policy) => policy.name === createdPolicy.name
-    );
+    const getAllPolicies = () => {
+      const policyNameExists = policies.some(
+        (policy) => policy.name === createdPolicy.name
+      );
 
-    const res = policies.map((policy) =>
-      policy.name === createdPolicy.name ? createdPolicy : policy
-    );
-
-    const allPolicies = policyNameExists ? res : policies.concat(createdForm);
+      if (policyNameExists) {
+        return policies.map((policy) =>
+          policy.name === createdPolicy.name ? createdPolicy : policy
+        );
+      } else if (createdForm.name !== policyName) {
+        return policies
+          .filter((item) => item.name !== policyName)
+          .concat(createdForm);
+      }
+      return policies.concat(createdForm);
+    };
 
     try {
       await adminClient.clientPolicies.updatePolicy({
-        policies: allPolicies,
+        policies: getAllPolicies(),
       });
       addAlert(
         t("realm-settings:createClientPolicySuccess"),
@@ -328,7 +335,6 @@ export default function NewClientPolicyForm() {
         t("realm-settings:addClientProfileSuccess"),
         AlertVariant.success
       );
-      refresh();
     } catch (error) {
       addError("realm-settings:addClientProfileError", error);
     }
@@ -350,7 +356,7 @@ export default function NewClientPolicyForm() {
       <ViewHeader
         titleKey={
           showAddConditionsAndProfilesForm || policyName
-            ? policyName!
+            ? formValues.name!
             : t("createPolicy")
         }
         divider


### PR DESCRIPTION
## Motivation
<!-- Add references to relevant tickets, issues, design specs and/or a short description of what motivated you to do it. -->
https://issues.redhat.com/browse/CLUX-293

## Verification Steps
<!--
Add the steps required to verify this change. Keep in mind that these steps should be written so groups unfamiliar with the 
new functionality can follow them, such as QE or documentation.-->

1. Go to Realm Settings -> Client Policies tab
2. Click on the "policies" subtab
3. Create a policy
4. Go back to the data table and click the policy you just created
5. Change the name and/or description of the policy
6. Verify the save is successful
7. Go back to the data table and select the policy you just edited
8. Verify the data shown is correct


## Checklist:

- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [x] Help has been implemented
- [x] axe report has been run and resulting a11y issues have been resolved
- [x] Unit tests have been created/updated

## Additional Notes
<!-- 
Add images and/or screen caps to illustrate what was changed if this pull request adds to or modifies existing user-visible appearance/output. 
-->
