### PR TITLE
Fixes localization 500 error

### DIFF
--- a/src/realm-settings/LocalizationTab.tsx
+++ b/src/realm-settings/LocalizationTab.tsx
@@ -409,17 +409,20 @@ export const LocalizationTab = ({
                       isOpen={supportedLocalesOpen}
                       placeholderText={t("selectLocales")}
                     >
-                      {themeTypes.login![0].locales.map(
-                        (locale: string, idx: number) => (
-                          <SelectOption
-                            selected={value.includes(locale)}
-                            key={`locale-${idx}`}
-                            value={locale}
-                          >
-                            {t(`allSupportedLocales.${locale}`)}
-                          </SelectOption>
+                      {
+                        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+                        themeTypes.login![0].locales?.map(
+                          (locale: string, idx: number) => (
+                            <SelectOption
+                              selected={value.includes(locale)}
+                              key={`locale-${idx}`}
+                              value={locale}
+                            >
+                              {t(`allSupportedLocales.${locale}`)}
+                            </SelectOption>
+                          )
                         )
-                      )}
+                      }
                     </Select>
                   )}
                 />

--- a/src/realm-settings/LocalizationTab.tsx
+++ b/src/realm-settings/LocalizationTab.tsx
@@ -125,6 +125,7 @@ export const LocalizationTab = ({
             getValues("defaultLocale") ||
             whoAmI.getLocale(),
         })
+        // prevents server error in dev mode due to snowpack
         .catch(() => []);
 
       const searchInBundles = (idx: number) => {

--- a/src/realm-settings/LocalizationTab.tsx
+++ b/src/realm-settings/LocalizationTab.tsx
@@ -115,13 +115,17 @@ export const LocalizationTab = ({
 
   useFetch(
     async () => {
-      let result = await adminClient.realms.getRealmLocalizationTexts({
-        first,
-        max,
-        realm: realm.realm!,
-        selectedLocale:
-          selectMenuLocale || getValues("defaultLocale") || whoAmI.getLocale(),
-      });
+      let result = await adminClient.realms
+        .getRealmLocalizationTexts({
+          first,
+          max,
+          realm: realm.realm!,
+          selectedLocale:
+            selectMenuLocale ||
+            getValues("defaultLocale") ||
+            whoAmI.getLocale(),
+        })
+        .catch(() => []);
 
       const searchInBundles = (idx: number) => {
         return Object.entries(result).filter((i) => i[idx].includes(filter));


### PR DESCRIPTION
Closes #1857 

Previously there was a `try/catch` block in the loader that prevented this error. The loader was recently refactored to a `useFetch` in #1663 to allow for message bundle functionality. 