### PR TITLE
Fix. 1359-Can't view all scopes.

### DIFF
--- a/cypress/integration/client_scopes_test.spec.ts
+++ b/cypress/integration/client_scopes_test.spec.ts
@@ -6,6 +6,7 @@ import CreateClientScopePage from "../support/pages/admin_console/manage/client_
 import { keycloakBefore } from "../support/util/keycloak_before";
 import RoleMappingTab from "../support/pages/admin_console/manage/RoleMappingTab";
 import ModalUtils from "../support/util/ModalUtils";
+import AdminClient from "../support/util/AdminClient";
 
 let itemId = "client_scope_crud";
 const loginPage = new LoginPage();
@@ -16,6 +17,36 @@ const createClientScopePage = new CreateClientScopePage();
 const modalUtils = new ModalUtils();
 
 describe("Client Scopes test", () => {
+  describe("Client Scope list items ", () => {
+    const clientScopeName = "test";
+
+    before(async () => {
+      const client = new AdminClient();
+      for (let i = 0; i < 5; i++) {
+        await client.createClientScope({ name: clientScopeName + i });
+      }
+    });
+
+    beforeEach(() => {
+      keycloakBefore();
+      loginPage.logIn();
+      sidebarPage.goToClientScopes();
+    });
+
+    after(async () => {
+      const client = new AdminClient();
+      for (let i = 0; i < 5; i++) {
+        await client.deleteClientScope(clientScopeName + i);
+      }
+    });
+
+    it("should show items on next page are more than 11", () => {
+      listingPage.showNextPageTableItems();
+
+      cy.get(listingPage.tableRowItem).its("length").should("be.gt", 1);
+    });
+  });
+
   describe("Client Scope creation", () => {
     beforeEach(() => {
       keycloakBefore();

--- a/cypress/integration/client_scopes_test.spec.ts
+++ b/cypress/integration/client_scopes_test.spec.ts
@@ -18,12 +18,24 @@ const modalUtils = new ModalUtils();
 
 describe("Client Scopes test", () => {
   describe("Client Scope list items ", () => {
-    const clientScopeName = "test";
+    const clientScopeName = "client-scope-test";
+    const clientScope = {
+      name: clientScopeName,
+      description: "",
+      protocol: "openid-connect",
+      attributes: {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true",
+        "gui.order": "1",
+        "consent.screen.text": "",
+      },
+    };
 
     before(async () => {
       const client = new AdminClient();
       for (let i = 0; i < 5; i++) {
-        await client.createClientScope({ name: clientScopeName + i });
+        clientScope.name = clientScopeName + i;
+        await client.createClientScope(clientScope);
       }
     });
 

--- a/cypress/integration/clients_test.spec.ts
+++ b/cypress/integration/clients_test.spec.ts
@@ -10,6 +10,7 @@ import InitialAccessTokenTab from "../support/pages/admin_console/manage/clients
 import { keycloakBefore } from "../support/util/keycloak_before";
 import RoleMappingTab from "../support/pages/admin_console/manage/RoleMappingTab";
 import KeysTab from "../support/pages/admin_console/manage/clients/KeysTab";
+import ClientScopesTab from "../support/pages/admin_console/manage/clients/ClientScopesTab";
 
 let itemId = "client_crud";
 const loginPage = new LoginPage();
@@ -20,6 +21,56 @@ const createClientPage = new CreateClientPage();
 const modalUtils = new ModalUtils();
 
 describe("Clients test", () => {
+  describe("Client details - Client scopes subtab", () => {
+    const clientScopesTab = new ClientScopesTab();
+    const clientScopeName = "test";
+    const clientId = "client-test-scopes-subtab";
+    const client = new AdminClient();
+
+    before(() => {
+      client.createClient({
+        clientId,
+        protocol: "openid-connect",
+        publicClient: false,
+      });
+      async () => {
+        for (let i = 0; i < 5; i++) {
+          await client.createClientScope({ name: clientScopeName + i });
+          await client.addClientScopeToClient(clientId, clientScopeName + i);
+        }
+      };
+    });
+
+    beforeEach(() => {
+      keycloakBefore();
+      loginPage.logIn();
+      sidebarPage.goToClients();
+      cy.intercept("/auth/admin/realms/master/clients/*").as("fetchClient");
+      listingPage.searchItem(clientId).goToItemDetails(clientId);
+      cy.wait("@fetchClient");
+      clientScopesTab.goToTab();
+    });
+
+    after(() => {
+      async () => {
+        for (let i = 0; i < 5; i++) {
+          await client.removeClientScopeFromClient(
+            clientId,
+            clientScopeName + i
+          );
+          await client.deleteClientScope(clientScopeName + i);
+        }
+      };
+      client.deleteClient(clientId);
+    });
+
+    it("should show items on next page are more than 11", () => {
+      listingPage.showNextPageTableItems();
+
+      cy.get(listingPage.tableRowItem).its("length").should("be.gt", 1);
+    });
+  });
+
   describe("Client creation", () => {
     beforeEach(() => {
       keycloakBefore();

--- a/cypress/integration/clients_test.spec.ts
+++ b/cypress/integration/clients_test.spec.ts
@@ -23,22 +23,35 @@ const modalUtils = new ModalUtils();
 describe("Clients test", () => {
   describe("Client details - Client scopes subtab", () => {
     const clientScopesTab = new ClientScopesTab();
-    const clientScopeName = "test";
-    const clientId = "client-test-scopes-subtab";
     const client = new AdminClient();
+    const clientId = "client-scopes-subtab-test";
+    const clientScopeName = "client-scope-test";
+    const clientScope = {
+      name: clientScopeName,
+      description: "",
+      protocol: "openid-connect",
+      attributes: {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true",
+        "gui.order": "1",
+        "consent.screen.text": "",
+      },
+    };
 
-    before(() => {
+    before(async () => {
       client.createClient({
         clientId,
         protocol: "openid-connect",
         publicClient: false,
       });
-      async () => {
-        for (let i = 0; i < 5; i++) {
-          await client.createClientScope({ name: clientScopeName + i });
-          await client.addClientScopeToClient(clientId, clientScopeName + i);
-        }
-      };
+      for (let i = 0; i < 5; i++) {
+        clientScope.name = clientScopeName + i;
+        await client.createClientScope(clientScope);
+        await client.addDefaultClientScopeInClient(
+          clientScopeName + i,
+          clientId
+        );
+      }
     });
 
     beforeEach(() => {
@@ -51,22 +64,15 @@ describe("Clients test", () => {
       clientScopesTab.goToTab();
     });
 
-    after(() => {
-      async () => {
-        for (let i = 0; i < 5; i++) {
-          await client.removeClientScopeFromClient(
-            clientId,
-            clientScopeName + i
-          );
-          await client.deleteClientScope(clientScopeName + i);
-        }
-      };
+    after(async () => {
       client.deleteClient(clientId);
+      for (let i = 0; i < 5; i++) {
+        await client.deleteClientScope(clientScopeName + i);
+      }
     });
 
     it("should show items on next page are more than 11", () => {
       listingPage.showNextPageTableItems();
-
       cy.get(listingPage.tableRowItem).its("length").should("be.gt", 1);
     });
   });

--- a/cypress/support/pages/admin_console/ListingPage.ts
+++ b/cypress/support/pages/admin_console/ListingPage.ts
@@ -10,6 +10,23 @@ export default class ListingPage {
     ".pf-c-page__main .pf-c-toolbar__content-section .pf-m-primary:visible";
   private importBtn =
     ".pf-c-page__main .pf-c-toolbar__content-section .pf-m-link";
+  private previousPageBtn =
+    "div[class=pf-c-pagination__nav-control] button[data-action=previous]:visible";
+  private nextPageBtn =
+    "div[class=pf-c-pagination__nav-control] button[data-action=next]:visible";
+  public tableRowItem = "tbody tr[data-ouia-component-type]:visible";
+
+  showPreviousPageTableItems() {
+    cy.get(this.previousPageBtn).first().click();
+
+    return this;
+  }
+
+  showNextPageTableItems() {
+    cy.get(this.nextPageBtn).first().click();
+
+    return this;
+  }
 
   goToCreateItem() {
     cy.get(this.createBtn).click();

--- a/cypress/support/pages/admin_console/manage/clients/ClientScopesTab.ts
+++ b/cypress/support/pages/admin_console/manage/clients/ClientScopesTab.ts
@@ -1,0 +1,8 @@
+export default class ClientScopesTab {
+  private clientScopesTab = "#pf-tab-clientScopes-clientScopes";
+
+  goToTab() {
+    cy.get(this.clientScopesTab).click();
+    return this;
+  }
+}

--- a/cypress/support/util/AdminClient.ts
+++ b/cypress/support/util/AdminClient.ts
@@ -87,9 +87,9 @@ export default class AdminClient {
     await this.client.users.del({ id: user[0].id! });
   }
 
-  async createClientScope(clientScope: ClientScopeRepresentation) {
+  async createClientScope(scope: ClientScopeRepresentation) {
     await this.login();
-    return await this.client.clientScopes.create(clientScope);
+    return await this.client.clientScopes.create(scope);
   }
 
   async deleteClientScope(clientScopeName: string) {
@@ -100,47 +100,33 @@ export default class AdminClient {
     return await this.client.clientScopes.del({ id: clientScope?.id! });
   }
 
-  async addClientScopeToClient(
-    clientId: string,
+  async addDefaultClientScopeInClient(
     clientScopeName: string,
-    defaultElseOptional?: boolean
+    clientId: string
   ) {
     await this.login();
-    const clientScope = await this.client.clientScopes.findOneByName({
+    const scope = await this.client.clientScopes.findOneByName({
       name: clientScopeName,
     });
-    if (defaultElseOptional) {
-      await this.client.clients.addDefaultClientScope({
-        id: clientId,
-        clientScopeId: clientScope?.id!,
-      });
-    } else {
-      await this.client.clients.addOptionalClientScope({
-        id: clientId,
-        clientScopeId: clientScope?.id!,
-      });
-    }
+    const client = await this.client.clients.find({ clientId: clientId });
+    return await this.client.clients.addDefaultClientScope({
+      id: client[0]?.id!,
+      clientScopeId: scope?.id!,
+    });
   }
 
-  async removeClientScopeFromClient(
-    clientId: string,
+  async removeDefaultClientScopeInClient(
     clientScopeName: string,
-    defaultElseOptional?: boolean
+    clientId: string
   ) {
     await this.login();
-    const clientScope = await this.client.clientScopes.findOneByName({
+    const scope = await this.client.clientScopes.findOneByName({
       name: clientScopeName,
     });
-    if (defaultElseOptional) {
-      await this.client.clients.delDefaultClientScope({
-        id: clientId,
-        clientScopeId: clientScope?.id!,
-      });
-    } else {
-      await this.client.clients.delOptionalClientScope({
-        id: clientId,
-        clientScopeId: clientScope?.id!,
-      });
-    }
+    const client = await this.client.clients.find({ clientId: clientId });
+    return await this.client.clients.delDefaultClientScope({
+      id: client[0]?.id!,
+      clientScopeId: scope?.id!,
+    });
   }
 }

--- a/cypress/support/util/AdminClient.ts
+++ b/cypress/support/util/AdminClient.ts
@@ -1,6 +1,7 @@
 import KeycloakAdminClient from "@keycloak/keycloak-admin-client";
 import type UserRepresentation from "@keycloak/keycloak-admin-client/lib/defs/userRepresentation";
 import type ClientRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientRepresentation";
+import type ClientScopeRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientScopeRepresentation";
 
 export default class AdminClient {
   private client: KeycloakAdminClient;
@@ -84,5 +85,62 @@ export default class AdminClient {
     await this.login();
     const user = await this.client.users.find({ username });
     await this.client.users.del({ id: user[0].id! });
+  }
+
+  async createClientScope(clientScope: ClientScopeRepresentation) {
+    await this.login();
+    return await this.client.clientScopes.create(clientScope);
+  }
+
+  async deleteClientScope(clientScopeName: string) {
+    await this.login();
+    const clientScope = await this.client.clientScopes.findOneByName({
+      name: clientScopeName,
+    });
+    return await this.client.clientScopes.del({ id: clientScope?.id! });
+  }
+
+  async addClientScopeToClient(
+    clientId: string,
+    clientScopeName: string,
+    defaultElseOptional?: boolean
+  ) {
+    await this.login();
+    const clientScope = await this.client.clientScopes.findOneByName({
+      name: clientScopeName,
+    });
+    if (defaultElseOptional) {
+      await this.client.clients.addDefaultClientScope({
+        id: clientId,
+        clientScopeId: clientScope?.id!,
+      });
+    } else {
+      await this.client.clients.addOptionalClientScope({
+        id: clientId,
+        clientScopeId: clientScope?.id!,
+      });
+    }
+  }
+
+  async removeClientScopeFromClient(
+    clientId: string,
+    clientScopeName: string,
+    defaultElseOptional?: boolean
+  ) {
+    await this.login();
+    const clientScope = await this.client.clientScopes.findOneByName({
+      name: clientScopeName,
+    });
+    if (defaultElseOptional) {
+      await this.client.clients.delDefaultClientScope({
+        id: clientId,
+        clientScopeId: clientScope?.id!,
+      });
+    } else {
+      await this.client.clients.delOptionalClientScope({
+        id: clientId,
+        clientScopeId: clientScope?.id!,
+      });
+    }
   }
 }

--- a/src/client-scopes/ClientScopesSection.tsx
+++ b/src/client-scopes/ClientScopesSection.tsx
@@ -100,7 +100,7 @@ export default function ClientScopesSection() {
       })
       .filter(filter)
       .sort((a, b) => a.name!.localeCompare(b.name!, whoAmI.getLocale()))
-      .slice(first, max);
+      .slice(first, Number(first) + Number(max));
   };
 
   const [toggleDeleteDialog, DeleteConfirm] = useConfirmDialog({

--- a/src/clients/scopes/ClientScopes.tsx
+++ b/src/clients/scopes/ClientScopes.tsx
@@ -110,7 +110,7 @@ export const ClientScopes = ({
 
     const filter =
       searchType === "name" ? nameFilter(search) : typeFilter(searchTypeType);
-    return rows.filter(filter).slice(first, max);
+    return rows.filter(filter).slice(first, Number(first) + Number(max));
   };
 
   const TypeSelector = (scope: Row) => (


### PR DESCRIPTION
## Motivation
Closes [#1359](https://github.com/keycloak/keycloak-admin-ui/issues/1359)

## Verification Steps

**Client scopes**
1. Go to **Client scopes** and create six new scopes so that there are 15 total
2. When the table is set to display 1-10 rows, go to the next page
3. You should have listed remaining 5 items in second page.

**Clients**
1. Go to **Clients** -> Clients list -> Navigate to client details page by item _Client ID_ link
2. Navigate to _Clients Scope_ tab and Add client scope to ensure client has more than 11 items added.
2. When the table is set to display 1-10 rows, go to the next page
3. You should have listed remaining items in second page.

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [X] Unit tests have been created/updated