### PR TITLE
Show exact commit hash of Admin UI in interface

### DIFF
--- a/keycloak-theme/pom.xml
+++ b/keycloak-theme/pom.xml
@@ -105,6 +105,19 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>io.github.git-commit-id</groupId>
+                <artifactId>git-commit-id-maven-plugin</artifactId>
+                <version>5.0.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                        <phase>initialize</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>com.google.code.maven-replacer-plugin</groupId>
                 <artifactId>maven-replacer-plugin</artifactId>
                 <version>1.4.1</version>
@@ -142,6 +155,7 @@
       "resourceUrl": "${resourceUrl}",
       "masterRealm": "${masterRealm}",
       "resourceVersion": "${resourceVersion}",
+      "commitHash": "${git.commit.id}",
       "isRunningAsTheme": true
     }
   </script>

--- a/src/dashboard/Dashboard.tsx
+++ b/src/dashboard/Dashboard.tsx
@@ -160,6 +160,9 @@ const Dashboard = () => {
             </Card>
           </GridItem>
         </Grid>
+        <Text className="pf-u-font-size-sm pf-u-color-200 pf-u-mt-sm">
+          {t("adminUiVersion", { version: environment.commitHash })}
+        </Text>
       </PageSection>
     </>
   );

--- a/src/dashboard/messages.ts
+++ b/src/dashboard/messages.ts
@@ -13,5 +13,6 @@ export default {
     infoEnabledFeatures: "Something about what enabled features are.",
     infoDisabledFeatures: "Something about what disabled features are.",
     disabledFeatures: "Disabled features",
+    adminUiVersion: "Admin UI version: {{version}}",
   },
 };

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -12,6 +12,8 @@ export type Environment = {
   masterRealm: string;
   /** The version hash of the auth sever. */
   resourceVersion: string;
+  /** The hash of the commit the Admin UI was built on, useful to determine the exact version the user is running. */
+  commitHash: string;
   /** Indicates if the application is running as a Keycloak theme. */
   isRunningAsTheme: boolean;
 };
@@ -29,6 +31,7 @@ const defaultEnvironment: Environment = {
   resourceUrl: ".",
   masterRealm: "master",
   resourceVersion: "unknown",
+  commitHash: "unknown",
   isRunningAsTheme: false,
 };
 


### PR DESCRIPTION
## Motivation
Shows the exact commit hash of the Admin UI in the user-interface when built with Maven. This allows us to find out the exact version the user is running so we can reliably reproduce bugs and other issues.

The commit hash is shown on the dashboard page below the server information.

![A screenshot showing the commit hash](https://user-images.githubusercontent.com/695720/142438743-573f49d7-567f-4551-be65-ee3cdb999e97.png)
