### PR TITLE
Downgrade to Node 16

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v2
         with:
-          node-version: 17
+          node-version: 16
           check-latest: true
           cache: npm
           cache-dependency-path: ${{ env.ADMIN_UI_PATH }}/package-lock.json

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+env:
+  NODE_VERSION: 16
 jobs:
   setup:
     runs-on: ubuntu-latest
@@ -14,7 +16,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v2
         with:
-          node-version: 17
+          node-version: ${{ env.NODE_VERSION }}
           check-latest: true
           cache: npm
 
@@ -51,7 +53,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v2
         with:
-          node-version: 17
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Run ${{ matrix.command }} task
         run: npm run ${{ matrix.command }}

--- a/keycloak-theme/pom.xml
+++ b/keycloak-theme/pom.xml
@@ -79,7 +79,7 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <nodeVersion>v17.0.1</nodeVersion>
+                    <nodeVersion>v16.13.0</nodeVersion>
                     <workingDirectory>../</workingDirectory>
                     <installDirectory>.</installDirectory>
                 </configuration>

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,7 @@
         "typescript": "^4.4.4"
       },
       "engines": {
-        "node": "17"
+        "node": "16"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "license": "Apache",
   "engines": {
-    "node": "17"
+    "node": "16"
   },
   "scripts": {
     "build": "snowpack build",


### PR DESCRIPTION
## Motivation
Node 17 causes issues like failing to run the tests in Cypress 9 and breaks `import.mjs`. To mitigate this we can downgrade to version 16 which is an LTS version and will be supported for a while.