### PR TITLE
Update Keycloak development server to 16.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY . .
 
 RUN mvn -f /app/keycloak-theme/pom.xml install
 
-FROM quay.io/keycloak/keycloak:15.1.0
+FROM quay.io/keycloak/keycloak:16.1.0
 COPY --from=builder /app/keycloak-theme/target/classes /opt/jboss/keycloak/themes/keycloak.v2
 
 EXPOSE 8080

--- a/start.mjs
+++ b/start.mjs
@@ -11,7 +11,7 @@ import cliProgress from "cli-progress";
 import colors from "colors";
 
 const args = process.argv.slice(2);
-const version = args[0] && !args[0].startsWith("-") ? args[0] : "15.1.0";
+const version = args[0] && !args[0].startsWith("-") ? args[0] : "16.1.0";
 
 const folder = "server";
 const fileName = path.join(folder, `keycloak-${version}.tar.gz`);


### PR DESCRIPTION
## Motivation
New version of Keycloak is out, this keeps us up-to-date.