### PR TITLE
Realm settings: Return user to Policies subtab 

### DIFF
--- a/cypress/integration/realm_settings_client_policies_test.spec.ts
+++ b/cypress/integration/realm_settings_client_policies_test.spec.ts
@@ -27,15 +27,15 @@ describe("Realm settings client policies tab tests", () => {
     await new AdminClient().deleteRealm(realmName);
   });
 
-  it("Go to client policies tab", () => {
+  it.skip("Go to client policies tab", () => {
     realmSettingsPage.shouldDisplayPoliciesTab();
   });
 
-  it("Check new client form is displaying", () => {
+  it.skip("Check new client form is displaying", () => {
     realmSettingsPage.shouldDisplayNewClientPolicyForm();
   });
 
-  it("Complete new client form and cancel", () => {
+  it.skip("Complete new client form and cancel", () => {
     realmSettingsPage.shouldCompleteAndCancelCreateNewClientPolicy();
   });
 
@@ -43,47 +43,47 @@ describe("Realm settings client policies tab tests", () => {
     realmSettingsPage.shouldCompleteAndCreateNewClientPolicyFromEmptyState();
   });
 
-  it("Should perform client profile search by profile name", () => {
+  it.skip("Should perform client profile search by profile name", () => {
     realmSettingsPage.shouldSearchClientPolicy();
   });
 
-  it("Should not have conditions configured by default", () => {
+  it.skip("Should not have conditions configured by default", () => {
     realmSettingsPage.shouldNotHaveConditionsConfigured();
   });
 
-  it("Should cancel adding a new condition to a client profile", () => {
+  it.skip("Should cancel adding a new condition to a client profile", () => {
     realmSettingsPage.shouldCancelAddingCondition();
   });
 
-  it("Should add a new client-roles condition to a client profile", () => {
+  it.skip("Should add a new client-roles condition to a client profile", () => {
     realmSettingsPage.shouldAddClientRolesCondition();
   });
 
-  it("Should add a new client-scopes condition to a client profile", () => {
+  it.skip("Should add a new client-scopes condition to a client profile", () => {
     realmSettingsPage.shouldAddClientScopesCondition();
   });
 
-  it("Should edit the client-roles condition of a client profile", () => {
+  it.skip("Should edit the client-roles condition of a client profile", () => {
     realmSettingsPage.shouldEditClientRolesCondition();
   });
 
-  it("Should edit the client-scopes condition of a client profile", () => {
+  it.skip("Should edit the client-scopes condition of a client profile", () => {
     realmSettingsPage.shouldEditClientScopesCondition();
   });
 
-  it("Should cancel deleting condition from a client profile", () => {
+  it.skip("Should cancel deleting condition from a client profile", () => {
     realmSettingsPage.shouldCancelDeletingCondition();
   });
 
-  it("Should delete client-roles condition from a client profile", () => {
+  it.skip("Should delete client-roles condition from a client profile", () => {
     realmSettingsPage.shouldDeleteClientRolesCondition();
   });
 
-  it("Should delete client-scopes condition from a client profile", () => {
+  it.skip("Should delete client-scopes condition from a client profile", () => {
     realmSettingsPage.shouldDeleteClientScopesCondition();
   });
 
-  it("Check cancelling the client policy deletion", () => {
+  it.skip("Check cancelling the client policy deletion", () => {
     realmSettingsPage.shouldDisplayDeleteClientPolicyDialog();
   });
 
@@ -91,7 +91,7 @@ describe("Realm settings client policies tab tests", () => {
     realmSettingsPage.shouldDeleteClientPolicyDialog();
   });
 
-  it("Check navigating between Form View and JSON editor", () => {
+  it.skip("Check navigating between Form View and JSON editor", () => {
     realmSettingsPage.shouldNavigateBetweenFormAndJSONViewPolicies();
   });
 
@@ -114,7 +114,7 @@ describe("Realm settings client policies tab tests", () => {
     realmSettingsPage.shouldRemoveClientPolicyFromCreateView();
   });
 
-  it("Check reloading JSON policies", () => {
+  it.skip("Check reloading JSON policies", () => {
     realmSettingsPage.shouldReloadJSONPolicies();
   });
 });

--- a/cypress/integration/realm_settings_client_policies_test.spec.ts
+++ b/cypress/integration/realm_settings_client_policies_test.spec.ts
@@ -27,15 +27,15 @@ describe("Realm settings client policies tab tests", () => {
     await new AdminClient().deleteRealm(realmName);
   });
 
-  it.skip("Go to client policies tab", () => {
+  it("Go to client policies tab", () => {
     realmSettingsPage.shouldDisplayPoliciesTab();
   });
 
-  it.skip("Check new client form is displaying", () => {
+  it("Check new client form is displaying", () => {
     realmSettingsPage.shouldDisplayNewClientPolicyForm();
   });
 
-  it.skip("Complete new client form and cancel", () => {
+  it("Complete new client form and cancel", () => {
     realmSettingsPage.shouldCompleteAndCancelCreateNewClientPolicy();
   });
 
@@ -43,47 +43,47 @@ describe("Realm settings client policies tab tests", () => {
     realmSettingsPage.shouldCompleteAndCreateNewClientPolicyFromEmptyState();
   });
 
-  it.skip("Should perform client profile search by profile name", () => {
+  it("Should perform client profile search by profile name", () => {
     realmSettingsPage.shouldSearchClientPolicy();
   });
 
-  it.skip("Should not have conditions configured by default", () => {
+  it("Should not have conditions configured by default", () => {
     realmSettingsPage.shouldNotHaveConditionsConfigured();
   });
 
-  it.skip("Should cancel adding a new condition to a client profile", () => {
+  it("Should cancel adding a new condition to a client profile", () => {
     realmSettingsPage.shouldCancelAddingCondition();
   });
 
-  it.skip("Should add a new client-roles condition to a client profile", () => {
+  it("Should add a new client-roles condition to a client profile", () => {
     realmSettingsPage.shouldAddClientRolesCondition();
   });
 
-  it.skip("Should add a new client-scopes condition to a client profile", () => {
+  it("Should add a new client-scopes condition to a client profile", () => {
     realmSettingsPage.shouldAddClientScopesCondition();
   });
 
-  it.skip("Should edit the client-roles condition of a client profile", () => {
+  it("Should edit the client-roles condition of a client profile", () => {
     realmSettingsPage.shouldEditClientRolesCondition();
   });
 
-  it.skip("Should edit the client-scopes condition of a client profile", () => {
+  it("Should edit the client-scopes condition of a client profile", () => {
     realmSettingsPage.shouldEditClientScopesCondition();
   });
 
-  it.skip("Should cancel deleting condition from a client profile", () => {
+  it("Should cancel deleting condition from a client profile", () => {
     realmSettingsPage.shouldCancelDeletingCondition();
   });
 
-  it.skip("Should delete client-roles condition from a client profile", () => {
+  it("Should delete client-roles condition from a client profile", () => {
     realmSettingsPage.shouldDeleteClientRolesCondition();
   });
 
-  it.skip("Should delete client-scopes condition from a client profile", () => {
+  it("Should delete client-scopes condition from a client profile", () => {
     realmSettingsPage.shouldDeleteClientScopesCondition();
   });
 
-  it.skip("Check cancelling the client policy deletion", () => {
+  it("Check cancelling the client policy deletion", () => {
     realmSettingsPage.shouldDisplayDeleteClientPolicyDialog();
   });
 
@@ -91,7 +91,7 @@ describe("Realm settings client policies tab tests", () => {
     realmSettingsPage.shouldDeleteClientPolicyDialog();
   });
 
-  it.skip("Check navigating between Form View and JSON editor", () => {
+  it("Check navigating between Form View and JSON editor", () => {
     realmSettingsPage.shouldNavigateBetweenFormAndJSONViewPolicies();
   });
 
@@ -114,7 +114,7 @@ describe("Realm settings client policies tab tests", () => {
     realmSettingsPage.shouldRemoveClientPolicyFromCreateView();
   });
 
-  it.skip("Check reloading JSON policies", () => {
+  it("Check reloading JSON policies", () => {
     realmSettingsPage.shouldReloadJSONPolicies();
   });
 });

--- a/cypress/support/pages/admin_console/manage/realm_settings/RealmSettingsPage.ts
+++ b/cypress/support/pages/admin_console/manage/realm_settings/RealmSettingsPage.ts
@@ -625,15 +625,15 @@ export default class RealmSettingsPage {
   }
 
   shouldDisplayDeleteClientPolicyDialog() {
-    cy.get(this.moreDrpDwn).last().click({ force: true });
-    cy.get(this.moreDrpDwnItems).click();
+    this.listingPage.searchItem("Test", false);
+    this.listingPage.clickRowDetails("Test").clickDetailMenu("Delete");
     cy.get(this.deleteDialogTitle).contains("Delete policy?");
     cy.get(this.deleteDialogBodyText).contains(
       "This action will permanently delete the policy Test. This cannot be undone."
     );
     cy.findByTestId("modalConfirm").contains("Delete");
     cy.get(this.deleteDialogCancelBtn).contains("Cancel").click();
-    cy.get("table").should("not.have.text", "Test");
+    cy.get("table").should("be.visible").contains("td", "Test");
   }
 
   shouldDeleteClientProfileDialog() {

--- a/cypress/support/pages/admin_console/manage/realm_settings/RealmSettingsPage.ts
+++ b/cypress/support/pages/admin_console/manage/realm_settings/RealmSettingsPage.ts
@@ -625,7 +625,7 @@ export default class RealmSettingsPage {
   }
 
   shouldDisplayDeleteClientPolicyDialog() {
-    cy.get(this.moreDrpDwn).last().click();
+    cy.get(this.moreDrpDwn).last().click({ force: true });
     cy.get(this.moreDrpDwnItems).click();
     cy.get(this.deleteDialogTitle).contains("Delete policy?");
     cy.get(this.deleteDialogBodyText).contains(
@@ -914,7 +914,7 @@ export default class RealmSettingsPage {
       "Test Description"
     );
     cy.findByTestId(this.cancelNewClientPolicyBtn).click();
-    cy.get("table").should("not.have.text", "Test");
+    cy.findByTestId(this.createPolicyEmptyStateBtn).should("exist");
   }
 
   shouldCompleteAndCreateNewClientPolicy() {
@@ -1119,12 +1119,12 @@ export default class RealmSettingsPage {
     );
     cy.findByTestId(this.saveNewClientPolicyBtn).click();
     cy.get(this.alertMessage).should("be.visible", "New client policy created");
-    cy.wait(200);
+    cy.wait(500);
     cy.findByTestId(this.clientPolicyDrpDwn).contains("Action").click();
     cy.findByTestId("deleteClientPolicyDropdown").click();
     cy.findByTestId("modalConfirm").contains("Delete").click();
     cy.get(this.alertMessage).should("be.visible", "Client profile deleted");
-    cy.get("table").should("not.have.text", "Test Again Description");
+    cy.findByTestId(this.createPolicyEmptyStateBtn).should("exist");
   }
 
   shouldReloadJSONPolicies() {

--- a/src/realm-settings/ClientProfileForm.tsx
+++ b/src/realm-settings/ClientProfileForm.tsx
@@ -176,7 +176,7 @@ export default function ClientProfileForm() {
             globalProfiles,
           });
           addAlert(t("deleteClientSuccess"), AlertVariant.success);
-          history.push(toClientPolicies({ realm }));
+          history.push(toClientPolicies({ realm, tab: "profiles" }));
         } catch (error) {
           addError(t("deleteClientError"), error);
         }

--- a/src/realm-settings/NewClientPolicyForm.tsx
+++ b/src/realm-settings/NewClientPolicyForm.tsx
@@ -34,13 +34,13 @@ import { PlusCircleIcon, TrashIcon } from "@patternfly/react-icons";
 import "./RealmSettingsSection.css";
 import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
 import type ClientPolicyRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientPolicyRepresentation";
-import { toClientPolicies } from "./routes/ClientPolicies";
 import { toNewClientPolicyCondition } from "./routes/AddCondition";
 import { useServerInfo } from "../context/server-info/ServerInfoProvider";
 import { toEditClientPolicyCondition } from "./routes/EditCondition";
 import type { EditClientPolicyParams } from "./routes/EditClientPolicy";
 import { AddClientProfileModal } from "./AddClientProfileModal";
 import type ClientProfileRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientProfileRepresentation";
+import { toRealmSettings } from "./routes/RealmSettings";
 
 type NewClientPolicyForm = Required<ClientPolicyRepresentation>;
 
@@ -274,7 +274,13 @@ export default function NewClientPolicyForm() {
           policies: updatedPolicies,
         });
         addAlert(t("deleteClientPolicySuccess"), AlertVariant.success);
-        history.push(toClientPolicies({ realm }));
+        history.push(
+          toRealmSettings({
+            realm,
+            tab: "clientPolicies",
+            subTab: "policies",
+          })
+        );
       } catch (error) {
         addError(t("deleteClientPolicyError"), error);
       }
@@ -314,7 +320,13 @@ export default function NewClientPolicyForm() {
               policies: updatedPolicies,
             });
             addAlert(t("deleteClientSuccess"), AlertVariant.success);
-            history.push(toClientPolicies({ realm }));
+            history.push(
+              toRealmSettings({
+                realm,
+                tab: "clientPolicies",
+                subTab: "policies",
+              })
+            );
           } catch (error) {
             addError(t("deleteClientError"), error);
           }
@@ -354,7 +366,13 @@ export default function NewClientPolicyForm() {
             policies: updatedPolicies,
           });
           addAlert(t("deleteClientSuccess"), AlertVariant.success);
-          history.push(toClientPolicies({ realm }));
+          history.push(
+            toRealmSettings({
+              realm,
+              tab: "clientPolicies",
+              subTab: "policies",
+            })
+          );
         } catch (error) {
           addError(t("deleteClientError"), error);
         }
@@ -411,14 +429,6 @@ export default function NewClientPolicyForm() {
     } catch (error) {
       addError("realm-settings:addClientProfileError", error);
     }
-  };
-
-  const goToPoliciesSubtab = () => {
-    history.push(toClientPolicies({ realm }));
-
-    setTimeout(() => {
-      document.getElementById("pf-tab-1-policies")?.click();
-    }, 100);
   };
 
   return (
@@ -496,7 +506,13 @@ export default function NewClientPolicyForm() {
               onClick={() =>
                 showAddConditionsAndProfilesForm || policyName
                   ? reset()
-                  : goToPoliciesSubtab()
+                  : history.push(
+                      toRealmSettings({
+                        realm,
+                        tab: "clientPolicies",
+                        subTab: "policies",
+                      })
+                    )
               }
               data-testid="cancelCreatePolicy"
             >

--- a/src/realm-settings/NewClientPolicyForm.tsx
+++ b/src/realm-settings/NewClientPolicyForm.tsx
@@ -413,6 +413,14 @@ export default function NewClientPolicyForm() {
     }
   };
 
+  const goToPoliciesSubtab = () => {
+    history.push(toClientPolicies({ realm }));
+
+    setTimeout(() => {
+      document.getElementById("pf-tab-1-policies")?.click();
+    }, 100);
+  };
+
   return (
     <>
       <DeleteConditionConfirm />
@@ -488,7 +496,7 @@ export default function NewClientPolicyForm() {
               onClick={() =>
                 showAddConditionsAndProfilesForm || policyName
                   ? reset()
-                  : history.push(toClientPolicies({ realm }))
+                  : goToPoliciesSubtab()
               }
               data-testid="cancelCreatePolicy"
             >

--- a/src/realm-settings/PoliciesTab.tsx
+++ b/src/realm-settings/PoliciesTab.tsx
@@ -79,7 +79,7 @@ export const PoliciesTab = () => {
       await adminClient.clientPolicies.updatePolicy({
         policies: updatedPolicies,
       });
-      history.push(toClientPolicies({ realm }));
+      history.push(toClientPolicies({ realm, tab: "policies" }));
       addAlert(
         t("realm-settings:updateClientPolicySuccess"),
         AlertVariant.success

--- a/src/realm-settings/ProfilesTab.tsx
+++ b/src/realm-settings/ProfilesTab.tsx
@@ -202,7 +202,10 @@ export default function ProfilesTab() {
               <Button
                 id="createProfile"
                 component={(props) => (
-                  <Link {...props} to={toAddClientProfile({ realm })} />
+                  <Link
+                    {...props}
+                    to={toAddClientProfile({ realm, tab: "profiles" })}
+                  />
                 )}
                 data-testid="createProfile"
               >

--- a/src/realm-settings/RealmSettingsSection.tsx
+++ b/src/realm-settings/RealmSettingsSection.tsx
@@ -36,10 +36,20 @@ export const ToClientPolicies = () => {
   const { t } = useTranslation("realm-settings");
   const { realm } = useRealm();
 
+  const goToPoliciesSubtab = () => {
+    setTimeout(() => {
+      document.getElementById("pf-tab-1-policies")?.click();
+    }, 100);
+  };
+
   return (
     <BreadcrumbItem
       render={(props) => (
-        <Link {...props} to={toClientPolicies({ realm })}>
+        <Link
+          {...props}
+          onClick={() => goToPoliciesSubtab()}
+          to={toClientPolicies({ realm })}
+        >
           {t("clientPolicies")}
         </Link>
       )}

--- a/src/realm-settings/RealmSettingsSection.tsx
+++ b/src/realm-settings/RealmSettingsSection.tsx
@@ -36,19 +36,16 @@ export const ToClientPolicies = () => {
   const { t } = useTranslation("realm-settings");
   const { realm } = useRealm();
 
-  const goToPoliciesSubtab = () => {
-    setTimeout(() => {
-      document.getElementById("pf-tab-1-policies")?.click();
-    }, 100);
-  };
-
   return (
     <BreadcrumbItem
       render={(props) => (
         <Link
           {...props}
-          onClick={() => goToPoliciesSubtab()}
-          to={toClientPolicies({ realm })}
+          to={toRealmSettings({
+            realm,
+            tab: "clientPolicies",
+            subTab: "policies",
+          })}
         >
           {t("clientPolicies")}
         </Link>

--- a/src/realm-settings/RealmSettingsSection.tsx
+++ b/src/realm-settings/RealmSettingsSection.tsx
@@ -73,7 +73,7 @@ export const EditProfileCrumb = () => {
     <Breadcrumb>
       <BreadcrumbItem
         render={(props) => (
-          <Link {...props} to={toClientPolicies({ realm })}>
+          <Link {...props} to={toClientPolicies({ realm, tab: "profiles" })}>
             {t("clientPolicies")}
           </Link>
         )}
@@ -91,7 +91,7 @@ export const EditExecutorCrumb = () => {
     <Breadcrumb>
       <BreadcrumbItem
         render={(props) => (
-          <Link {...props} to={toClientPolicies({ realm })}>
+          <Link {...props} to={toClientPolicies({ realm, tab: "profiles" })}>
             {t("clientPolicies")}
           </Link>
         )}
@@ -109,7 +109,7 @@ export const NewPolicyCrumb = () => {
     <Breadcrumb>
       <BreadcrumbItem
         render={(props) => (
-          <Link {...props} to={toClientPolicies({ realm })}>
+          <Link {...props} to={toClientPolicies({ realm, tab: "policy" })}>
             {t("clientPolicies")}
           </Link>
         )}

--- a/src/realm-settings/RealmSettingsTabs.tsx
+++ b/src/realm-settings/RealmSettingsTabs.tsx
@@ -423,13 +423,8 @@ export const RealmSettingsTabs = ({
                 history,
               })}
             >
-              <Tabs
-                activeKey={activeTab}
-                onSelect={(_, key) => setActiveTab(Number(key))}
-              >
+              <RoutableTabs>
                 <Tab
-                  id="profiles"
-                  eventKey={0}
                   data-testid="rs-policies-clientProfiles-tab"
                   aria-label={t("clientProfilesSubTab")}
                   title={
@@ -443,6 +438,13 @@ export const RealmSettingsTabs = ({
                       </span>
                     </TabTitleText>
                   }
+                  {...routableTab({
+                    to: toRealmSettings({
+                      realm: realmName,
+                      tab: "clientPolicies",
+                    }),
+                    history,
+                  })}
                 >
                   <ProfilesTab />
                 </Tab>
@@ -450,7 +452,14 @@ export const RealmSettingsTabs = ({
                   id="policies"
                   data-testid="rs-policies-clientPolicies-tab"
                   aria-label={t("clientPoliciesSubTab")}
-                  eventKey={1}
+                  {...routableTab({
+                    to: toRealmSettings({
+                      realm: realmName,
+                      tab: "clientPolicies",
+                      subTab: "policies",
+                    }),
+                    history,
+                  })}
                   title={
                     <TabTitleText>
                       {t("policies")}
@@ -465,7 +474,7 @@ export const RealmSettingsTabs = ({
                 >
                   <PoliciesTab />
                 </Tab>
-              </Tabs>
+              </RoutableTabs>
             </Tab>
             {isFeatureEnabled(Feature.DeclarativeUserProfile) &&
               userProfileEnabled === "true" && (

--- a/src/realm-settings/RealmSettingsTabs.tsx
+++ b/src/realm-settings/RealmSettingsTabs.tsx
@@ -57,6 +57,7 @@ import environment from "../environment";
 import helpUrls from "../help-urls";
 import { UserProfileTab } from "./user-profile/UserProfileTab";
 import useIsFeatureEnabled, { Feature } from "../utils/useIsFeatureEnabled";
+import { toClientPolicies } from "./routes/ClientPolicies";
 
 type RealmSettingsHeaderProps = {
   onChange: (value: boolean) => void;
@@ -423,7 +424,13 @@ export const RealmSettingsTabs = ({
                 history,
               })}
             >
-              <RoutableTabs>
+              <RoutableTabs
+                mountOnEnter
+                defaultLocation={toClientPolicies({
+                  realm: realmName,
+                  tab: "profiles",
+                })}
+              >
                 <Tab
                   data-testid="rs-policies-clientProfiles-tab"
                   aria-label={t("clientProfilesSubTab")}
@@ -439,9 +446,9 @@ export const RealmSettingsTabs = ({
                     </TabTitleText>
                   }
                   {...routableTab({
-                    to: toRealmSettings({
+                    to: toClientPolicies({
                       realm: realmName,
-                      tab: "clientPolicies",
+                      tab: "profiles",
                     }),
                     history,
                   })}
@@ -453,10 +460,9 @@ export const RealmSettingsTabs = ({
                   data-testid="rs-policies-clientPolicies-tab"
                   aria-label={t("clientPoliciesSubTab")}
                   {...routableTab({
-                    to: toRealmSettings({
+                    to: toClientPolicies({
                       realm: realmName,
-                      tab: "clientPolicies",
-                      subTab: "policies",
+                      tab: "policies",
                     }),
                     history,
                   })}

--- a/src/realm-settings/routes/AddClientPolicy.ts
+++ b/src/realm-settings/routes/AddClientPolicy.ts
@@ -7,7 +7,7 @@ import { NewPolicyCrumb } from "../RealmSettingsSection";
 export type AddClientPolicyParams = { realm: string };
 
 export const AddClientPolicyRoute: RouteDef = {
-  path: "/:realm/realm-settings/clientPolicies/add-client-policy",
+  path: "/:realm/realm-settings/clientPolicies/policies/add-client-policy",
   component: lazy(() => import("../NewClientPolicyForm")),
   breadcrumb: () => NewPolicyCrumb,
   access: "manage-clients",

--- a/src/realm-settings/routes/AddClientProfile.ts
+++ b/src/realm-settings/routes/AddClientProfile.ts
@@ -5,10 +5,11 @@ import type { RouteDef } from "../../route-config";
 
 export type AddClientProfileParams = {
   realm: string;
+  tab: string;
 };
 
 export const AddClientProfileRoute: RouteDef = {
-  path: "/:realm/realm-settings/clientPolicies/add-profile",
+  path: "/:realm/realm-settings/clientPolicies/:tab/add-profile",
   component: lazy(() => import("../ClientProfileForm")),
   breadcrumb: (t) => t("realm-settings:newClientProfile"),
   access: "manage-realm",

--- a/src/realm-settings/routes/ClientPolicies.ts
+++ b/src/realm-settings/routes/ClientPolicies.ts
@@ -3,12 +3,15 @@ import { lazy } from "react";
 import { generatePath } from "react-router-dom";
 import type { RouteDef } from "../../route-config";
 
+export type UserProfileTab = "profiles" | "policies";
+
 export type ClientPoliciesParams = {
   realm: string;
+  tab: string;
 };
 
 export const ClientPoliciesRoute: RouteDef = {
-  path: "/:realm/realm-settings/clientPolicies",
+  path: "/:realm/realm-settings/clientPolicies/:tab",
   component: lazy(() => import("../ProfilesTab")),
   breadcrumb: (t) => t("realm-settings:allClientPolicies"),
   access: "view-realm",

--- a/src/realm-settings/routes/RealmSettings.ts
+++ b/src/realm-settings/routes/RealmSettings.ts
@@ -4,6 +4,7 @@ import { generatePath } from "react-router-dom";
 import type { RouteDef } from "../../route-config";
 
 export type RealmSettingsTab =
+  | "general"
   | "login"
   | "email"
   | "themes"
@@ -20,10 +21,11 @@ export type RealmSettingsTab =
 export type RealmSettingsParams = {
   realm: string;
   tab?: RealmSettingsTab;
+  subTab?: string;
 };
 
 export const RealmSettingsRoute: RouteDef = {
-  path: "/:realm/realm-settings/:tab?",
+  path: "/:realm/realm-settings/:tab?/:subTab?",
   component: lazy(() => import("../RealmSettingsSection")),
   breadcrumb: (t) => t("realmSettings"),
   access: "view-realm",


### PR DESCRIPTION
## Motivation
<!-- Add references to relevant tickets, issues, design specs and/or a short description of what motivated you to do it. -->
@_**Haley Wang|246396** [said](https://keycloak.zulipchat.com/#narrow/pm-with/246396,327337-pm/near/265912135):
> Can the cancel here navigate back to the policies list instead of the profiles list?

<img width="1623" alt="Screen Shot 2022-01-04 at 10 57 41 AM" src="https://user-images.githubusercontent.com/32821331/148086878-6789412c-68f9-4596-9d38-e053c9308078.png">


This has been a repeated subject of discussion, as the current implementation of tabs does not support bookmarkable subtabs. @ssilvert recently brought this up while reviewing the code for client policies, and @yih-wang also requested a change here.

## Brief Description
<!-- Add a short answer for: 
What was done in this PR? (e.g Fix to prevent users from accessing feature X.)
Why it was done? (e.g Feature X was deprecated.)
-->
The PR includes a workaround for navigating back to the "Client Policies" subtab.

## Verification Steps
<!--
Add the steps required to verify this change. Keep in mind that these steps should be written so groups unfamiliar with the 
new functionality can follow them, such as QE or documentation.-->


1. Go to Client Policies -> Policies subtab.
2. Click "Create client policy"
3. Click the "Cancel" button.
4. Verify that the UI takes you to the client policies list, rather than the client profiles list.
5. Repeat steps 1-2 and add a new client policy.
6. Go back to the policies list, and click on the new policy.
7. Click the "Client Policies" link in the breadcrumb, and verify that the UI takes you back to the client policies list.

## Checklist:

- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [x] Help has been implemented
- [x] axe report has been run and resulting a11y issues have been resolved
- [x] Unit tests have been created/updated
