### PR TITLE
Use correct feature flag name in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ For development on this project you will need a running Keycloak server listenin
     git checkout git@github.com:keycloak/keycloak-admin-ui.git
     cd keycloak-admin-ui
     docker build -t keycloak-v2 .
-    docker run --name keycloak-v2 -d -p 127.0.0.1:8080:8080 -e KEYCLOAK_USER=admin -e KEYCLOAK_PASSWORD=admin keycloak-v2 -Dprofile.feature.newadmin=enabled
+    docker run --name keycloak-v2 -d -p 127.0.0.1:8080:8080 -e KEYCLOAK_USER=admin -e KEYCLOAK_PASSWORD=admin keycloak-v2 -Dkeycloak.profile.feature.admin2=enabled
 
 You can reach the new admin interface at `http://localhost:8080`. Then go to `Realm Settings --> Themes` and set Admin Console Theme to `keycloak.v2`.
 

--- a/keycloak-theme/README.md
+++ b/keycloak-theme/README.md
@@ -19,7 +19,7 @@ For development, you can also just copy the contents of `./target/classes` to `<
 Until New Admin Console becomes the default, you will need to start Keycloak server like this:
 
 ```bash
-$> bin/standalone.sh -Dprofile.feature.newadmin=enabled
+$> bin/standalone.sh -Dkeycloak.profile.feature.admin2=enabled
 ```
 
 Then go to `Realm Settings --> Themes` and set Admin Console Theme to `keycloak.v2`.


### PR DESCRIPTION
The name of the feature to enable the new Admin UI has changed, but this was not yet reflected in all the documentation. This PR resolves this issue.

Closes #1831