### PR TITLE
Enable 'admin-preview' profile when building Keycloak

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Build Keycloak Server
         working-directory: ${{ env.KEYCLOAK_SERVER_PATH }}
-        run: mvn clean install --no-snapshot-updates --batch-mode --errors -DskipTests -Pdistribution
+        run: mvn clean install --no-snapshot-updates --batch-mode --errors -DskipTests -Pdistribution,admin-preview
 
       - name: Configure distribution path
         working-directory: ${{ env.KEYCLOAK_SERVER_PATH }}


### PR DESCRIPTION
Enables the 'admin-preview' profile when building Keycloak so that the Admin UI is correctly installed. This allows the Cypress tests to run properly again.