### PR TITLE
Change read-only default based on mapper type

### DIFF
--- a/src/user-federation/ldap/mappers/LdapMapperUserAttribute.tsx
+++ b/src/user-federation/ldap/mappers/LdapMapperUserAttribute.tsx
@@ -74,7 +74,9 @@ export const LdapMapperUserAttribute = ({
       >
         <Controller
           name="config.read-only"
-          defaultValue={["true"]}
+          defaultValue={
+            mapperType === "user-attribute-ldap-mapper" ? ["true"] : ["false"]
+          }
           control={form.control}
           render={({ onChange, value }) => (
             <Switch


### PR DESCRIPTION
## Motivation
Fixes https://github.com/keycloak/keycloak-admin-ui/issues/1484.

## Brief Description
The original issue above was fixed as part of https://github.com/keycloak/keycloak-admin-ui/issues/1480. However, during testing, `Read Only` was defaulting to `ON` for `user-attribute-ldap-mapper` and `certificate-ldap-mapper`, which is incorrect. `Read Only` should only default to `ON` for `user-attribute-ldap-mapper`, and for `certificate-ldap-mapper` it should default to `OFF`. 

## Verification Steps
1. Go to User Federation > LDAP > LDAP Mappers.
2. Create new mapper.
3. Choose `certificate-ldap-mapper` as mapper type.
4. Verify that the `Attribute default value` field exists and can be save/retrieved.
5. On the create new mapper screen, verify that `Read only` defaults to `ON` when you select the `user-attribute-ldap-mapper` mapper type and `OFF` when you select the `certificate-ldap-mapper` mapper type.

## Checklist:
- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [x] Help has been implemented
- [x] Unit tests have been created/updated

## Additional Notes
None