### PR TITLE
Realm settings(Client policies): Update client-scopes condition to match new design

### DIFF
--- a/cypress/integration/realm_settings_test.spec.ts
+++ b/cypress/integration/realm_settings_test.spec.ts
@@ -118,7 +118,7 @@ describe("Realm settings tests", () => {
       masthead.checkNotificationMessage("Realm successfully updated");
     });
 
-    it.skip("Go to login tab", () => {
+    it("Go to login tab", () => {
       sidebarPage.goToRealmSettings();
       cy.findByTestId("rs-login-tab").click();
       realmSettingsPage.toggleSwitch(realmSettingsPage.userRegSwitch);
@@ -126,7 +126,7 @@ describe("Realm settings tests", () => {
       realmSettingsPage.toggleSwitch(realmSettingsPage.rememberMeSwitch);
     });
 
-    it.skip("Check login tab values", () => {
+    it("Check login tab values", () => {
       sidebarPage.goToRealmSettings();
       cy.findByTestId("rs-login-tab").click();
 
@@ -605,20 +605,32 @@ describe("Realm settings tests", () => {
       realmSettingsPage.shouldCancelAddingCondition();
     });
 
-    it("Should add a new condition to a client profile", () => {
-      realmSettingsPage.shouldAddCondition();
+    it("Should add a new client-roles condition to a client profile", () => {
+      realmSettingsPage.shouldAddClientRolesCondition();
     });
 
-    it("Should edit the condition of a client profile", () => {
-      realmSettingsPage.shouldEditCondition();
+    it("Should add a new client-scopes condition to a client profile", () => {
+      realmSettingsPage.shouldAddClientScopesCondition();
+    });
+
+    it("Should edit the client-roles condition of a client profile", () => {
+      realmSettingsPage.shouldEditClientRolesCondition();
+    });
+
+    it("Should edit the client-scopes condition of a client profile", () => {
+      realmSettingsPage.shouldEditClientScopesCondition();
     });
 
     it("Should cancel deleting condition from a client profile", () => {
       realmSettingsPage.shouldCancelDeletingCondition();
     });
 
-    it("Should delete condition from a client profile", () => {
-      realmSettingsPage.shouldDeleteCondition();
+    it("Should delete client-roles condition from a client profile", () => {
+      realmSettingsPage.shouldDeleteClientRolesCondition();
+    });
+
+    it("Should delete client-scopes condition from a client profile", () => {
+      realmSettingsPage.shouldDeleteClientScopesCondition();
     });
 
     it("Check cancelling the client policy deletion", () => {

--- a/cypress/support/pages/admin_console/manage/realm_settings/RealmSettingsPage.ts
+++ b/cypress/support/pages/admin_console/manage/realm_settings/RealmSettingsPage.ts
@@ -197,6 +197,8 @@ export default class RealmSettingsPage {
   private addConditionCancelBtn = "addCondition-cancelBtn";
   private addConditionSaveBtn = "addCondition-saveBtn";
   private conditionTypeLink = "condition-type-link";
+  private clientRolesConditionLink = "client-roles-condition-link";
+  private clientScopesConditionLink = "client-scopes-condition-link";
   private eventListenersFormLabel = ".pf-c-form__label-text";
   private eventListenersDrpDwn = ".pf-c-select.kc_eventListeners_select";
   private eventListenersSaveBtn = "saveEventListenerBtn";
@@ -208,6 +210,9 @@ export default class RealmSettingsPage {
     ".pf-c-button.pf-c-select__toggle-button.pf-m-plain";
   private eventListenerRemove = '[data-ouia-component-id="Remove"]';
   private roleSelect = ".pf-c-select.kc-role-select";
+  private selectScopeButton = "select-scope-button";
+  private deleteClientRolesCondition = "delete-client-roles-condition";
+  private deleteClientScopesCondition = "delete-client-scopes-condition";
 
   selectLoginThemeType(themeType: string) {
     cy.get(this.selectLoginTheme).click();
@@ -966,7 +971,7 @@ export default class RealmSettingsPage {
     );
   }
 
-  shouldAddCondition() {
+  shouldAddClientRolesCondition() {
     cy.get(this.clientPolicy).click();
     cy.findByTestId(this.addCondition).click();
     cy.get(this.addConditionDrpDwn).click();
@@ -989,10 +994,43 @@ export default class RealmSettingsPage {
     cy.get('ul[class*="pf-c-data-list"]').should("have.text", "client-roles");
   }
 
-  shouldEditCondition() {
+  addClientScopes() {
+    cy.findByTestId(this.selectScopeButton).click();
+    cy.get(".pf-c-table__check > input[name=checkrow0]").click();
+    cy.get(".pf-c-table__check > input[name=checkrow1]").click();
+    cy.get(".pf-c-table__check > input[name=checkrow2]").click();
+
+    cy.findByTestId("modalConfirm").contains("Add").click();
+  }
+
+  shouldAddClientScopesCondition() {
+    cy.get(this.clientPolicy).click();
+    cy.findByTestId(this.addCondition).click();
+    cy.get(this.addConditionDrpDwn).click();
+    cy.findByTestId(this.addConditionDrpDwnOption)
+      .contains("client-scopes")
+      .click();
+
+    this.addClientScopes();
+
+<<<<<<< HEAD
+    cy.get(this.roleSelect).click();
+    cy.get(this.roleSelect).contains("create-client").click();
+
+    cy.get(this.roleSelect).click();
+=======
+    cy.findByTestId(this.addConditionSaveBtn).click();
+    cy.get(this.alertMessage).should(
+      "be.visible",
+      "Success! Condition created successfully"
+    );
+    cy.get('ul[class*="pf-c-data-list"]').contains("client-scopes");
+  }
+
+  shouldEditClientRolesCondition() {
     cy.get(this.clientPolicy).click();
 
-    cy.findByTestId(this.conditionTypeLink).contains("client-roles").click();
+    cy.findByTestId(this.clientRolesConditionLink).click();
 
     cy.get(this.roleSelect).click();
     cy.get(this.roleSelect).contains("create-client").click();
@@ -1006,24 +1044,52 @@ export default class RealmSettingsPage {
     );
   }
 
+  shouldEditClientScopesCondition() {
+    cy.get(this.clientPolicy).click();
+
+    cy.findByTestId(this.clientScopesConditionLink).click();
+
+    cy.wait(200);
+
+    this.addClientScopes();
+>>>>>>> wip client roles select field
+
+    cy.findByTestId(this.addConditionSaveBtn).click();
+    cy.get(this.alertMessage).should(
+      "be.visible",
+      "Success! Condition updated successfully"
+    );
+  }
+
   shouldCancelDeletingCondition() {
     cy.get(this.clientPolicy).click();
-    cy.get('svg[class*="kc-conditionType-trash-icon"]').click();
+    cy.findByTestId(this.deleteClientRolesCondition).click();
     cy.get(this.deleteDialogTitle).contains("Delete condition?");
     cy.get(this.deleteDialogBodyText).contains(
       "This action will permanently delete client-roles. This cannot be undone."
     );
     cy.findByTestId("modalConfirm").contains("Delete");
     cy.get(this.deleteDialogCancelBtn).contains("Cancel").click();
-    cy.get('ul[class*="pf-c-data-list"]').should("have.text", "client-roles");
+    cy.get('ul[class*="pf-c-data-list"]').contains("client-roles");
   }
 
-  shouldDeleteCondition() {
+  shouldDeleteClientRolesCondition() {
     cy.get(this.clientPolicy).click();
-    cy.get('svg[class*="kc-conditionType-trash-icon"]').click();
+    cy.findByTestId(this.deleteClientRolesCondition).click();
     cy.get(this.deleteDialogTitle).contains("Delete condition?");
     cy.get(this.deleteDialogBodyText).contains(
       "This action will permanently delete client-roles. This cannot be undone."
+    );
+    cy.findByTestId("modalConfirm").contains("Delete").click();
+    cy.get('ul[class*="pf-c-data-list"]').contains("client-scopes");
+  }
+
+  shouldDeleteClientScopesCondition() {
+    cy.get(this.clientPolicy).click();
+    cy.findByTestId(this.deleteClientScopesCondition).click();
+    cy.get(this.deleteDialogTitle).contains("Delete condition?");
+    cy.get(this.deleteDialogBodyText).contains(
+      "This action will permanently delete client-scopes. This cannot be undone."
     );
     cy.findByTestId("modalConfirm").contains("Delete").click();
     cy.get('h6[class*="kc-emptyConditions"]').should(

--- a/cypress/support/pages/admin_console/manage/realm_settings/RealmSettingsPage.ts
+++ b/cypress/support/pages/admin_console/manage/realm_settings/RealmSettingsPage.ts
@@ -1013,12 +1013,6 @@ export default class RealmSettingsPage {
 
     this.addClientScopes();
 
-<<<<<<< HEAD
-    cy.get(this.roleSelect).click();
-    cy.get(this.roleSelect).contains("create-client").click();
-
-    cy.get(this.roleSelect).click();
-=======
     cy.findByTestId(this.addConditionSaveBtn).click();
     cy.get(this.alertMessage).should(
       "be.visible",
@@ -1052,7 +1046,6 @@ export default class RealmSettingsPage {
     cy.wait(200);
 
     this.addClientScopes();
->>>>>>> wip client roles select field
 
     cy.findByTestId(this.addConditionSaveBtn).click();
     cy.get(this.alertMessage).should(

--- a/src/client-scopes/ClientScopesSection.tsx
+++ b/src/client-scopes/ClientScopesSection.tsx
@@ -19,7 +19,7 @@ import { useAlerts } from "../components/alert/Alerts";
 import { KeycloakDataTable } from "../components/table-toolbar/KeycloakDataTable";
 import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
 import { useRealm } from "../context/realm-context/RealmContext";
-import { upperCaseFormatter, emptyFormatter } from "../util";
+import { emptyFormatter } from "../util";
 import {
   CellDropdown,
   ClientScope,
@@ -44,6 +44,7 @@ import {
   typeFilter,
 } from "./details/SearchFilter";
 import type { Row } from "../clients/scopes/ClientScopes";
+import { getProtocolName } from "../clients/utils";
 
 export default function ClientScopesSection() {
   const { realm } = useRealm();
@@ -267,7 +268,8 @@ export default function ClientScopesSection() {
             {
               name: "protocol",
               displayKey: "client-scopes:protocol",
-              cellFormatters: [upperCaseFormatter()],
+              cellRenderer: (client) =>
+                getProtocolName(t, client.protocol ?? "openid-connect"),
               transforms: [cellWidth(15)],
             },
             {

--- a/src/clients/ClientDetails.tsx
+++ b/src/clients/ClientDetails.tsx
@@ -458,6 +458,7 @@ export default function ClientDetails() {
                     title={<TabTitleText>{t("setup")}</TabTitleText>}
                   >
                     <ClientScopes
+                      clientName={client.clientId!}
                       clientId={clientId}
                       protocol={client!.protocol!}
                     />

--- a/src/clients/messages.ts
+++ b/src/clients/messages.ts
@@ -29,7 +29,7 @@ export default {
       "You haven't created any roles for this client. Create a role to get started.",
     clientScopes: "Client scopes",
     addClientScope: "Add client scope",
-    addClientScopesTo: "Add client scopes to {{clientId}}",
+    addClientScopesTo: "Add client scopes to {{clientName}}",
     clientScopeRemoveSuccess: "Scope mapping successfully removed",
     clientScopeRemoveError: "Could not remove the scope mapping {{error}}",
     clientScopeSuccess: "Scope mapping successfully updated",

--- a/src/clients/messages.ts
+++ b/src/clients/messages.ts
@@ -1,9 +1,11 @@
 export default {
   clients: {
-    protocol: {
+    protocolTypes: {
       openIdConnect: "OpenID Connect",
       saml: "SAML",
+      all: "All",
     },
+    protocol: "Protocol",
     clientType: "Client type",
     clientAuthorization: "Authorization",
     implicitFlow: "Implicit flow",

--- a/src/clients/scopes/AddScopeDialog.tsx
+++ b/src/clients/scopes/AddScopeDialog.tsx
@@ -40,14 +40,14 @@ export type AddScopeDialogProps = {
 };
 
 enum FilterType {
-  Name = "name",
-  Protocol = "protocol",
+  Name = "Name",
+  Protocol = "Protocol",
 }
 
 enum ProtocolType {
-  All = "all",
-  SAML = "saml",
-  OpenIDConnect = "openid-connect",
+  All = "All",
+  SAML = "SAML",
+  OpenIDConnect = "OpenID Connect",
 }
 
 export const AddScopeDialog = ({
@@ -60,8 +60,10 @@ export const AddScopeDialog = ({
   const { t } = useTranslation("clients");
   const [addToggle, setAddToggle] = useState(false);
   const [rows, setRows] = useState<ClientScopeRepresentation[]>([]);
-  const [filterType, setFilterType] = useState<FilterType>("Name");
-  const [protocolType, setProtocolType] = useState<ProtocolType>("All");
+  const [filterType, setFilterType] = useState<FilterType>(FilterType.Name);
+  const [protocolType, setProtocolType] = useState<ProtocolType>(
+    ProtocolType.All
+  );
   const [key, setKey] = useState(0);
   const refresh = () => setKey(key + 1);
 
@@ -106,23 +108,23 @@ export const AddScopeDialog = ({
 
   const onFilterTypeDropdownSelect = (filterType: string) => {
     if (filterType === "Name") {
-      setFilterType("Protocol");
+      setFilterType(FilterType.Protocol);
     }
     if (filterType === "Protocol") {
-      setFilterType("Name");
+      setFilterType(FilterType.Name);
     }
     setIsFilterTypeDropdownOpen(!isFilterTypeDropdownOpen);
   };
 
   const onProtocolTypeDropdownSelect = (protocolType: string) => {
     if (protocolType === "SAML") {
-      setProtocolType("SAML");
+      setProtocolType(ProtocolType.SAML);
     }
     if (protocolType === "OpenID Connect") {
-      setProtocolType("OpenID Connect");
+      setProtocolType(ProtocolType.OpenIDConnect);
     }
     if (protocolType === "All") {
-      setProtocolType("All");
+      setProtocolType(ProtocolType.All);
     }
     setIsProtocolTypeDropdownOpen(!isProtocolTypeDropdownOpen);
   };

--- a/src/clients/scopes/AddScopeDialog.tsx
+++ b/src/clients/scopes/AddScopeDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Button,
@@ -8,8 +8,17 @@ import {
   Modal,
   ModalVariant,
   DropdownDirection,
+  DropdownItem,
+  Select,
+  SelectOption,
+  SelectVariant,
+  SelectDirection,
 } from "@patternfly/react-core";
-import { CaretUpIcon } from "@patternfly/react-icons";
+import {
+  CaretDownIcon,
+  CaretUpIcon,
+  FilterIcon,
+} from "@patternfly/react-icons";
 import type ClientScopeRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientScopeRepresentation";
 
 import {
@@ -25,21 +34,50 @@ export type AddScopeDialogProps = {
   open: boolean;
   toggleDialog: () => void;
   onAdd: (
-    scopes: { scope: ClientScopeRepresentation; type: ClientScopeType }[]
+    scopes: { scope: ClientScopeRepresentation; type?: ClientScopeType }[]
   ) => void;
+  isClientScopesConditionType?: boolean;
 };
+
+type FilterType = "Name" | "Protocol";
+type ProtocolType = "All" | "SAML" | "OpenID Connect";
 
 export const AddScopeDialog = ({
   clientScopes,
   open,
   toggleDialog,
   onAdd,
+  isClientScopesConditionType,
 }: AddScopeDialogProps) => {
   const { t } = useTranslation("clients");
   const [addToggle, setAddToggle] = useState(false);
   const [rows, setRows] = useState<ClientScopeRepresentation[]>([]);
+  const [filterType, setFilterType] = useState<FilterType>("Name");
+  const [protocolType, setProtocolType] = useState<ProtocolType>("All");
+  const [key, setKey] = useState(0);
+  const refresh = () => setKey(new Date().getTime());
 
-  const loader = () => Promise.resolve(clientScopes);
+  const [isFilterTypeDropdownOpen, setIsFilterTypeDropdownOpen] =
+    useState(false);
+
+  const [isProtocolTypeDropdownOpen, setIsProtocolTypeDropdownOpen] =
+    useState(false);
+
+  useEffect(() => {
+    refresh();
+  }, [filterType, protocolType]);
+
+  const loader = () => {
+    if (protocolType === "OpenID Connect") {
+      return Promise.resolve(
+        clientScopes.filter((item) => item.protocol === "openid-connect")
+      );
+    } else if (protocolType === "SAML") {
+      return Promise.resolve(
+        clientScopes.filter((item) => item.protocol === "saml")
+      );
+    } else return Promise.resolve(clientScopes);
+  };
 
   const action = (scope: ClientScopeType) => {
     const scopes = rows.map((row) => {
@@ -50,55 +88,203 @@ export const AddScopeDialog = ({
     toggleDialog();
   };
 
+  const onFilterTypeDropdownToggle = () => {
+    setIsFilterTypeDropdownOpen(!isFilterTypeDropdownOpen);
+  };
+
+  const onProtocolTypeDropdownToggle = () => {
+    setIsProtocolTypeDropdownOpen(!isProtocolTypeDropdownOpen);
+  };
+
+  const onFilterTypeDropdownSelect = (filterType: string) => {
+    if (filterType === "Name") {
+      setFilterType("Protocol");
+    }
+    if (filterType === "Protocol") {
+      setFilterType("Name");
+    }
+    setIsFilterTypeDropdownOpen(!isFilterTypeDropdownOpen);
+  };
+
+  const onProtocolTypeDropdownSelect = (protocolType: string) => {
+    if (protocolType === "SAML") {
+      setProtocolType("SAML");
+    }
+    if (protocolType === "OpenID Connect") {
+      setProtocolType("OpenID Connect");
+    }
+    if (protocolType === "All") {
+      setProtocolType("All");
+    }
+    setIsProtocolTypeDropdownOpen(!isProtocolTypeDropdownOpen);
+  };
+
+  const protocolTypeOptions = [
+    <SelectOption key={1} value={t("protocolTypes.saml")} />,
+    <SelectOption key={2} value={t("protocolTypes.openIdConnect")} />,
+    <SelectOption key={3} value={t("protocolTypes.all")} isPlaceholder />,
+  ];
+
   return (
     <Modal
       variant={ModalVariant.medium}
-      title={t("addClientScopesTo", { clientId: "test" })}
+      title={
+        isClientScopesConditionType
+          ? t("addClientScope")
+          : t("addClientScopesTo", { clientId: "test" })
+      }
       isOpen={open}
       onClose={toggleDialog}
-      actions={[
-        <Dropdown
-          className="keycloak__client-scopes-add__add-dropdown"
-          id="add-dropdown"
-          key="add-dropdown"
-          direction={DropdownDirection.up}
-          isOpen={addToggle}
-          toggle={
-            <DropdownToggle
-              isDisabled={rows.length === 0}
-              onToggle={() => setAddToggle(!addToggle)}
-              isPrimary
-              toggleIndicator={CaretUpIcon}
-              id="add-scope-toggle"
-            >
-              {t("common:add")}
-            </DropdownToggle>
-          }
-          dropdownItems={clientScopeTypesDropdown(t, action)}
-        />,
-        <Button
-          id="modal-cancel"
-          key="cancel"
-          variant={ButtonVariant.link}
-          onClick={() => {
-            setRows([]);
-            toggleDialog();
-          }}
-        >
-          {t("common:cancel")}
-        </Button>,
-      ]}
+      actions={
+        isClientScopesConditionType
+          ? [
+              <Button
+                id="modal-add"
+                data-testid="modalConfirm"
+                key="add"
+                variant={ButtonVariant.primary}
+                onClick={() => {
+                  const scopes = rows.map((row) => {
+                    return { scope: row };
+                  });
+                  onAdd(scopes);
+                  toggleDialog();
+                }}
+              >
+                {t("common:add")}
+              </Button>,
+              <Button
+                id="modal-cancel"
+                key="cancel"
+                variant={ButtonVariant.link}
+                onClick={() => {
+                  setRows([]);
+                  toggleDialog();
+                }}
+              >
+                {t("common:cancel")}
+              </Button>,
+            ]
+          : [
+              <Dropdown
+                className="keycloak__client-scopes-add__add-dropdown"
+                id="add-dropdown"
+                key="add-dropdown"
+                direction={DropdownDirection.up}
+                isOpen={addToggle}
+                toggle={
+                  <DropdownToggle
+                    isDisabled={rows.length === 0}
+                    onToggle={() => setAddToggle(!addToggle)}
+                    isPrimary
+                    toggleIndicator={CaretUpIcon}
+                    id="add-scope-toggle"
+                  >
+                    {t("common:add")}
+                  </DropdownToggle>
+                }
+                dropdownItems={clientScopeTypesDropdown(t, action)}
+              />,
+              <Button
+                id="modal-cancel"
+                key="cancel"
+                variant={ButtonVariant.link}
+                onClick={() => {
+                  setRows([]);
+                  toggleDialog();
+                }}
+              >
+                {t("common:cancel")}
+              </Button>,
+            ]
+      }
     >
       <KeycloakDataTable
         loader={loader}
         ariaLabelKey="client-scopes:chooseAMapperType"
-        searchPlaceholderKey="client-scopes:searchFor"
+        searchPlaceholderKey={
+          filterType === "Name" ? "client-scopes:searchFor" : undefined
+        }
+        searchTypeComponent={
+          <Dropdown
+            onSelect={() => {
+              onFilterTypeDropdownSelect(filterType);
+            }}
+            data-testid="filter-type-dropdown"
+            toggle={
+              <DropdownToggle
+                id="toggle-id-9"
+                onToggle={onFilterTypeDropdownToggle}
+                toggleIndicator={CaretDownIcon}
+                icon={<FilterIcon />}
+              >
+                {filterType}
+              </DropdownToggle>
+            }
+            isOpen={isFilterTypeDropdownOpen}
+            dropdownItems={[
+              <DropdownItem
+                data-testid="filter-type-dropdown-item"
+                key="filter-type"
+              >
+                {filterType === "Name" ? t("protocol") : t("common:name")}
+              </DropdownItem>,
+            ]}
+          />
+        }
+        key={key}
+        toolbarItem={
+          filterType === "Protocol" && (
+            <>
+              <Dropdown
+                onSelect={() => {
+                  onFilterTypeDropdownSelect(filterType);
+                }}
+                data-testid="filter-type-dropdown"
+                toggle={
+                  <DropdownToggle
+                    id="toggle-id-9"
+                    onToggle={onFilterTypeDropdownToggle}
+                    toggleIndicator={CaretDownIcon}
+                    icon={<FilterIcon />}
+                  >
+                    {filterType}
+                  </DropdownToggle>
+                }
+                isOpen={isFilterTypeDropdownOpen}
+                dropdownItems={[
+                  <DropdownItem
+                    data-testid="filter-type-dropdown-item"
+                    key="filter-type"
+                  >
+                    {t("common:name")}
+                  </DropdownItem>,
+                ]}
+              />
+              <Select
+                variant={SelectVariant.single}
+                className="kc-protocolType-select"
+                aria-label="Select Input"
+                onToggle={onProtocolTypeDropdownToggle}
+                onSelect={(_, value) =>
+                  onProtocolTypeDropdownSelect(value.toString())
+                }
+                selections={protocolType}
+                isOpen={isProtocolTypeDropdownOpen}
+                direction={SelectDirection.down}
+              >
+                {protocolTypeOptions}
+              </Select>
+            </>
+          )
+        }
         canSelectAll
         onSelect={(rows) => setRows(rows)}
         columns={[
           {
             name: "name",
           },
+          { name: "protocol", displayKey: "Protocol" },
           {
             name: "description",
           },

--- a/src/clients/scopes/AddScopeDialog.tsx
+++ b/src/clients/scopes/AddScopeDialog.tsx
@@ -28,6 +28,7 @@ import {
 import { KeycloakDataTable } from "../../components/table-toolbar/KeycloakDataTable";
 
 import "./client-scopes.css";
+import { getProtocolName } from "../utils";
 
 export type AddScopeDialogProps = {
   clientScopes: ClientScopeRepresentation[];
@@ -247,7 +248,7 @@ export const AddScopeDialog = ({
         }
         key={key}
         toolbarItem={
-          filterType === "Protocol" && (
+          filterType === FilterType.Protocol && (
             <>
               <Dropdown
                 onSelect={() => {
@@ -297,7 +298,12 @@ export const AddScopeDialog = ({
           {
             name: "name",
           },
-          { name: "protocol", displayKey: "clients:protocol" },
+          {
+            name: "protocol",
+            displayKey: "clients:protocol",
+            cellRenderer: (client) =>
+              getProtocolName(t, client.protocol ?? "openid-connect"),
+          },
           {
             name: "description",
           },

--- a/src/clients/scopes/AddScopeDialog.tsx
+++ b/src/clients/scopes/AddScopeDialog.tsx
@@ -39,8 +39,16 @@ export type AddScopeDialogProps = {
   isClientScopesConditionType?: boolean;
 };
 
-type FilterType = "Name" | "Protocol";
-type ProtocolType = "All" | "SAML" | "OpenID Connect";
+enum FilterType {
+  Name = "name",
+  Protocol = "protocol",
+}
+
+enum ProtocolType {
+  All = "all",
+  SAML = "saml",
+  OpenIDConnect = "openid-connect",
+}
 
 export const AddScopeDialog = ({
   clientScopes,
@@ -55,7 +63,7 @@ export const AddScopeDialog = ({
   const [filterType, setFilterType] = useState<FilterType>("Name");
   const [protocolType, setProtocolType] = useState<ProtocolType>("All");
   const [key, setKey] = useState(0);
-  const refresh = () => setKey(new Date().getTime());
+  const refresh = () => setKey(key + 1);
 
   const [isFilterTypeDropdownOpen, setIsFilterTypeDropdownOpen] =
     useState(false);
@@ -120,9 +128,15 @@ export const AddScopeDialog = ({
   };
 
   const protocolTypeOptions = [
-    <SelectOption key={1} value={t("protocolTypes.saml")} />,
-    <SelectOption key={2} value={t("protocolTypes.openIdConnect")} />,
-    <SelectOption key={3} value={t("protocolTypes.all")} isPlaceholder />,
+    <SelectOption key={1} value={ProtocolType.SAML}>
+      {t("protocolTypes.saml")}
+    </SelectOption>,
+    <SelectOption key={2} value={ProtocolType.OpenIDConnect}>
+      {t("protocolTypes.openIdConnect")}
+    </SelectOption>,
+    <SelectOption key={3} value={ProtocolType.All} isPlaceholder>
+      {t("protocolTypes.all")}
+    </SelectOption>,
   ];
 
   return (
@@ -144,9 +158,7 @@ export const AddScopeDialog = ({
                 key="add"
                 variant={ButtonVariant.primary}
                 onClick={() => {
-                  const scopes = rows.map((row) => {
-                    return { scope: row };
-                  });
+                  const scopes = rows.map((scope) => ({ scope }));
                   onAdd(scopes);
                   toggleDialog();
                 }}

--- a/src/clients/scopes/AddScopeDialog.tsx
+++ b/src/clients/scopes/AddScopeDialog.tsx
@@ -31,6 +31,7 @@ import "./client-scopes.css";
 
 export type AddScopeDialogProps = {
   clientScopes: ClientScopeRepresentation[];
+  clientName?: string;
   open: boolean;
   toggleDialog: () => void;
   onAdd: (
@@ -52,6 +53,7 @@ enum ProtocolType {
 
 export const AddScopeDialog = ({
   clientScopes,
+  clientName,
   open,
   toggleDialog,
   onAdd,
@@ -147,7 +149,7 @@ export const AddScopeDialog = ({
       title={
         isClientScopesConditionType
           ? t("addClientScope")
-          : t("addClientScopesTo", { clientId: "test" })
+          : t("addClientScopesTo", { clientName: clientName })
       }
       isOpen={open}
       onClose={toggleDialog}
@@ -298,7 +300,7 @@ export const AddScopeDialog = ({
           {
             name: "name",
           },
-          { name: "protocol", displayKey: "Protocol" },
+          { name: "protocol", displayKey: "clients:protocol" },
           {
             name: "description",
           },

--- a/src/clients/scopes/AddScopeDialog.tsx
+++ b/src/clients/scopes/AddScopeDialog.tsx
@@ -62,10 +62,8 @@ export const AddScopeDialog = ({
   const { t } = useTranslation("clients");
   const [addToggle, setAddToggle] = useState(false);
   const [rows, setRows] = useState<ClientScopeRepresentation[]>([]);
-  const [filterType, setFilterType] = useState<FilterType>(FilterType.Name);
-  const [protocolType, setProtocolType] = useState<ProtocolType>(
-    ProtocolType.All
-  );
+  const [filterType, setFilterType] = useState(FilterType.Name);
+  const [protocolType, setProtocolType] = useState(ProtocolType.All);
   const [key, setKey] = useState(0);
   const refresh = () => setKey(key + 1);
 
@@ -79,16 +77,14 @@ export const AddScopeDialog = ({
     refresh();
   }, [filterType, protocolType]);
 
-  const loader = () => {
-    if (protocolType === "OpenID Connect") {
-      return Promise.resolve(
-        clientScopes.filter((item) => item.protocol === "openid-connect")
-      );
-    } else if (protocolType === "SAML") {
-      return Promise.resolve(
-        clientScopes.filter((item) => item.protocol === "saml")
-      );
-    } else return Promise.resolve(clientScopes);
+  const loader = async () => {
+    if (protocolType === ProtocolType.OpenIDConnect) {
+      return clientScopes.filter((item) => item.protocol === "openid-connect");
+    } else if (protocolType === ProtocolType.SAML) {
+      return clientScopes.filter((item) => item.protocol === "saml");
+    }
+
+    return clientScopes;
   };
 
   const action = (scope: ClientScopeType) => {
@@ -109,25 +105,24 @@ export const AddScopeDialog = ({
   };
 
   const onFilterTypeDropdownSelect = (filterType: string) => {
-    if (filterType === "Name") {
+    if (filterType === FilterType.Name) {
       setFilterType(FilterType.Protocol);
-    }
-    if (filterType === "Protocol") {
+    } else if (filterType === FilterType.Protocol) {
       setFilterType(FilterType.Name);
     }
+
     setIsFilterTypeDropdownOpen(!isFilterTypeDropdownOpen);
   };
 
   const onProtocolTypeDropdownSelect = (protocolType: string) => {
-    if (protocolType === "SAML") {
+    if (protocolType === ProtocolType.SAML) {
       setProtocolType(ProtocolType.SAML);
-    }
-    if (protocolType === "OpenID Connect") {
+    } else if (protocolType === ProtocolType.OpenIDConnect) {
       setProtocolType(ProtocolType.OpenIDConnect);
-    }
-    if (protocolType === "All") {
+    } else if (protocolType === ProtocolType.All) {
       setProtocolType(ProtocolType.All);
     }
+
     setIsProtocolTypeDropdownOpen(!isProtocolTypeDropdownOpen);
   };
 
@@ -149,7 +144,7 @@ export const AddScopeDialog = ({
       title={
         isClientScopesConditionType
           ? t("addClientScope")
-          : t("addClientScopesTo", { clientName: clientName })
+          : t("addClientScopesTo", { clientName })
       }
       isOpen={open}
       onClose={toggleDialog}
@@ -219,7 +214,7 @@ export const AddScopeDialog = ({
         loader={loader}
         ariaLabelKey="client-scopes:chooseAMapperType"
         searchPlaceholderKey={
-          filterType === "Name" ? "client-scopes:searchFor" : undefined
+          filterType === FilterType.Name ? "client-scopes:searchFor" : undefined
         }
         searchTypeComponent={
           <Dropdown
@@ -243,7 +238,9 @@ export const AddScopeDialog = ({
                 data-testid="filter-type-dropdown-item"
                 key="filter-type"
               >
-                {filterType === "Name" ? t("protocol") : t("common:name")}
+                {filterType === FilterType.Name
+                  ? t("protocol")
+                  : t("common:name")}
               </DropdownItem>,
             ]}
           />

--- a/src/clients/scopes/ClientScopes.tsx
+++ b/src/clients/scopes/ClientScopes.tsx
@@ -146,7 +146,7 @@ export const ClientScopes = ({ clientId, protocol }: ClientScopesProps) => {
                       adminClient,
                       clientId,
                       scope.scope,
-                      scope.type
+                      scope.type!
                     )
                 )
               );

--- a/src/clients/scopes/ClientScopes.tsx
+++ b/src/clients/scopes/ClientScopes.tsx
@@ -38,6 +38,7 @@ import { ChangeTypeDropdown } from "../../client-scopes/ChangeTypeDropdown";
 export type ClientScopesProps = {
   clientId: string;
   protocol: string;
+  clientName: string;
 };
 
 export type Row = ClientScopeRepresentation & {
@@ -45,7 +46,11 @@ export type Row = ClientScopeRepresentation & {
   description?: string;
 };
 
-export const ClientScopes = ({ clientId, protocol }: ClientScopesProps) => {
+export const ClientScopes = ({
+  clientId,
+  protocol,
+  clientName,
+}: ClientScopesProps) => {
   const { t } = useTranslation("clients");
   const adminClient = useAdminClient();
   const { addAlert, addError } = useAlerts();
@@ -135,6 +140,7 @@ export const ClientScopes = ({ clientId, protocol }: ClientScopesProps) => {
       {rest && (
         <AddScopeDialog
           clientScopes={rest}
+          clientName={clientName!}
           open={addDialogOpen}
           toggleDialog={() => setAddDialogOpen(!addDialogOpen)}
           onAdd={async (scopes) => {

--- a/src/clients/scopes/client-scopes.css
+++ b/src/clients/scopes/client-scopes.css
@@ -6,3 +6,7 @@
 .keycloak__client-scopes-add__add-dropdown {
   margin-right: var(--pf-global--spacer--md);
 }
+
+.kc-protocolType-select {
+  max-width: 25%;
+}

--- a/src/clients/utils.ts
+++ b/src/clients/utils.ts
@@ -11,10 +11,10 @@ export const isRealmClient = (client: ClientRepresentation) => !client.protocol;
  */
 export const getProtocolName = (t: TFunction<"clients">, protocol: string) => {
   switch (protocol) {
-    case "protocol.openIdConnect":
-      return t("clients:protocol:openIdConnect");
-    case "protocol.saml":
-      return t("clients:protocol:saml");
+    case "openid-connect":
+      return t("clients:protocolTypes:openIdConnect");
+    case "saml":
+      return t("clients:protocolTypes:saml");
   }
 
   return protocol;

--- a/src/clients/utils.ts
+++ b/src/clients/utils.ts
@@ -11,9 +11,9 @@ export const isRealmClient = (client: ClientRepresentation) => !client.protocol;
  */
 export const getProtocolName = (t: TFunction<"clients">, protocol: string) => {
   switch (protocol) {
-    case "openid-connect":
+    case "protocol.openIdConnect":
       return t("clients:protocol:openIdConnect");
-    case "saml":
+    case "protocol.saml":
       return t("clients:protocol:saml");
   }
 

--- a/src/components/dynamic/MultivaluedScopesComponent.tsx
+++ b/src/components/dynamic/MultivaluedScopesComponent.tsx
@@ -1,0 +1,129 @@
+import React, { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Controller, useFormContext } from "react-hook-form";
+import {
+  Button,
+  Chip,
+  ChipGroup,
+  FormGroup,
+  TextInput,
+} from "@patternfly/react-core";
+
+import { HelpItem } from "../help-enabler/HelpItem";
+import type { ComponentProps } from "./components";
+import { AddScopeDialog } from "../../clients/scopes/AddScopeDialog";
+import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
+import type ClientScopeRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientScopeRepresentation";
+import { useParams } from "react-router";
+import type { EditClientPolicyConditionParams } from "../../realm-settings/routes/EditCondition";
+
+export const MultivaluedScopesComponent = ({
+  defaultValue,
+  name,
+}: ComponentProps) => {
+  const { t } = useTranslation("dynamic");
+  const { control } = useFormContext();
+  const { conditionName } = useParams<EditClientPolicyConditionParams>();
+  const adminClient = useAdminClient();
+  const [open, setOpen] = useState(false);
+  const [clientScopes, setClientScopes] = useState<ClientScopeRepresentation[]>(
+    []
+  );
+
+  useFetch(
+    () => adminClient.clientScopes.find(),
+    (clientScopes) => {
+      setClientScopes(clientScopes);
+    },
+    []
+  );
+
+  const toggleModal = () => {
+    setOpen(!open);
+  };
+
+  return (
+    <FormGroup
+      label={t("realm-settings:clientScopesCondition")}
+      id="expected-scopes"
+      labelIcon={
+        <HelpItem
+          helpText={t("realm-settings-help:clientScopesConditionTooltip")}
+          forLabel={t("clientScopes")}
+          forID={name!}
+        />
+      }
+      fieldId={name!}
+    >
+      <Controller
+        name={`config.scopes`}
+        control={control}
+        defaultValue={[defaultValue]}
+        rules={{ required: true }}
+        render={({ onChange, value }) => {
+          return (
+            <>
+              {open && (
+                <AddScopeDialog
+                  clientScopes={clientScopes.filter(
+                    (scope) => !value.includes(scope.name!)
+                  )}
+                  isClientScopesConditionType
+                  open={open}
+                  toggleDialog={() => setOpen(!open)}
+                  onAdd={(scopes) => {
+                    onChange([
+                      ...value,
+                      ...scopes
+                        .map((scope) => scope.scope)
+                        .map((item) => item.name!),
+                    ]);
+                  }}
+                />
+              )}
+              {value.length === 0 && !conditionName && (
+                <TextInput
+                  type="text"
+                  id="kc-scopes"
+                  value={value}
+                  data-testid="client-scope-input"
+                  name="config.client-scopes"
+                  isDisabled
+                />
+              )}
+              <ChipGroup
+                className="kc-client-scopes-chip-group"
+                isClosable
+                onClick={() => {
+                  onChange([]);
+                }}
+              >
+                {value.map((currentChip: string) => (
+                  <Chip
+                    key={currentChip}
+                    onClick={() => {
+                      onChange(
+                        value.filter((item: string) => item !== currentChip)
+                      );
+                    }}
+                  >
+                    {currentChip}
+                  </Chip>
+                ))}
+              </ChipGroup>
+              <Button
+                data-testid="select-scope-button"
+                variant="secondary"
+                onClick={() => {
+                  toggleModal();
+                }}
+              >
+                {t("common:select")}
+              </Button>
+            </>
+          );
+        }}
+      />
+    </FormGroup>
+  );
+};

--- a/src/realm-settings/NewClientPolicyForm.tsx
+++ b/src/realm-settings/NewClientPolicyForm.tsx
@@ -551,7 +551,7 @@ export default function NewClientPolicyForm() {
                               0 ? (
                                 <Link
                                   key={condition.condition}
-                                  data-testid="condition-type-link"
+                                  data-testid={`${condition.condition}-condition-link`}
                                   to={toEditClientPolicyCondition({
                                     realm,
                                     conditionName: condition.condition!,
@@ -581,7 +581,7 @@ export default function NewClientPolicyForm() {
                                         icon={
                                           <TrashIcon
                                             className="kc-conditionType-trash-icon"
-                                            data-testid="deleteClientProfileDropdown"
+                                            data-testid={`delete-${condition.condition}-condition`}
                                             onClick={() => {
                                               toggleDeleteConditionDialog();
                                               setConditionToDelete({

--- a/src/realm-settings/RealmSettingsSection.css
+++ b/src/realm-settings/RealmSettingsSection.css
@@ -252,3 +252,16 @@ article.pf-c-card.pf-m-flat.kc-login-settings-template
 .kc_eventListeners_select {
   width: 35rem;
 }
+
+input#kc-scopes {
+  width: 630px;
+  
+  margin-right: 24px;
+}
+
+.kc-client-scopes-chip-group {
+  margin-right: var(--pf-global--spacer--2xl);
+  max-width: 585px;
+  min-width: 585px;
+  padding-left: none;
+}


### PR DESCRIPTION
## Motivation
<!-- Add references to relevant tickets, issues, design specs and/or a short description of what motivated you to do it. -->
https://issues.redhat.com/browse/CLUX-330
https://marvelapp.com/prototype/2b3ghc06/screen/81619352

## Brief Description
<!-- Add a short answer for: 
What was done in this PR? (e.g Fix to prevent users from accessing feature X.)
Why it was done? (e.g Feature X was deprecated.)
-->
- Adds screen, correct fields, and functionality to client policies -> add condition -> client-scopes condition type
- Supports save and edit functionality

## Verification Steps
<!--
Add the steps required to verify this change. Keep in mind that these steps should be written so groups unfamiliar with the 
new functionality can follow them, such as QE or documentation.-->

1. Go to Realm settings -> Client policies -> Policies subtab
2. Create a new client policy if one doesn't exist yet.
3. Click on the client policy and under Conditions, click "Add condition"
4. Select the "client-scopes" condition type.
5. Verify that the UI and functionality match the design and work as expected. 
6. Save the client-scopes condition.
7. Navigate back to the client-scope condition type and verify that updating the data works as expected.

## Checklist:

- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [x] Help has been implemented
- [x] axe report has been run and resulting a11y issues have been resolved
- [x] Unit tests have been created/updated

## Additional Notes
<!-- 
Add images and/or screen caps to illustrate what was changed if this pull request adds to or modifies existing user-visible appearance/output. 
-->
Dependent on #1532  - will rebase once merged to simplify review process.