### PR TITLE
Realm settings(client policies): Edit conditions in client policy

### DIFF
--- a/cypress/integration/realm_settings_test.spec.ts
+++ b/cypress/integration/realm_settings_test.spec.ts
@@ -566,6 +566,30 @@ describe("Realm settings tests", () => {
       realmSettingsPage.shouldSearchClientPolicy();
     });
 
+    it("Should not have conditions configured by default", () => {
+      realmSettingsPage.shouldNotHaveConditionsConfigured();
+    });
+
+    it("Should cancel adding a new condition to a client profile", () => {
+      realmSettingsPage.shouldCancelAddingCondition();
+    });
+
+    it("Should add a new condition to a client profile", () => {
+      realmSettingsPage.shouldAddCondition();
+    });
+
+    it("Should edit the condition of a client profile", () => {
+      realmSettingsPage.shouldEditCondition();
+    });
+
+    it("Should cancel deleting condition from a client profile", () => {
+      realmSettingsPage.shouldCancelDeletingCondition();
+    });
+
+    it("Should delete condition from a client profile", () => {
+      realmSettingsPage.shouldDeleteCondition();
+    });
+
     it("Check cancelling the client policy deletion", () => {
       realmSettingsPage.shouldDisplayDeleteClientPolicyDialog();
     });

--- a/cypress/support/pages/admin_console/manage/realm_settings/RealmSettingsPage.ts
+++ b/cypress/support/pages/admin_console/manage/realm_settings/RealmSettingsPage.ts
@@ -176,8 +176,12 @@ export default class RealmSettingsPage {
   private clientPolicyDrpDwn = "action-dropdown";
   private searchFld = "[id^=realm-settings][id$=profilesinput]";
   private searchFldPolicies = "[id^=realm-settings][id$=clientPoliciesinput]";
-  private clientProfileOne = 'a[href*="realm-settings/clientPolicies/Test"]';
-  private clientProfileTwo = 'a[href*="realm-settings/clientPolicies/Edit"]';
+  private clientProfileOne =
+    'a[href*="realm-settings/clientPolicies/Test/edit-profile"]';
+  private clientProfileTwo =
+    'a[href*="realm-settings/clientPolicies/Edit/edit-profile"]';
+  private clientPolicy =
+    'a[href*="realm-settings/clientPolicies/Test/edit-policy"]';
   private reloadBtn = "reloadProfile";
   private addExecutor = "addExecutor";
   private addExecutorDrpDwn = ".pf-c-select__toggle";
@@ -185,6 +189,13 @@ export default class RealmSettingsPage {
   private addExecutorCancelBtn = "addExecutor-cancelBtn";
   private addExecutorSaveBtn = "addExecutor-saveBtn";
   private listingPage = new ListingPage();
+  private addCondition = "addCondition";
+  private addConditionDrpDwn = ".pf-c-select__toggle";
+  private addConditionDrpDwnOption = "conditionType-select";
+  private addConditionCancelBtn = "addCondition-cancelBtn";
+  private addConditionSaveBtn = "addCondition-saveBtn";
+  private conditionTypeLink = "condition-type-link";
+  private addValue = "addValue";
 
   selectLoginThemeType(themeType: string) {
     cy.get(this.selectLoginTheme).click();
@@ -841,6 +852,87 @@ export default class RealmSettingsPage {
     cy.findByTestId("modalConfirm").contains("Delete");
     cy.get(this.deleteDialogCancelBtn).contains("Cancel").click();
     cy.get("table").should("be.visible").contains("td", "Test");
+  }
+
+  shouldNotHaveConditionsConfigured() {
+    cy.get(this.clientPolicy).click();
+    cy.get('h6[class*="kc-emptyConditions"]').should(
+      "have.text",
+      "No conditions configured"
+    );
+  }
+
+  shouldCancelAddingCondition() {
+    cy.get(this.clientPolicy).click();
+    cy.findByTestId(this.addCondition).click();
+    cy.get(this.addConditionDrpDwn).click();
+    cy.findByTestId(this.addConditionDrpDwnOption)
+      .contains("any-client")
+      .click();
+    cy.findByTestId(this.addConditionCancelBtn).click();
+    cy.get('h6[class*="kc-emptyConditions"]').should(
+      "have.text",
+      "No conditions configured"
+    );
+  }
+
+  shouldAddCondition() {
+    cy.get(this.clientPolicy).click();
+    cy.findByTestId(this.addCondition).click();
+    cy.get(this.addConditionDrpDwn).click();
+    cy.findByTestId(this.addConditionDrpDwnOption)
+      .contains("client-roles")
+      .click();
+    cy.get('input[name="config.roles[0].value"]').click().type("role 1");
+
+    cy.findByTestId(this.addConditionSaveBtn).click();
+    cy.get(this.alertMessage).should(
+      "be.visible",
+      "Success! Condition created successfully"
+    );
+    cy.get('ul[class*="pf-c-data-list"]').should("have.text", "client-roles");
+  }
+
+  shouldEditCondition() {
+    cy.get(this.clientPolicy).click();
+
+    cy.findByTestId(this.conditionTypeLink).contains("client-roles").click();
+
+    cy.findByTestId(this.addValue).click();
+
+    cy.get('input[name="config.roles[1].value"]').click().type("role 2");
+
+    cy.findByTestId(this.addConditionSaveBtn).click();
+    cy.get(this.alertMessage).should(
+      "be.visible",
+      "Success! Condition updated successfully"
+    );
+  }
+
+  shouldCancelDeletingCondition() {
+    cy.get(this.clientPolicy).click();
+    cy.get('svg[class*="kc-conditionType-trash-icon"]').click();
+    cy.get(this.deleteDialogTitle).contains("Delete condition?");
+    cy.get(this.deleteDialogBodyText).contains(
+      "This action will permanently delete client-roles. This cannot be undone."
+    );
+    cy.findByTestId("modalConfirm").contains("Delete");
+    cy.get(this.deleteDialogCancelBtn).contains("Cancel").click();
+    cy.get('ul[class*="pf-c-data-list"]').should("have.text", "client-roles");
+  }
+
+  shouldDeleteCondition() {
+    cy.get(this.clientPolicy).click();
+    cy.get('svg[class*="kc-conditionType-trash-icon"]').click();
+    cy.get(this.deleteDialogTitle).contains("Delete condition?");
+    cy.get(this.deleteDialogBodyText).contains(
+      "This action will permanently delete client-roles. This cannot be undone."
+    );
+    cy.findByTestId("modalConfirm").contains("Delete").click();
+    cy.get('h6[class*="kc-emptyConditions"]').should(
+      "have.text",
+      "No conditions configured"
+    );
   }
 
   shouldDeleteClientPolicyDialog() {

--- a/src/components/dynamic/DynamicComponents.tsx
+++ b/src/components/dynamic/DynamicComponents.tsx
@@ -5,15 +5,28 @@ import { COMPONENTS, isValidComponentType } from "./components";
 
 type DynamicComponentProps = {
   properties: ConfigPropertyRepresentation[];
+  selectedValues?: string[];
+  parentCallback?: (data: string[]) => void;
 };
 
-export const DynamicComponents = ({ properties }: DynamicComponentProps) => (
+export const DynamicComponents = ({
+  properties,
+  selectedValues,
+  parentCallback,
+}: DynamicComponentProps) => (
   <>
     {properties.map((property) => {
       const componentType = property.type!;
       if (isValidComponentType(componentType)) {
         const Component = COMPONENTS[componentType];
-        return <Component key={property.name} {...property} />;
+        return (
+          <Component
+            key={property.name}
+            selectedValues={selectedValues}
+            parentCallback={parentCallback}
+            {...property}
+          />
+        );
       } else {
         console.warn(`There is no editor registered for ${componentType}`);
       }

--- a/src/components/dynamic/MultivaluedListComponent.tsx
+++ b/src/components/dynamic/MultivaluedListComponent.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Controller, useFormContext } from "react-hook-form";
 import {
@@ -18,10 +18,20 @@ export const MultiValuedListComponent = ({
   helpText,
   defaultValue,
   options,
+  selectedValues,
+  parentCallback,
 }: ComponentProps) => {
   const { t } = useTranslation("dynamic");
   const { control } = useFormContext();
   const [open, setOpen] = useState(false);
+  const [selectedItems, setSelectedItems] = useState<string[]>([defaultValue]);
+
+  useEffect(() => {
+    if (selectedValues) {
+      parentCallback!(selectedValues);
+      setSelectedItems(selectedValues!);
+    }
+  }, []);
 
   return (
     <FormGroup
@@ -52,10 +62,19 @@ export const MultiValuedListComponent = ({
               const option = v.toString();
               if (!value) {
                 onChange([option]);
+                parentCallback!([option]);
+                setSelectedItems([option]);
               } else if (value.includes(option)) {
-                onChange(value.filter((item: string) => item !== option));
+                const updatedItems = selectedItems.filter(
+                  (item: string) => item !== option
+                );
+                setSelectedItems(updatedItems);
+                onChange(updatedItems);
+                parentCallback!(updatedItems);
               } else {
                 onChange([...value, option]);
+                parentCallback!([...value, option]);
+                setSelectedItems([...selectedItems, option]);
               }
             }}
             onClear={(event) => {

--- a/src/components/dynamic/components.ts
+++ b/src/components/dynamic/components.ts
@@ -10,7 +10,10 @@ import { ClientSelectComponent } from "./ClientSelectComponent";
 import { MultiValuedStringComponent } from "./MultivaluedStringComponent";
 import { MultiValuedListComponent } from "./MultivaluedListComponent";
 
-export type ComponentProps = Omit<ConfigPropertyRepresentation, "type">;
+export type ComponentProps = Omit<ConfigPropertyRepresentation, "type"> & {
+  selectedValues?: string[];
+  parentCallback?: (data: any) => void;
+};
 const ComponentTypes = [
   "String",
   "boolean",

--- a/src/components/multi-line-input/MultiLineInput.tsx
+++ b/src/components/multi-line-input/MultiLineInput.tsx
@@ -15,13 +15,13 @@ export type MultiLine = {
 };
 
 export function convertToMultiline(fields: string[]): MultiLine[] {
-  return (fields && fields.length > 0 ? fields : [""]).map((field) => {
+  return (fields.length > 0 ? fields : [""]).map((field) => {
     return { value: field };
   });
 }
 
 export function toValue(formValue: MultiLine[]): string[] {
-  return formValue?.map((field) => field.value);
+  return formValue.map((field) => field.value);
 }
 
 export type MultiLineInputProps = Omit<TextInputProps, "form"> & {
@@ -76,6 +76,8 @@ export const MultiLineInput = ({
               onClick={() => append({})}
               tabIndex={-1}
               aria-label={t("common:add")}
+              data-testid="addValue"
+              // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
               isDisabled={rest.isDisabled || !currentValues?.[index]?.value}
             >
               <PlusCircleIcon /> {t(addButtonLabel || "common:add")}

--- a/src/realm-settings/NewClientPolicyForm.tsx
+++ b/src/realm-settings/NewClientPolicyForm.tsx
@@ -37,6 +37,7 @@ import type ClientPolicyRepresentation from "@keycloak/keycloak-admin-client/lib
 import { toClientPolicies } from "./routes/ClientPolicies";
 import { toNewClientPolicyCondition } from "./routes/AddCondition";
 import { useServerInfo } from "../context/server-info/ServerInfoProvider";
+import { toEditClientPolicyCondition } from "./routes/EditCondition";
 import type { EditClientPolicyParams } from "./routes/EditClientPolicy";
 import { AddClientProfileModal } from "./AddClientProfileModal";
 import type ClientProfileRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientProfileRepresentation";
@@ -462,7 +463,7 @@ export default function NewClientPolicyForm() {
                     )}
                     variant="link"
                     className="kc-addCondition"
-                    data-testid="cancelCreateProfile"
+                    data-testid="addCondition"
                     icon={<PlusCircleIcon />}
                   >
                     {t("realm-settings:addCondition")}
@@ -490,7 +491,11 @@ export default function NewClientPolicyForm() {
                                 <Link
                                   key={condition.condition}
                                   data-testid="condition-type-link"
-                                  to={""}
+                                  to={toEditClientPolicyCondition({
+                                    realm,
+                                    conditionName: condition.condition!,
+                                    policyName: policyName,
+                                  })}
                                   className="kc-condition-link"
                                 >
                                   {condition.condition}
@@ -570,7 +575,7 @@ export default function NewClientPolicyForm() {
                     id="addClientProfile"
                     variant="link"
                     className="kc-addClientProfile"
-                    data-testid="cancelCreateProfile"
+                    data-testid="addClientProfile"
                     icon={<PlusCircleIcon />}
                     onClick={toggleModal}
                   >

--- a/src/realm-settings/messages.ts
+++ b/src/realm-settings/messages.ts
@@ -200,6 +200,7 @@ export default {
     createClientPolicySuccess: "New policy created",
     createClientConditionSuccess: "Condition created successfully.",
     createClientConditionError: "Error creating condition: {{error}}",
+    updateClientConditionSuccess: "Condition updated successfully.",
     deleteClientConditionSuccess: "Condition deleted successfully.",
     deleteClientConditionError: "Error creating condition: {{error}}",
     clientPolicySearch: "Search client policy",
@@ -312,6 +313,7 @@ export default {
     clientUpdaterSourceRoles: "Updating entity role",
     conditionsHelpItem: "Conditions help item",
     addCondition: "Add condition",
+    editCondition: "Edit condition",
     emptyConditions: "No conditions configured",
     updateClientPoliciesSuccess:
       "The client policies configuration was updated",

--- a/src/realm-settings/routes.ts
+++ b/src/realm-settings/routes.ts
@@ -13,6 +13,7 @@ import { AddExecutorRoute } from "./routes/AddExecutor";
 import { AddClientPolicyRoute } from "./routes/AddClientPolicy";
 import { EditClientPolicyRoute } from "./routes/EditClientPolicy";
 import { NewClientPolicyConditionRoute } from "./routes/AddCondition";
+import { EditClientPolicyConditionRoute } from "./routes/EditCondition";
 
 const routes: RouteDef[] = [
   RealmSettingsRoute,
@@ -29,6 +30,7 @@ const routes: RouteDef[] = [
   AddClientPolicyRoute,
   EditClientPolicyRoute,
   NewClientPolicyConditionRoute,
+  EditClientPolicyConditionRoute,
 ];
 
 export default routes;

--- a/src/realm-settings/routes/EditCondition.ts
+++ b/src/realm-settings/routes/EditCondition.ts
@@ -12,7 +12,7 @@ export type EditClientPolicyConditionParams = {
 export const EditClientPolicyConditionRoute: RouteDef = {
   path: "/:realm/realm-settings/clientPolicies/:policyName?/edit-policy/:conditionName/edit-condition",
   component: NewClientPolicyCondition,
-  breadcrumb: (t) => t("realm-settings:addCondition"),
+  breadcrumb: (t) => t("realm-settings:editCondition"),
   access: "manage-clients",
 };
 


### PR DESCRIPTION
## Motivation
<!-- Add references to relevant tickets, issues, design specs and/or a short description of what motivated you to do it. -->
https://issues.redhat.com/browse/CLUX-329

## Brief Description
<!-- Add a short answer for: 
What was done in this PR? (e.g Fix to prevent users from accessing feature X.)
Why it was done? (e.g Feature X was deprecated.)
-->
Conditions are now editable.

## Verification Steps
<!--
Add the steps required to verify this change. Keep in mind that these steps should be written so groups unfamiliar with the 
new functionality can follow them, such as QE or documentation.
-->

1. Go to Realm settings -> Client Policies tab
2. Create a client policy if one does not exist yet.
3. Save the new client policy and then click "Add condition"
4. Add a new condition.
5. Navigate back to the "Edit policy" screen
6. Click the condition you created and update the field(s) under the condition type.
7. Save
8. Navigate back to the condition again and verify your changes were saved successfully. 

## Checklist:

- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [x] Help has been implemented
- [x] axe report has been run and resulting a11y issues have been resolved
- [x] Unit tests have been created/updated

## Additional Notes
<!-- 
Add images and/or screen caps to illustrate what was changed if this pull request adds to or modifies existing user-visible appearance/output. 
-->
