### PR TITLE
Update Masthead tests

### DIFF
--- a/cypress/integration/login_test.spec.ts
+++ b/cypress/integration/login_test.spec.ts
@@ -22,7 +22,7 @@ describe("Logging In", () => {
   it("logs in", () => {
     loginPage.logIn(username, password);
 
-    masthead.isAdminConsole();
+    masthead.checkIsAdminConsole();
 
     cy.getCookie("KEYCLOAK_SESSION_LEGACY").should("exist");
   });

--- a/cypress/integration/masthead_test.spec.ts
+++ b/cypress/integration/masthead_test.spec.ts
@@ -19,7 +19,7 @@ const goToAcctMgtTest = () => {
     masthead.accountManagement();
     cy.contains("Welcome to Keycloak Account Management");
     cy.get("#landingReferrerLink").click({ force: true });
-    masthead.isAdminConsole();
+    masthead.checkIsAdminConsole();
   });
 };
 

--- a/cypress/support/pages/admin_console/Masthead.ts
+++ b/cypress/support/pages/admin_console/Masthead.ts
@@ -5,9 +5,8 @@ export default class Masthead {
 
   private userDrpDwn = "#user-dropdown";
   private userDrpDwnKebab = "#user-dropdown-kebab";
-  private isMobile = false;
 
-  isAdminConsole() {
+  checkIsAdminConsole() {
     cy.get(this.logoBtn).should("exist");
     cy.get(this.userDrpDwn).should("exist");
 
@@ -15,11 +14,10 @@ export default class Masthead {
   }
 
   get isMobileMode() {
-    return this.isMobile;
+    return window.parent[0].innerWidth < 1024;
   }
 
   setMobileMode(isMobileMode: boolean) {
-    this.isMobile = isMobileMode;
     if (isMobileMode) {
       cy.viewport("iphone-6");
     } else {


### PR DESCRIPTION
## Motivation
Updating Masthead tests in order to make it more clear and avoid a possible failure scenario of  the`isMobileMode` method


## Brief Description
- Change the name of the method `isAdminConsole`, that could imply the return of a boolean, to `checkIsAdminConsole` to imply the assert check.
- Modify `isMobileMode` method to check the window size instead of just returning a variable (there are different scenarios where the mobile mode could change without updating the variable)

## Checklist:

- [ x] Code has been tested locally by PR requester
- [ ] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated