### PR TITLE
Fix role-ldap-mapper defaults

### DIFF
--- a/src/user-federation/ldap/mappers/LdapMapperRoleGroup.tsx
+++ b/src/user-federation/ldap/mappers/LdapMapperRoleGroup.tsx
@@ -33,6 +33,7 @@ export const LdapMapperRoleGroup = ({
   const [isRetrieveStratDropdownOpen, setIsRetrieveStratDropdownOpen] =
     useState(false);
   const [isClientIdDropdownOpen, setIsClientIdDropdownOpen] = useState(false);
+  const [vendor, setVendor] = useState<string | undefined>();
   const [clients, setClients] = useState<ClientRepresentation[]>([]);
   const { id, mapperId } = useParams<UserFederationLdapMapperParams>();
 
@@ -61,7 +62,7 @@ export const LdapMapperRoleGroup = ({
     },
     (fetchedComponent) => {
       if (fetchedComponent) {
-        const vendor = fetchedComponent.config?.vendor[0];
+        setVendor(fetchedComponent.config?.vendor[0]);
         if (mapperId === "new" && vendor === "ad") {
           form.setValue(
             isRole
@@ -384,70 +385,107 @@ export const LdapMapperRoleGroup = ({
           )}
         ></Controller>
       </FormGroup>
-      <FormGroup
-        label={
-          isRole
-            ? t("userRolesRetrieveStrategy")
-            : t("userGroupsRetrieveStrategy")
-        }
-        labelIcon={
-          <HelpItem
-            helpText={
-              isRole
-                ? helpText("userRolesRetrieveStrategyHelp")
-                : helpText("userGroupsRetrieveStrategyHelp")
-            }
-            forLabel={
-              isRole
-                ? t("userRolesRetrieveStrategy")
-                : t("userGroupsRetrieveStrategy")
-            }
-            forID="kc-user-retrieve-strategy"
-          />
-        }
-        fieldId="kc-user-retrieve-strategy"
-      >
-        <Controller
-          name={
-            isRole
-              ? "config.user-roles-retrieve-strategy[0]"
-              : "config.user-groups-retrieve-strategy[0]"
+      {isRole ? (
+        <FormGroup
+          label={t("userRolesRetrieveStrategy")}
+          labelIcon={
+            <HelpItem
+              helpText={helpText("userRolesRetrieveStrategyHelp")}
+              forLabel={t("userRolesRetrieveStrategy")}
+              forID="kc-user-retrieve-strategy"
+            />
           }
-          defaultValue="LOAD_ROLES_BY_MEMBER_ATTRIBUTE"
-          control={form.control}
-          render={({ onChange, value }) => (
-            <Select
-              toggleId="kc-user-retrieve-strategy"
-              onToggle={() =>
-                setIsRetrieveStratDropdownOpen(!isRetrieveStratDropdownOpen)
-              }
-              isOpen={isRetrieveStratDropdownOpen}
-              onSelect={(_, value) => {
-                onChange(value as string);
-                setIsRetrieveStratDropdownOpen(false);
-              }}
-              selections={value}
-              variant={SelectVariant.single}
-            >
-              <SelectOption key={0} value="LOAD_ROLES_BY_MEMBER_ATTRIBUTE">
-                LOAD_ROLES_BY_MEMBER_ATTRIBUTE
-              </SelectOption>
-              <SelectOption
-                key={1}
-                value="GET_ROLES_FROM_USER_MEMBEROF_ATTRIBUTE"
+          fieldId="kc-user-retrieve-strategy"
+        >
+          <Controller
+            name="config.user-roles-retrieve-strategy[0]"
+            defaultValue="LOAD_ROLES_BY_MEMBER_ATTRIBUTE"
+            control={form.control}
+            render={({ onChange, value }) => (
+              <Select
+                toggleId="kc-user-retrieve-strategy"
+                onToggle={() =>
+                  setIsRetrieveStratDropdownOpen(!isRetrieveStratDropdownOpen)
+                }
+                isOpen={isRetrieveStratDropdownOpen}
+                onSelect={(_, value) => {
+                  onChange(value as string);
+                  setIsRetrieveStratDropdownOpen(false);
+                }}
+                selections={value}
+                variant={SelectVariant.single}
               >
-                GET_ROLES_FROM_USER_MEMBEROF_ATTRIBUTE
-              </SelectOption>
-              <SelectOption
-                key={2}
-                value="LOAD_ROLES_BY_MEMBER_ATTRIBUTE_RECURSIVELY"
+                <SelectOption key={0} value="LOAD_ROLES_BY_MEMBER_ATTRIBUTE">
+                  LOAD_ROLES_BY_MEMBER_ATTRIBUTE
+                </SelectOption>
+                <SelectOption
+                  key={1}
+                  value="GET_ROLES_FROM_USER_MEMBEROF_ATTRIBUTE"
+                >
+                  GET_ROLES_FROM_USER_MEMBEROF_ATTRIBUTE
+                </SelectOption>
+                <SelectOption
+                  hidden={vendor !== "ad"}
+                  key={2}
+                  value="LOAD_ROLES_BY_MEMBER_ATTRIBUTE_RECURSIVELY"
+                >
+                  LOAD_ROLES_BY_MEMBER_ATTRIBUTE_RECURSIVELY
+                </SelectOption>
+              </Select>
+            )}
+          ></Controller>
+        </FormGroup>
+      ) : (
+        <FormGroup
+          label={t("userGroupsRetrieveStrategy")}
+          labelIcon={
+            <HelpItem
+              helpText={helpText("userGroupsRetrieveStrategyHelp")}
+              forLabel={t("userGroupsRetrieveStrategy")}
+              forID="kc-user-retrieve-strategy"
+            />
+          }
+          fieldId="kc-user-retrieve-strategy"
+        >
+          <Controller
+            name="config.user-roles-retrieve-strategy[0]"
+            defaultValue="LOAD_GROUPS_BY_MEMBER_ATTRIBUTE"
+            control={form.control}
+            render={({ onChange, value }) => (
+              <Select
+                toggleId="kc-user-retrieve-strategy"
+                onToggle={() =>
+                  setIsRetrieveStratDropdownOpen(!isRetrieveStratDropdownOpen)
+                }
+                isOpen={isRetrieveStratDropdownOpen}
+                onSelect={(_, value) => {
+                  onChange(value as string);
+                  setIsRetrieveStratDropdownOpen(false);
+                }}
+                selections={value}
+                variant={SelectVariant.single}
               >
-                LOAD_ROLES_BY_MEMBER_ATTRIBUTE_RECURSIVELY
-              </SelectOption>
-            </Select>
-          )}
-        ></Controller>
-      </FormGroup>
+                <SelectOption key={0} value="LOAD_GROUPS_BY_MEMBER_ATTRIBUTE">
+                  LOAD_GROUPS_BY_MEMBER_ATTRIBUTE
+                </SelectOption>
+                <SelectOption
+                  key={1}
+                  value="GET_GROUPS_FROM_USER_MEMBEROF_ATTRIBUTE"
+                >
+                  GET_GROUPS_FROM_USER_MEMBEROF_ATTRIBUTE
+                </SelectOption>
+                <SelectOption
+                  hidden={vendor !== "ad"}
+                  key={2}
+                  value="LOAD_GROUPS_BY_MEMBER_ATTRIBUTE_RECURSIVELY"
+                >
+                  LOAD_GROUPS_BY_MEMBER_ATTRIBUTE_RECURSIVELY
+                </SelectOption>
+              </Select>
+            )}
+          ></Controller>
+        </FormGroup>
+      )}
       <FormGroup
         label={t("memberofLdapAttribute")}
         labelIcon={

--- a/src/user-federation/ldap/mappers/LdapMapperRoleGroup.tsx
+++ b/src/user-federation/ldap/mappers/LdapMapperRoleGroup.tsx
@@ -33,7 +33,7 @@ export const LdapMapperRoleGroup = ({
   const [isRetrieveStratDropdownOpen, setIsRetrieveStratDropdownOpen] =
     useState(false);
   const [isClientIdDropdownOpen, setIsClientIdDropdownOpen] = useState(false);
-  const [vendor, setVendor] = useState<string | undefined>();
+  const [vendorType, setVendorType] = useState<string | undefined>();
   const [clients, setClients] = useState<ClientRepresentation[]>([]);
   const { id, mapperId } = useParams<UserFederationLdapMapperParams>();
 
@@ -62,7 +62,8 @@ export const LdapMapperRoleGroup = ({
     },
     (fetchedComponent) => {
       if (fetchedComponent) {
-        setVendor(fetchedComponent.config?.vendor[0]);
+        const vendor = fetchedComponent.config?.vendor[0];
+        setVendorType(vendor);
         if (mapperId === "new" && vendor === "ad") {
           form.setValue(
             isRole
@@ -425,7 +426,7 @@ export const LdapMapperRoleGroup = ({
                   GET_ROLES_FROM_USER_MEMBEROF_ATTRIBUTE
                 </SelectOption>
                 <SelectOption
-                  hidden={vendor !== "ad"}
+                  hidden={vendorType !== "ad"}
                   key={2}
                   value="LOAD_ROLES_BY_MEMBER_ATTRIBUTE_RECURSIVELY"
                 >
@@ -475,7 +476,7 @@ export const LdapMapperRoleGroup = ({
                   GET_GROUPS_FROM_USER_MEMBEROF_ATTRIBUTE
                 </SelectOption>
                 <SelectOption
-                  hidden={vendor !== "ad"}
+                  hidden={vendorType !== "ad"}
                   key={2}
                   value="LOAD_GROUPS_BY_MEMBER_ATTRIBUTE_RECURSIVELY"
                 >


### PR DESCRIPTION
## Motivation
Fixes https://github.com/keycloak/keycloak-admin-ui/issues/1481.

## Brief Description
As noted in https://github.com/keycloak/keycloak-admin-ui/issues/1481, the `Role Object Classes` issue was fixed as part of https://github.com/keycloak/keycloak-admin-ui/pull/1511.

For the `User roles retrieve strategy` issue, fixed it so the Active Directory vendor has three possible choices vs the other 4 vendor types which only have two available choices.

During testing, noticed that the field itself was not writing/reading correctly - this is because both roles and groups both use the user-roles-retrieve-strategy API value, but have different enums. It works correctly now.

And finally, with these changes, there were just far too many IF conditions within the Select so made one check for isRole and based on that load a different Select.

## Verification Steps
1. Go to User Federation > LDAP > LDAP Mappers.
2. Create new mapper.
3. Choose `role-ldap-mapper` as mapper type.
4. Verify that `Role Object Classes` has the correct defaults for the Active Directory vendor type (`group`) vs the other vendors (`groupOfNames`), and that you can save/read correctly, using the old console if needed.
5. Verify that for the Active Directory vendor type, `User roles retrieve strategy` has three choices, vs the other vendors which  should have only two choices, and that you can save/read correctly, using the old console if needed.
6. Repeat with the `group-ldap-mapper` mapper type. See old console for comparison purposes.

## Checklist:
- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [x] Help has been implemented
- [x] Unit tests have been created/updated

## Additional Notes
None