### PR TITLE
Include .git directory to fix Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,2 @@
-.git
 cypress
 .github


### PR DESCRIPTION
Since merging #1572 the Docker build is no longer functional, this is because the Maven plugin that was included needs information from the `.git` directory. This PR allows this directory to be passed into the Docker build, which allows it to function again.