### PR TITLE
Fix help string for hardcoded-ldap-group mapper Group field

### DIFF
--- a/src/user-federation/help.ts
+++ b/src/user-federation/help.ts
@@ -211,10 +211,10 @@ export default {
       "Value of the model attribute to be added when importing user from LDAP",
 
     roleHelp:
-      "Role to grant to user.  Click 'Select Role' button to browse roles, or just type it in the textbox.  To reference an application role the syntax is appname.approle, i.e. myapp.myrole.",
+      "Role to grant to user. Click 'Select Role' button to browse roles, or just type it in the textbox. To reference an application role the syntax is appname.approle, i.e. myapp.myrole.",
 
     groupHelp:
-      "Users imported from LDAP will be automatically added into this configured group.",
+      "Group to add the user in. Fill the full path of the group including path. For example: '/root-group/child-group'.",
 
     ldapAttributeNameHelp:
       "Name of the LDAP attribute, which will be added to the new user during registration",


### PR DESCRIPTION
## Motivation
Fixes https://github.com/keycloak/keycloak-admin-ui/issues/1486.

## Brief Description
Fixed incorrect help string for hardcoded-ldap-group-mapper's Group field.

## Verification Steps
1. Go to User Federation > LDAP > LDAP Mappers.
2. Create new mapper.
3. Choose `hardcoded-ldap-group-mapper` as mapper type.
4. Verify that the help text for `Group` matches the string from the old console.

## Checklist:
- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [x] Help has been implemented
- [x] Unit tests have been created/updated

## Additional Notes
None