### PR TITLE
LDAP mapper test fix

### DIFF
--- a/cypress/integration/user_fed_ldap_hardcoded_mapper_test.spec.ts
+++ b/cypress/integration/user_fed_ldap_hardcoded_mapper_test.spec.ts
@@ -154,7 +154,7 @@ describe("User Fed LDAP mapper tests", () => {
     listingPage.itemExist(lastNameMapper, false);
 
     listingPage.itemExist(modifyDateMapper).deleteItem(modifyDateMapper);
-    modalUtils.checkModalTitle(mapperDeleteTitle).confirmModal();
+    modalUtils.checkModalTitle(mapperDeleteTitle).confirmModal(true);
     masthead.checkNotificationMessage(mapperDeletedSuccess, true);
     listingPage.itemExist(modifyDateMapper, false);
   });

--- a/cypress/integration/user_fed_ldap_mapper_test.spec.ts
+++ b/cypress/integration/user_fed_ldap_mapper_test.spec.ts
@@ -133,7 +133,7 @@ describe("User Fed LDAP mapper tests", () => {
     listingPage
       .itemExist(MsadAccountControlsMapper)
       .deleteItem(MsadAccountControlsMapper);
-    modalUtils.checkModalTitle(mapperDeleteTitle).confirmModal();
+    modalUtils.checkModalTitle(mapperDeleteTitle).confirmModal(true);
     masthead.checkNotificationMessage(mapperDeletedSuccess, true);
   });
 

--- a/cypress/support/util/ModalUtils.ts
+++ b/cypress/support/util/ModalUtils.ts
@@ -6,8 +6,8 @@ export default class ModalUtils {
   private cancelModalBtn = "#modal-cancel";
   private closeModalBtn = ".pf-c-modal-box .pf-m-plain";
 
-  confirmModal() {
-    cy.get(this.confirmModalBtn).click();
+  confirmModal(force: boolean = false) {
+    cy.get(this.confirmModalBtn).click({ force: force });
 
     return this;
   }

--- a/cypress/support/util/ModalUtils.ts
+++ b/cypress/support/util/ModalUtils.ts
@@ -6,8 +6,8 @@ export default class ModalUtils {
   private cancelModalBtn = "#modal-cancel";
   private closeModalBtn = ".pf-c-modal-box .pf-m-plain";
 
-  confirmModal(force: boolean = false) {
-    cy.get(this.confirmModalBtn).click({ force: force });
+  confirmModal(force = false) {
+    cy.get(this.confirmModalBtn).click({ force });
 
     return this;
   }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "start:rh-sso": "THEME_NAME=rh-sso snowpack dev",
     "test": "jest",
     "start:cypress": "cypress open",
-    "start:cypress-tests": "cypress run",
+    "start:cypress-tests": "cypress run --spec ./cypress/integration/*_mapper_test.spec.ts",
     "prepare": "husky install"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "start:rh-sso": "THEME_NAME=rh-sso snowpack dev",
     "test": "jest",
     "start:cypress": "cypress open",
-    "start:cypress-tests": "cypress run --spec ./cypress/integration/*_mapper_test.spec.ts",
+    "start:cypress-tests": "cypress run",
     "prepare": "husky install"
   },
   "dependencies": {


### PR DESCRIPTION
## Motivation
Now that we are getting more consistent cypress test suite passes, the LDAP mapper tests stand out as being still a bit flakey and seem to sporadically cause an otherwise passing test suite to fail. 

## Brief Description
After watching the vids of the failing ldap mapper tests, the issue is that when the final mapper is deleted, the timing causes the modal confirm button to be disconnected from the DOM. This is a common issue with cypress and although there are a few community-proposed workarounds, there is no cypress officially supported solution. In my testing, adding a force to the modal button click seems like the easiest resolution to the issue. 

To test these changes, I ran the mapper tests locally (UI and headless) 10 times, and then ran the mapper tests on CI 5 times, and then the full suite on CI an additional 3 times. I could not get either of the mapper tests to fail with these changes.

## Verification Steps
The mapper tests now consistently pass on CI so no verification should be needed, but you can re-run them on CI and/or run the tests locally to verify if you choose.

## Checklist:
- [x] Code has been tested locally by PR requester

## Additional Notes
None