### PR TITLE
Add missing field/change default value in user-attribute-ldap-mapper

### DIFF
--- a/src/user-federation/help.ts
+++ b/src/user-federation/help.ts
@@ -147,6 +147,8 @@ export default {
       "If on, then during reading of the LDAP attribute value will always used instead of the value from Keycloak DB.",
     isMandatoryInLdapHelp:
       "If true, attribute is mandatory in LDAP. Hence if there is no value in Keycloak DB, the empty value will be set to be propagated to LDAP.",
+    attributeDefaultValueHelp:
+      "If there is no value in Keycloak DB and attribute is mandatory in LDAP, this value will be propagated to LDAP.",
     isBinaryAttributeHelp: "Should be true for binary LDAP attributes.",
 
     derFormattedHelp:

--- a/src/user-federation/ldap/mappers/LdapMapperUserAttribute.tsx
+++ b/src/user-federation/ldap/mappers/LdapMapperUserAttribute.tsx
@@ -74,7 +74,7 @@ export const LdapMapperUserAttribute = ({
       >
         <Controller
           name="config.read-only"
-          defaultValue={["false"]}
+          defaultValue={["true"]}
           control={form.control}
           render={({ onChange, value }) => (
             <Switch
@@ -143,6 +143,25 @@ export const LdapMapperUserAttribute = ({
             />
           )}
         ></Controller>
+      </FormGroup>
+      <FormGroup
+        label={t("attributeDefaultValue")}
+        labelIcon={
+          <HelpItem
+            helpText={helpText("attributeDefaultValueHelp")}
+            forLabel={t("attributeDefaultValue")}
+            forID="kc-attribute-default-value"
+          />
+        }
+        fieldId="kc-attribute-default-value"
+      >
+        <TextInput
+          type="text"
+          id="kc-attribute-default-value"
+          data-testid="mapper-attributeDefaultValue-fld"
+          name="config.attribute-default-value[0]"
+          ref={form.register}
+        />
       </FormGroup>
       <FormGroup
         label={t("isBinaryAttribute")}

--- a/src/user-federation/messages.ts
+++ b/src/user-federation/messages.ts
@@ -184,6 +184,7 @@ export default {
     readOnly: "Read only",
     alwaysReadValueFromLdap: "Always read value from LDAP",
     isMandatoryInLdap: "Is mandatory in LDAP",
+    attributeDefaultValue: "Attribute default value",
     isBinaryAttribute: "Is binary attribute",
     derFormatted: "DER formatted",
 


### PR DESCRIPTION
## Motivation
Fixes https://github.com/keycloak/keycloak-admin-ui/issues/1480.

## Brief Description
For the `user-attribute-ldap-mapper` mapper type, there was field missing called `Attribute default value`. Also, the default for the `Read only` switch was incorrectly set to `OFF`, when it should be `ON`.

## Verification Steps
1. Create an LDAP user federation provider and click the Mappers tab. 
2. Click `Add mapper` to create new mapper.
3. Select `user-attribute-ldap-mapper` as the mapper type.
4. Verify that the `Read only` field defaults to `On`, and that you can save/retrieve values for the newly-added `Attribute default value` field (and that help works, etc).

## Checklist:
- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [x] Help has been implemented
- [x] Unit tests have been created/updated

## Additional Notes
None