### PR TITLE
Show/hide principal attribute field correctly

### DIFF
--- a/src/identity-providers/add/DescriptorSettings.tsx
+++ b/src/identity-providers/add/DescriptorSettings.tsx
@@ -247,7 +247,7 @@ const Fields = ({ readOnly }: DescriptorSettingsProps) => {
         ></Controller>
       </FormGroup>
 
-      {principalType!.includes("ATTRIBUTE") && (
+      {principalType?.includes("ATTRIBUTE") && (
         <FormGroup
           label={t("principalAttribute")}
           labelIcon={

--- a/src/identity-providers/add/DescriptorSettings.tsx
+++ b/src/identity-providers/add/DescriptorSettings.tsx
@@ -45,10 +45,9 @@ const Fields = ({ readOnly }: DescriptorSettingsProps) => {
     name: "config.validateSignature",
   });
 
-  const principalType = useWatch({
+  const principalType = useWatch<string>({
     control,
     name: "config.principalType",
-    defaultValue: "",
   });
 
   return (
@@ -248,7 +247,7 @@ const Fields = ({ readOnly }: DescriptorSettingsProps) => {
         ></Controller>
       </FormGroup>
 
-      {principalType.includes("ATTRIBUTE") && (
+      {principalType!.includes("ATTRIBUTE") && (
         <FormGroup
           label={t("principalAttribute")}
           labelIcon={


### PR DESCRIPTION
## Motivation
Fixes https://github.com/keycloak/keycloak-admin-ui/issues/1433.

## Brief Description
Changed watch behavior of the `Principal type` field so that it does not set `Principal attribute` incorrectly.

## Verification Steps
1. Create a new SAML ID provider.
2. Set Principal type to `Attribute [Name]` or `Attribute [Friendly Name]`, fill in a value for `Principal attribute`, and save.
3. Go back to the ID Provider list.
4. Return to the details screen of the SAML ID provider created in step 1.
5. Verify that the `Principal attribute` field is displayed with the value you added in step 2.

## Checklist:
- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [x] Help has been implemented
- [x] Unit tests have been created/updated

## Additional Notes
None