### PR TITLE
Fix defaults and help for full-name-ldap-mapper

### DIFF
--- a/src/user-federation/help.ts
+++ b/src/user-federation/help.ts
@@ -155,11 +155,11 @@ export default {
       "Activate this if the certificate is DER formatted in LDAP and not PEM formatted.",
 
     ldapFullNameAttributeHelp:
-      "Name of LDAP attribute, which contains fullName of user. Usually it will be 'cn',",
-    fullNameLdapMapperReadOnlyHelp:
-      "For Read-only, data is imported from LDAP to Keycloak DB, but it's not saved back to LDAP when user is updated in Keycloak.",
-    fullNameLdapMapperWriteOnlyHelp:
-      "For Write-only, is data propagated to LDAP when user is created or updated in Keycloak. But this mapper is not used to propagate data from LDAP back into Keycloak. This setting is useful if you configured separate firstName and lastName attribute mappers and you want to use those to read attribute from LDAP into Keycloak",
+      "Name of the LDAP attribute, which contains the fullName of the user. Usually it will be 'cn'.",
+    fullNameLdapReadOnlyHelp:
+      "For Read-only, data is imported from LDAP to Keycloak DB, but it's not saved back to LDAP when the user is updated in Keycloak.",
+    fullNameLdapWriteOnlyHelp:
+      "For Write-only, data is propagated to LDAP when a user is created or updated in Keycloak. But this mapper is not used to propagate data from LDAP back into Keycloak. This setting is useful if you configured separate firstName and lastName attribute mappers and you want to use those to read the attribute from LDAP into Keycloak.",
 
     ldapGroupsDnHelp:
       "LDAP DN where groups of this tree are saved. For example 'ou=groups,dc=example,dc=org'",

--- a/src/user-federation/ldap/mappers/LdapMapperFullNameAttribute.tsx
+++ b/src/user-federation/ldap/mappers/LdapMapperFullNameAttribute.tsx
@@ -31,6 +31,7 @@ export const LdapMapperFullNameAttribute = ({
         <TextInput
           isRequired
           type="text"
+          defaultValue="cn"
           id="kc-full-name-attribute"
           data-testid="mapper-fullNameAttribute-fld"
           name="config.ldap-full-name-attribute[0]"
@@ -41,7 +42,7 @@ export const LdapMapperFullNameAttribute = ({
         label={t("readOnly")}
         labelIcon={
           <HelpItem
-            helpText={helpText("readOnlyHelp")}
+            helpText={helpText("fullNameLdapReadOnlyHelp")}
             forLabel={t("readOnly")}
             forID="kc-read-only"
           />
@@ -51,7 +52,7 @@ export const LdapMapperFullNameAttribute = ({
       >
         <Controller
           name="config.read-only"
-          defaultValue={["false"]}
+          defaultValue={["true"]}
           control={form.control}
           render={({ onChange, value }) => (
             <Switch
@@ -69,7 +70,7 @@ export const LdapMapperFullNameAttribute = ({
         label={t("writeOnly")}
         labelIcon={
           <HelpItem
-            helpText={helpText("writeOnlyHelp")}
+            helpText={helpText("fullNameLdapWriteOnlyHelp")}
             forLabel={t("writeOnly")}
             forID="kc-write-only"
           />


### PR DESCRIPTION
## Motivation
Fixes https://github.com/keycloak/keycloak-admin-ui/issues/1485.

## Brief Description
Added default value of `cn` to `LDAP full name attribute`.
Changed `Read only` default to `ON`.
Fixed `Write only` help, also fixed `Read-only` help which was pointing to the wrong help string.

## Verification Steps
1. Go to `User Federation > LDAP > LDAP Mappers`.
2. Create a new mapper.
3. Choose `full-name-ldap-mapper` as mapper type.
4. Verify that the `LDAP full name attribute` and `Read only`fields have default values of `cn` and `ON`, respectively.
5. Verify that the `Write only` help now displays correctly.

## Checklist:
- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [x] Help has been implemented
- [x] Unit tests have been created/updated

## Additional Notes
None