### PR TITLE
Fix notification-related cypress failures without waits

### DIFF
--- a/cypress/integration/user_fed_ldap_mapper_test.spec.ts
+++ b/cypress/integration/user_fed_ldap_mapper_test.spec.ts
@@ -151,39 +151,33 @@ describe("User Fed LDAP mapper tests", () => {
 
     listingPage.itemExist(creationDateMapper).deleteItem(creationDateMapper);
     modalUtils.checkModalTitle(mapperDeleteTitle).confirmModal();
-    masthead.checkNotificationMessage(mapperDeletedSuccess);
+    masthead.checkNotificationMessage(mapperDeletedSuccess, true);
     listingPage.itemExist(creationDateMapper, false);
-    cy.wait(5000);
 
     listingPage.itemExist(emailMapper).deleteItem(emailMapper);
     modalUtils.checkModalTitle(mapperDeleteTitle).confirmModal();
-    masthead.checkNotificationMessage(mapperDeletedSuccess);
+    masthead.checkNotificationMessage(mapperDeletedSuccess, true);
     listingPage.itemExist(emailMapper, false);
-    cy.wait(5000);
 
     listingPage.itemExist(lastNameMapper).deleteItem(lastNameMapper);
     modalUtils.checkModalTitle(mapperDeleteTitle).confirmModal();
-    masthead.checkNotificationMessage(mapperDeletedSuccess);
+    masthead.checkNotificationMessage(mapperDeletedSuccess, true);
     listingPage.itemExist(lastNameMapper, false);
-    cy.wait(5000);
 
     listingPage.itemExist(modifyDateMapper).deleteItem(modifyDateMapper);
     modalUtils.checkModalTitle(mapperDeleteTitle).confirmModal();
-    masthead.checkNotificationMessage(mapperDeletedSuccess);
+    masthead.checkNotificationMessage(mapperDeletedSuccess, true);
     listingPage.itemExist(modifyDateMapper, false);
-    cy.wait(5000);
 
     listingPage.itemExist(usernameMapper).deleteItem(usernameMapper);
     modalUtils.checkModalTitle(mapperDeleteTitle).confirmModal();
-    masthead.checkNotificationMessage(mapperDeletedSuccess);
+    masthead.checkNotificationMessage(mapperDeletedSuccess, true);
     listingPage.itemExist(usernameMapper, false);
-    cy.wait(5000);
 
     listingPage.itemExist(firstNameMapper).deleteItem(firstNameMapper);
     modalUtils.checkModalTitle(mapperDeleteTitle).confirmModal();
-    masthead.checkNotificationMessage(mapperDeletedSuccess);
+    masthead.checkNotificationMessage(mapperDeletedSuccess, true);
     listingPage.itemExist(firstNameMapper, false);
-    cy.wait(5000);
 
     listingPage
       .itemExist(MsadAccountControlsMapper)

--- a/cypress/support/pages/admin_console/Masthead.ts
+++ b/cypress/support/pages/admin_console/Masthead.ts
@@ -50,9 +50,11 @@ export default class Masthead {
     cy.get("#manage-account").click();
   }
 
-  checkNotificationMessage(message: string) {
+  checkNotificationMessage(message: string, closeNotification?: boolean) {
     cy.contains(message).should("exist");
-
+    if (closeNotification) {
+      cy.get(".pf-c-alert__action").click();
+    }
     return this;
   }
 


### PR DESCRIPTION
## Motivation
Follow-up to https://github.com/keycloak/keycloak-admin-ui/pull/1438, and provides a fix for the issue in which notifications can stack to a point that they will interfere with attempted actions on a modal. This solution dismisses the notifications instead of adding timed waits.

## Brief Description
See https://github.com/keycloak/keycloak-admin-ui/pull/1438 for a more descriptive explanation of the problem. This solution adds an optional closeNotification parameter to the existing checkNotificationMessage function, so when you call the function to check the content of a notification message and pass true, it will dismiss the notification after checking the text. I chose to make it optional so it won't affect any legacy tests in which this is not an issue.

## Verification Steps
Verify that the ldap mapper test no longer fails locally or in CI.

## Checklist:
- [x] Code has been tested locally by PR requester
- [x] Unit tests have been created/updated

## Additional Notes
None