### PR TITLE
Save Pass Subject correctly and add two missing fields to SAML IDP

### DIFF
--- a/src/identity-providers/add/DescriptorSettings.tsx
+++ b/src/identity-providers/add/DescriptorSettings.tsx
@@ -414,7 +414,7 @@ const Fields = ({ readOnly }: DescriptorSettingsProps) => {
         isReadOnly={readOnly}
       />
       <SwitchField
-        field="config.passSubject"
+        field="config.loginHint"
         label="passSubject"
         isReadOnly={readOnly}
       />
@@ -437,6 +437,50 @@ const Fields = ({ readOnly }: DescriptorSettingsProps) => {
           max="2147483"
           id="allowedClockSkew"
           name="config.allowedClockSkew"
+          ref={register}
+          isReadOnly={readOnly}
+        />
+      </FormGroup>
+
+      <FormGroup
+        label={t("attributeConsumingServiceIndex")}
+        labelIcon={
+          <HelpItem
+            helpText={th("attributeConsumingServiceIndex")}
+            forLabel={t("attributeConsumingServiceIndex")}
+            forID="attributeConsumingServiceIndex"
+          />
+        }
+        fieldId="attributeConsumingServiceIndex"
+        helperTextInvalid={t("common:required")}
+      >
+        <TextInput
+          type="number"
+          min="0"
+          max="65535"
+          id="attributeConsumingServiceIndex"
+          name="config.attributeConsumingServiceIndex"
+          ref={register}
+          isReadOnly={readOnly}
+        />
+      </FormGroup>
+
+      <FormGroup
+        label={t("attributeConsumingServiceName")}
+        labelIcon={
+          <HelpItem
+            helpText={th("attributeConsumingServiceName")}
+            forLabel={t("attributeConsumingServiceName")}
+            forID="attributeConsumingServiceName"
+          />
+        }
+        fieldId="attributeConsumingServiceName"
+        helperTextInvalid={t("common:required")}
+      >
+        <TextInput
+          type="text"
+          id="attributeConsumingServiceName"
+          name="config.attributeConsumingServiceName"
           ref={register}
           isReadOnly={readOnly}
         />

--- a/src/identity-providers/help.ts
+++ b/src/identity-providers/help.ts
@@ -28,7 +28,7 @@ export default {
     scopes:
       "The scopes to be sent when asking for authorization. It can be a space-separated list of scopes. Defaults to 'openid'.",
     prompt:
-      "Specifies whether the Authorization Server prompts the End-User for reauthentication and consent.",
+      "Specifies whether the Authorization Server prompts the End-User for re-authentication and consent.",
     acceptsPromptNone:
       "This is just used together with Identity Provider Authenticator or when kc_idp_hint points to this identity provider. In case that client sends a request with prompt=none and user is not yet authenticated, the error will not be directly returned to client, but the request with prompt=none will be forwarded to this identity provider.",
     validateSignature:
@@ -39,6 +39,10 @@ export default {
       "URL where identity provider keys in JWK format are stored. See JWK specification for more details. If you use external Keycloak identity provider, you can use URL like 'http://broker-keycloak:8180/auth/realms/test/protocol/openid-connect/certs' assuming your brokered Keycloak is running on 'http://broker-keycloak:8180' and its realm is 'test' .",
     allowedClockSkew:
       "Clock skew in seconds that is tolerated when validating identity provider tokens. Default value is zero.",
+    attributeConsumingServiceIndex:
+      "Index of the Attribute Consuming Service profile to request during authentication.",
+    attributeConsumingServiceName:
+      "Name of the Attribute Consuming Service profile to advertise in the SP metadata.",
     forwardParameters:
       "Non OpenID Connect/OAuth standard query parameters to be forwarded to external IDP from the initial application request to Authorization Endpoint. Multiple parameters can be entered, separated by comma (,).",
     clientAuthentication:
@@ -87,7 +91,7 @@ export default {
       "Indicates whether the identity provider expects a signed AuthnRequest.",
     signatureAlgorithm: "The signature algorithm to use to sign documents.",
     samlSignatureKeyName:
-      "Signed SAML documents contain identification of signing key in KeyName element. For Keycloak / RH-SSO counterparty, use KEY_ID, for MS AD FS use CERT_SUBJECT, for others check and use NONE if no other option works.",
+      "Signed SAML documents contain identification of signing key in KeyName element. For Keycloak / RH-SSO counter-party, use KEY_ID, for MS AD FS use CERT_SUBJECT, for others check and use NONE if no other option works.",
     wantAssertionsSigned:
       "Indicates whether this service provider expects a signed Assertion.",
     wantAssertionsEncrypted:

--- a/src/identity-providers/messages.ts
+++ b/src/identity-providers/messages.ts
@@ -129,6 +129,8 @@ export default {
     useJwksUrl: "Use JWKS URL",
     jwksUrl: "JWKS URL",
     allowedClockSkew: "Allowed clock skew",
+    attributeConsumingServiceIndex: "Attribute Consuming Service Index",
+    attributeConsumingServiceName: "Attribute Consuming Service Name",
     forwardParameters: "Forwarded query parameters",
     generalSettings: "General settings",
     oidcSettings: "OpenID Connect settings",


### PR DESCRIPTION
## Motivation
Fixes https://github.com/keycloak/keycloak-admin-ui/issues/1487.

## Brief Description
Change the `Pass subject` field so it correctly points to the correct API value: `loginHint`.
Added the two missing fields: `Attribute Consuming Service Index` and `Attribute Consuming Service Name`.

## Verification Steps
1. Go to Identity providers > some SAML provider > Provider details.
2. Change the `Pass subject` switch to `ON` (or if it is already `ON`, change it to `OFF`).
3. Add values to the `Attribute Consuming Service Index` and `Attribute Consuming Service Name` fields, and verify their help works as expected.
4. Click `Save`.
5. Verify that the values of the three fields you modified are persisted in both the new and old admin consoles.
6. Change the three values in the old admin console and verify that they are persisted in the new admin console.

## Checklist:
- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [x] Help has been implemented
- [x] Unit tests have been created/updated

## Additional Notes
None