### PR TITLE
Prevent Dependabot from offering major updates for React Router breadcrumbs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,5 @@ updates:
       update-types: ["version-update:semver-major"]
     - dependency-name: react-router-dom
       update-types: ["version-update:semver-major"]
+    - dependency-name: use-react-router-breadcrumbs
+      update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Prevents major updates to `use-react-router-breadcrumbs` from being offered since it is not compatible with the version of React Router we are using.