### PR TITLE
Prevent Dependabot from offering major updates for React Router

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,5 @@ updates:
   ignore:
     - dependency-name: react-hook-form
       update-types: ["version-update:semver-major"]
+    - dependency-name: react-router-dom
+      update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Motivation
Version 6 of React Router is a major version with a lot of breaking changes, the [upgrade guide](https://reactrouter.com/docs/en/v6/upgrading/v5) recommends the following:
> We recommend waiting for the backwards compatibility package to be released before upgrading apps that have more than a few routes.

Therefore this change will prevent Dependabot from offering updates until we have decided a proper upgrade path.