### PR TITLE
Alternative solution for test fix

### DIFF
--- a/src/context/auth/AdminClient.tsx
+++ b/src/context/auth/AdminClient.tsx
@@ -8,7 +8,11 @@ export const AdminClient = createContext<KeycloakAdminClient | undefined>(
   undefined
 );
 
-export const useAdminClient = () => useRequiredContext(AdminClient);
+export const useAdminClient = () => {
+  const adminClient = useRequiredContext(AdminClient);
+  adminClient.setConfig({ requestConfig: { cancelToken: undefined } });
+  return adminClient;
+};
 
 /**
  * Util function to only set the state when the component is still mounted.

--- a/src/identity-providers/IdentityProvidersSection.tsx
+++ b/src/identity-providers/IdentityProvidersSection.tsx
@@ -15,6 +15,7 @@ import {
   DropdownToggle,
   Gallery,
   PageSection,
+  Spinner,
   Split,
   SplitItem,
   Text,
@@ -50,9 +51,8 @@ export default function IdentityProvidersSection() {
 
   const [addProviderOpen, setAddProviderOpen] = useState(false);
   const [manageDisplayDialog, setManageDisplayDialog] = useState(false);
-  const [providers, setProviders] = useState<IdentityProviderRepresentation[]>(
-    []
-  );
+  const [providers, setProviders] =
+    useState<IdentityProviderRepresentation[]>();
   const [selectedProvider, setSelectedProvider] =
     useState<IdentityProviderRepresentation>();
 
@@ -142,7 +142,7 @@ export default function IdentityProvidersSection() {
           alias: selectedProvider!.alias!,
         });
         setProviders([
-          ...providers.filter((p) => p.alias !== selectedProvider?.alias),
+          ...providers!.filter((p) => p.alias !== selectedProvider?.alias),
         ]);
         refresh();
         addAlert(t("deletedSuccess"), AlertVariant.success);
@@ -151,6 +151,10 @@ export default function IdentityProvidersSection() {
       }
     },
   });
+
+  if (!providers) {
+    return <Spinner />;
+  }
 
   return (
     <>


### PR DESCRIPTION
This is an alternative solution to fix the IdP test (#1569), both commits fix this test.

The first commit fixes the test itself by waiting on the request so that the component doesn't get unmounted when it's still loading.
The second is resetting the cancalation token so that adminClient requests no longer use the same token.