### PR TITLE
Add Clients tests, fix notification message and stabilize tests

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -9,7 +9,9 @@
         "runMode": 2,
         "openMode": 0
       },
-    "defaultCommandTimeout": 10000,
+    "defaultCommandTimeout": 30000,
+    "slowTestThreshold": 30000,
+    "pageLoadTimeout": 120000,
     "videoCompression": false,
     "numTestsKeptInMemory": 30,
     "videoUploadOnPasses": false

--- a/cypress.json
+++ b/cypress.json
@@ -11,7 +11,6 @@
       },
     "defaultCommandTimeout": 30000,
     "slowTestThreshold": 30000,
-    "pageLoadTimeout": 120000,
     "videoCompression": false,
     "numTestsKeptInMemory": 30,
     "videoUploadOnPasses": false

--- a/cypress/integration/authentication_test.spec.ts
+++ b/cypress/integration/authentication_test.spec.ts
@@ -20,6 +20,7 @@ describe("Authentication test", () => {
   beforeEach(() => {
     keycloakBefore();
     loginPage.logIn();
+    sidebarPage.waitForPageLoad();
     sidebarPage.goToAuthentication();
   });
 

--- a/cypress/integration/clients_test.spec.ts
+++ b/cypress/integration/clients_test.spec.ts
@@ -126,6 +126,8 @@ describe("Clients test", () => {
 
       sidebarPage.goToClients();
 
+      listingPage.searchItem("John Doe", false).checkEmptyList();
+      listingPage.searchItem("").itemExist("account");
       listingPage.searchItem(itemId).itemExist(itemId);
 
       // Delete
@@ -139,22 +141,55 @@ describe("Clients test", () => {
 
     it("Initial access token", () => {
       const initialAccessTokenTab = new InitialAccessTokenTab();
-      initialAccessTokenTab.goToInitialAccessTokenTab().shouldBeEmpty();
-      initialAccessTokenTab.createNewToken(1, 1).save();
+      initialAccessTokenTab
+        .goToInitialAccessTokenTab()
+        .shouldBeEmpty()
+        .goToCreateFromEmptyList()
+        .fillNewTokenData(1, 3)
+        .save();
 
       modalUtils.checkModalTitle("Initial access token details").closeModal();
 
+      masthead.checkNotificationMessage(
+        "New initial access token has been created"
+      );
+
       initialAccessTokenTab.shouldNotBeEmpty();
 
-      initialAccessTokenTab.getFistId((id) => {
+      listingPage
+        .searchItem("John Doe", false)
+        .checkEmptyList()
+        .searchItem("", false);
+
+      initialAccessTokenTab.getFirstId((id) => {
+        listingPage
+          .checkRowColumnValue(id, 4, "3")
+          .checkRowColumnValue(id, 5, "3")
+          .itemExist(id);
+      });
+
+      listingPage.goToCreateItem();
+      initialAccessTokenTab.fillNewTokenData(1, 3).save();
+
+      modalUtils.closeModal();
+
+      initialAccessTokenTab.getFirstId((id) => {
         listingPage.deleteItem(id);
         modalUtils
           .checkModalTitle("Delete initial access token?")
           .confirmModal();
-        masthead.checkNotificationMessage(
-          "initial access token created successfully"
-        );
       });
+
+      masthead.checkNotificationMessage(
+        "Initial access token deleted successfully"
+      ); // TODO fix message
+      initialAccessTokenTab.shouldNotBeEmpty();
+
+      initialAccessTokenTab.getFirstId((id) => {
+        listingPage.deleteItem(id);
+        modalUtils.confirmModal();
+      });
+      initialAccessTokenTab.shouldBeEmpty();
     });
   });
 

--- a/cypress/integration/clients_test.spec.ts
+++ b/cypress/integration/clients_test.spec.ts
@@ -91,7 +91,7 @@ describe("Clients test", () => {
       sidebarPage.goToClients();
     });
 
-    it("should fail creating client", () => {
+    it("Should fail creating client", () => {
       listingPage.goToCreateItem();
 
       createClientPage.continue().checkClientIdRequiredMessage();
@@ -132,7 +132,8 @@ describe("Clients test", () => {
 
       // Delete
       listingPage.deleteItem(itemId);
-      modalUtils.checkModalTitle(`Delete ${itemId} ?`).confirmModal();
+      sidebarPage.waitForPageLoad();
+      modalUtils.checkModalTitle(`Delete ${itemId} ?`).confirmModal(true);
 
       masthead.checkNotificationMessage("The client has been deleted");
 
@@ -175,9 +176,10 @@ describe("Clients test", () => {
 
       initialAccessTokenTab.getFirstId((id) => {
         listingPage.deleteItem(id);
+        sidebarPage.waitForPageLoad();
         modalUtils
           .checkModalTitle("Delete initial access token?")
-          .confirmModal();
+          .confirmModal(true);
       });
 
       masthead.checkNotificationMessage(
@@ -187,7 +189,8 @@ describe("Clients test", () => {
 
       initialAccessTokenTab.getFirstId((id) => {
         listingPage.deleteItem(id);
-        modalUtils.confirmModal();
+        sidebarPage.waitForPageLoad();
+        modalUtils.confirmModal(true);
       });
       initialAccessTokenTab.shouldBeEmpty();
     });
@@ -287,7 +290,8 @@ describe("Clients test", () => {
         .assign();
       masthead.checkNotificationMessage("Role mapping updated");
       serviceAccountTab.selectRow("create-realm").unAssign();
-      modalUtils.checkModalTitle("Remove mapping?").confirmModal();
+      sidebarPage.waitForPageLoad();
+      modalUtils.checkModalTitle("Remove mapping?").confirmModal(true);
       masthead.checkNotificationMessage("Scope mapping successfully removed");
     });
   });
@@ -313,7 +317,7 @@ describe("Clients test", () => {
       new AdminClient().deleteClient(mappingClient);
     });
 
-    it("add mapping to openid client", () => {
+    it("Add mapping to openid client", () => {
       cy.findByTestId("mappersTab").click();
       cy.findByText("Add predefined mapper").click();
       cy.get("table input").first().click();
@@ -324,12 +328,6 @@ describe("Clients test", () => {
 
   describe("Keys tab test", () => {
     const keysName = "keys-client";
-    beforeEach(() => {
-      keycloakBeforeEach();
-      sidebarPage.goToClients();
-      listingPage.searchItem(keysName).goToItemDetails(keysName);
-    });
-
     before(() => {
       keycloakBefore();
       loginPage.logIn();
@@ -340,17 +338,23 @@ describe("Clients test", () => {
       });
     });
 
+    beforeEach(() => {
+      keycloakBeforeEach();
+      sidebarPage.goToClients();
+      listingPage.searchItem(keysName).goToItemDetails(keysName);
+    });
+
     after(() => {
       new AdminClient().deleteClient(keysName);
     });
 
-    it("change use JWKS Url", () => {
+    it("Change use JWKS Url", () => {
       const keysTab = new KeysTab();
       keysTab.goToTab().checkSaveDisabled();
       keysTab.toggleUseJwksUrl().checkSaveDisabled(false);
     });
 
-    it("generate new keys", () => {
+    it("Generate new keys", () => {
       const keysTab = new KeysTab();
       keysTab.goToTab().clickGenerate();
 
@@ -376,7 +380,7 @@ describe("Clients test", () => {
       keycloakBeforeEach();
     });
 
-    it("displays the correct tabs", () => {
+    it("Displays the correct tabs", () => {
       cy.findByTestId("client-tabs")
         .findByTestId("clientSettingsTab")
         .should("exist");
@@ -390,7 +394,7 @@ describe("Clients test", () => {
       cy.findByTestId("client-tabs").find("li").should("have.length", 3);
     });
 
-    it("hides the delete action", () => {
+    it("Hides the delete action", () => {
       cy.findByTestId("action-dropdown").click();
       cy.findByTestId("delete-client").should("not.exist");
     });
@@ -422,12 +426,12 @@ describe("Clients test", () => {
       keycloakBeforeEach();
     });
 
-    it("shows an explainer text for bearer only clients", () => {
+    it("Shows an explainer text for bearer only clients", () => {
       cy.findByTestId("bearer-only-explainer-label").trigger("mouseenter");
       cy.findByTestId("bearer-only-explainer-tooltip").should("exist");
     });
 
-    it("hides the capability config section", () => {
+    it("Hides the capability config section", () => {
       cy.findByTestId("capability-config-form").should("not.exist");
       cy.findByTestId("jump-link-capability-config").should("not.exist");
     });

--- a/cypress/integration/clients_test.spec.ts
+++ b/cypress/integration/clients_test.spec.ts
@@ -182,7 +182,7 @@ describe("Clients test", () => {
 
       masthead.checkNotificationMessage(
         "Initial access token deleted successfully"
-      ); // TODO fix message
+      );
       initialAccessTokenTab.shouldNotBeEmpty();
 
       initialAccessTokenTab.getFirstId((id) => {

--- a/cypress/integration/clients_test.spec.ts
+++ b/cypress/integration/clients_test.spec.ts
@@ -133,7 +133,7 @@ describe("Clients test", () => {
       // Delete
       listingPage.deleteItem(itemId);
       sidebarPage.waitForPageLoad();
-      modalUtils.checkModalTitle(`Delete ${itemId} ?`).confirmModal(true);
+      modalUtils.checkModalTitle(`Delete ${itemId} ?`).confirmModal();
 
       masthead.checkNotificationMessage("The client has been deleted");
 
@@ -179,7 +179,7 @@ describe("Clients test", () => {
         sidebarPage.waitForPageLoad();
         modalUtils
           .checkModalTitle("Delete initial access token?")
-          .confirmModal(true);
+          .confirmModal();
       });
 
       masthead.checkNotificationMessage(
@@ -190,7 +190,7 @@ describe("Clients test", () => {
       initialAccessTokenTab.getFirstId((id) => {
         listingPage.deleteItem(id);
         sidebarPage.waitForPageLoad();
-        modalUtils.confirmModal(true);
+        modalUtils.confirmModal();
       });
       initialAccessTokenTab.shouldBeEmpty();
     });
@@ -291,7 +291,7 @@ describe("Clients test", () => {
       masthead.checkNotificationMessage("Role mapping updated");
       serviceAccountTab.selectRow("create-realm").unAssign();
       sidebarPage.waitForPageLoad();
-      modalUtils.checkModalTitle("Remove mapping?").confirmModal(true);
+      modalUtils.checkModalTitle("Remove mapping?").confirmModal();
       masthead.checkNotificationMessage("Scope mapping successfully removed");
     });
   });

--- a/cypress/integration/clients_test.spec.ts
+++ b/cypress/integration/clients_test.spec.ts
@@ -269,7 +269,7 @@ describe("Clients test", () => {
       new AdminClient().deleteClient(serviceAccountName);
     });
 
-    it("list", () => {
+    it("List", () => {
       listingPage
         .searchItem(serviceAccountName)
         .goToItemDetails(serviceAccountName);
@@ -278,7 +278,7 @@ describe("Clients test", () => {
         .checkRoles(["manage-account", "offline_access", "uma_authorization"]);
     });
 
-    it("assign", () => {
+    it("Assign", () => {
       listingPage.goToItemDetails(serviceAccountName);
       serviceAccountTab
         .goToServiceAccountTab()

--- a/cypress/integration/masthead_test.spec.ts
+++ b/cypress/integration/masthead_test.spec.ts
@@ -13,21 +13,18 @@ const listingPage = new ListingPage();
 const sidebarPage = new SidebarPage();
 
 const logOutTest = () => {
-  it("logs out", () => {
-    sidebarPage.waitForPageLoad();
-    masthead.signOut();
-    loginPage.isLogInPage();
-  });
+  sidebarPage.waitForPageLoad();
+  masthead.signOut();
+  sidebarPage.waitForPageLoad();
+  loginPage.isLogInPage();
 };
 
 const goToAcctMgtTest = () => {
-  it("opens manage account and returns to admin console", () => {
-    sidebarPage.waitForPageLoad();
-    masthead.accountManagement();
-    cy.contains("Welcome to Keycloak Account Management");
-    cy.get("#landingReferrerLink").click({ force: true });
-    masthead.checkIsAdminConsole();
-  });
+  sidebarPage.waitForPageLoad();
+  masthead.accountManagement();
+  cy.contains("Welcome to Keycloak Account Management");
+  cy.get("#landingReferrerLink").click({ force: true });
+  masthead.checkIsAdminConsole();
 };
 
 describe("Masthead tests in desktop mode", () => {
@@ -40,9 +37,9 @@ describe("Masthead tests in desktop mode", () => {
     keycloakBeforeEach();
   });
 
-  goToAcctMgtTest();
+  it("Test dropdown in desktop mode", () => {
+    goToAcctMgtTest();
 
-  it("disables header help and form field help", () => {
     sidebarPage.goToClientScopes();
     listingPage.goToItemDetails("address");
 
@@ -53,9 +50,9 @@ describe("Masthead tests in desktop mode", () => {
 
     cy.get("#view-header-subkey").should("not.exist");
     cy.findByTestId("help-label-name").should("not.exist");
-  });
 
-  logOutTest();
+    logOutTest();
+  });
 });
 
 describe("Masthead tests with kebab menu", () => {
@@ -69,13 +66,12 @@ describe("Masthead tests with kebab menu", () => {
     keycloakBeforeEach();
   });
 
-  it("shows kabab and hides regular menu", () => {
+  it("Test dropdown in mobile mode", () => {
     masthead.checkKebabShown();
+    goToAcctMgtTest();
+    logOutTest();
   });
 
   // TODO: Add test for help when using kebab menu.
   //       Feature not yet implemented for kebab.
-
-  goToAcctMgtTest();
-  logOutTest();
 });

--- a/cypress/integration/partial_export_test.spec.ts
+++ b/cypress/integration/partial_export_test.spec.ts
@@ -6,7 +6,7 @@ import AdminClient from "../support/util/AdminClient";
 import { keycloakBefore } from "../support/util/keycloak_hooks";
 
 describe("Partial realm export", () => {
-  const REALM_NAME = "partial-export-test-realm";
+  const REALM_NAME = "Partial-export-test-realm";
   const client = new AdminClient();
 
   before(() => client.createRealm(REALM_NAME));
@@ -20,18 +20,17 @@ describe("Partial realm export", () => {
   beforeEach(() => {
     keycloakBefore();
     loginPage.logIn();
-    sidebarPage.goToRealm(REALM_NAME);
-    sidebarPage.goToRealmSettings();
+    sidebarPage.goToRealm(REALM_NAME).goToRealmSettings();
     realmSettings.clickActionMenu();
     modal.open();
   });
 
-  it("closes the dialog", () => {
+  it("Closes the dialog", () => {
     modal.cancelButton().click();
     modal.exportButton().should("not.exist");
   });
 
-  it("shows a warning message", () => {
+  it("Shows a warning message", () => {
     modal.warningMessage().should("not.exist");
 
     modal.includeGroupsAndRolesSwitch().click({ force: true });
@@ -45,7 +44,7 @@ describe("Partial realm export", () => {
     modal.warningMessage().should("not.exist");
   });
 
-  it("exports the realm", () => {
+  it("Exports the realm", () => {
     modal.includeGroupsAndRolesSwitch().click({ force: true });
     modal.includeGroupsAndRolesSwitch().click({ force: true });
     modal.exportButton().click();

--- a/cypress/integration/realm_settings_client_policies_test.spec.ts
+++ b/cypress/integration/realm_settings_client_policies_test.spec.ts
@@ -104,7 +104,7 @@ describe("Realm settings client policies tab tests", () => {
   it("Should delete client-roles condition from a client profile", () => {
     realmSettingsPage.deleteClientRolesCondition();
     sidebarPage.waitForPageLoad();
-    modalUtils.confirmModal(true);
+    modalUtils.confirmModal();
     realmSettingsPage.checkConditionsListContains("client-scopes");
   });
 
@@ -184,7 +184,7 @@ describe("Realm settings client policies tab tests", () => {
     cy.wait("@save");
     masthead.closeLastAlertMessage();
     realmSettingsPage.deleteClientPolicyFromDetails();
-    modalUtils.confirmModal(true);
+    modalUtils.confirmModal();
     masthead.checkNotificationMessage("Client policy deleted");
     sidebarPage.waitForPageLoad();
     realmSettingsPage.checkEmptyPolicyList();

--- a/cypress/integration/realm_settings_client_profiles_test.spec.ts
+++ b/cypress/integration/realm_settings_client_profiles_test.spec.ts
@@ -22,8 +22,7 @@ describe("Realm settings client profiles tab tests", () => {
 
   beforeEach(() => {
     keycloakBeforeEach();
-    sidebarPage.goToRealm(realmName);
-    sidebarPage.goToRealmSettings();
+    sidebarPage.waitForPageLoad().goToRealm(realmName).goToRealmSettings();
     cy.findByTestId("rs-clientPolicies-tab").click();
     cy.findByTestId("rs-policies-clientProfiles-tab").click();
   });

--- a/cypress/integration/realm_settings_client_profiles_test.spec.ts
+++ b/cypress/integration/realm_settings_client_profiles_test.spec.ts
@@ -7,10 +7,12 @@ import {
 } from "../support/util/keycloak_hooks";
 import AdminClient from "../support/util/AdminClient";
 import ModalUtils from "../support/util/ModalUtils";
+import Masthead from "../support/pages/admin_console/Masthead";
 
 const loginPage = new LoginPage();
 const sidebarPage = new SidebarPage();
 const modalUtils = new ModalUtils();
+const masthead = new Masthead();
 
 describe("Realm settings client profiles tab tests", () => {
   const profileName = "Test";
@@ -54,8 +56,8 @@ describe("Realm settings client profiles tab tests", () => {
   it("Complete new client form and submit", () => {
     realmSettingsPage
       .createClientProfile(profileName, "Test Description")
-      .saveClientProfileCreation()
-      .checkAlertMessage("New client profile created");
+      .saveClientProfileCreation();
+    masthead.checkNotificationMessage("New client profile created");
   });
 
   it("Should perform client profile search by profile name", () => {
@@ -70,9 +72,8 @@ describe("Realm settings client profiles tab tests", () => {
     realmSettingsPage.shouldSaveChangedJSONProfiles();
     realmSettingsPage.deleteClientPolicyItemFromTable(profileName);
     modalUtils.confirmModal();
-    realmSettingsPage
-      .checkAlertMessage("Client profile deleted")
-      .checkElementNotInList(profileName);
+    masthead.checkNotificationMessage("Client profile deleted");
+    realmSettingsPage.checkElementNotInList(profileName);
   });
 
   it("Should not create duplicate client profile", () => {
@@ -83,11 +84,11 @@ describe("Realm settings client profiles tab tests", () => {
     sidebarPage.goToRealmSettings();
     realmSettingsPage.goToClientPoliciesTab().goToClientProfilesList();
 
-    modalUtils.waitForProgressbar();
+    sidebarPage.waitForPageLoad();
     realmSettingsPage
       .createClientProfile(profileName, "Test Description")
       .saveClientProfileCreation();
-    realmSettingsPage.checkAlertMessage(
+    masthead.checkNotificationMessage(
       "Could not create client profile: 'proposed client profile name duplicated.'"
     );
   });
@@ -130,7 +131,7 @@ describe("Realm settings client profiles tab tests", () => {
 
   it("Should cancel editing executor", () => {
     realmSettingsPage.openProfileDetails(editedProfileName).editExecutor(4000);
-    modalUtils.waitForProgressbar();
+    sidebarPage.waitForPageLoad();
     realmSettingsPage
       .cancelEditingExecutor()
       .checkExecutorNotInList()
@@ -142,9 +143,9 @@ describe("Realm settings client profiles tab tests", () => {
     realmSettingsPage
       .openProfileDetails(editedProfileName)
       .editExecutor(4000)
-      .saveExecutor()
-      .checkAlertMessage("Executor updated successfully")
-      .editExecutor();
+      .saveExecutor();
+    masthead.checkNotificationMessage("Executor updated successfully");
+    realmSettingsPage.editExecutor();
     // TODO: UNCOMMENT LINE WHEN ISSUE 2037 IS FIXED
     //.checkAvailablePeriodExecutor(4000);
   });
@@ -168,8 +169,7 @@ describe("Realm settings client profiles tab tests", () => {
   it("Check deleting the client profile", () => {
     realmSettingsPage.deleteClientPolicyItemFromTable(editedProfileName);
     modalUtils.confirmModal();
-    realmSettingsPage
-      .checkAlertMessage("Client profile deleted")
-      .checkElementNotInList(editedProfileName);
+    masthead.checkNotificationMessage("Client profile deleted");
+    realmSettingsPage.checkElementNotInList(editedProfileName);
   });
 });

--- a/cypress/integration/realm_settings_client_profiles_test.spec.ts
+++ b/cypress/integration/realm_settings_client_profiles_test.spec.ts
@@ -23,8 +23,7 @@ describe("Realm settings client profiles tab tests", () => {
   beforeEach(() => {
     keycloakBeforeEach();
     sidebarPage.waitForPageLoad().goToRealm(realmName).goToRealmSettings();
-    cy.findByTestId("rs-clientPolicies-tab").click();
-    cy.findByTestId("rs-policies-clientProfiles-tab").click();
+    realmSettingsPage.goToClientPoliciesTab().goToClientProfilesList();
   });
 
   before(() => {
@@ -53,9 +52,12 @@ describe("Realm settings client profiles tab tests", () => {
   });
 
   it("Complete new client form and submit", () => {
+    const url = `/auth/admin/realms/${realmName}/client-policies/profiles`;
+    cy.intercept("PUT", url).as("save");
     realmSettingsPage
       .createClientProfile(profileName, "Test Description")
       .saveClientProfileCreation();
+    cy.wait("@save");
     masthead.checkNotificationMessage("New client profile created");
   });
 
@@ -76,9 +78,12 @@ describe("Realm settings client profiles tab tests", () => {
   });
 
   it("Should not create duplicate client profile", () => {
+    const url = `/auth/admin/realms/${realmName}/client-policies/profiles`;
+    cy.intercept("PUT", url).as("save");
     realmSettingsPage
       .createClientProfile(profileName, "Test Description")
       .saveClientProfileCreation();
+    cy.wait("@save");
 
     sidebarPage.goToRealmSettings();
     realmSettingsPage.goToClientPoliciesTab().goToClientProfilesList();
@@ -87,6 +92,7 @@ describe("Realm settings client profiles tab tests", () => {
     realmSettingsPage
       .createClientProfile(profileName, "Test Description")
       .saveClientProfileCreation();
+    cy.wait("@save");
     masthead.checkNotificationMessage(
       "Could not create client profile: 'proposed client profile name duplicated.'"
     );
@@ -169,6 +175,7 @@ describe("Realm settings client profiles tab tests", () => {
     realmSettingsPage.deleteClientPolicyItemFromTable(editedProfileName);
     modalUtils.confirmModal();
     masthead.checkNotificationMessage("Client profile deleted");
+    sidebarPage.waitForPageLoad();
     realmSettingsPage.checkElementNotInList(editedProfileName);
   });
 });

--- a/cypress/integration/realm_test.spec.ts
+++ b/cypress/integration/realm_test.spec.ts
@@ -15,7 +15,12 @@ const createRealmPage = new CreateRealmPage();
 const adminClient = new AdminClient();
 
 describe("Realms test", () => {
-  const testRealmName = "Test realm";
+  const testRealmName =
+    "Test realm " + (Math.random() + 1).toString(36).substring(7);
+  const newRealmName =
+    "New Test realm " + (Math.random() + 1).toString(36).substring(7);
+  const editedRealmName =
+    "Edited Test realm " + (Math.random() + 1).toString(36).substring(7);
   describe("Realm creation", () => {
     before(() => {
       keycloakBefore();
@@ -27,7 +32,7 @@ describe("Realms test", () => {
     });
 
     after(() => {
-      [testRealmName, "one", "two"].map((realm) =>
+      [testRealmName, newRealmName, editedRealmName].map((realm) =>
         adminClient.deleteRealm(realm)
       );
     });
@@ -39,6 +44,8 @@ describe("Realms test", () => {
       masthead.checkNotificationMessage(
         "Could not create realm Conflict detected. See logs for details"
       );
+      createRealmPage.cancelRealmCreation();
+      cy.reload();
     });
 
     it("should create Test realm", () => {
@@ -50,7 +57,7 @@ describe("Realms test", () => {
 
     it("should create realm from new a realm", () => {
       sidebarPage.goToCreateRealm();
-      createRealmPage.fillRealmName("one").createRealm();
+      createRealmPage.fillRealmName(newRealmName).createRealm();
 
       const fetchUrl = "/auth/admin/realms?briefRepresentation=true";
       cy.intercept(fetchUrl).as("fetch");
@@ -60,7 +67,7 @@ describe("Realms test", () => {
       cy.wait(["@fetch"]);
 
       sidebarPage.goToCreateRealm();
-      createRealmPage.fillRealmName("two").createRealm();
+      createRealmPage.fillRealmName(editedRealmName).createRealm();
 
       masthead.checkNotificationMessage("Realm created");
 
@@ -68,7 +75,7 @@ describe("Realms test", () => {
     });
 
     it("should change to Test realm", () => {
-      sidebarPage.getCurrentRealm().should("eq", "Two");
+      sidebarPage.getCurrentRealm().should("eq", editedRealmName);
 
       sidebarPage
         .goToRealm(testRealmName)

--- a/cypress/integration/realm_user_registration.spec.ts
+++ b/cypress/integration/realm_user_registration.spec.ts
@@ -10,10 +10,12 @@ import {
   keycloakBefore,
   keycloakBeforeEach,
 } from "../support/util/keycloak_hooks";
+import ModalUtils from "../support/util/ModalUtils";
 
 describe("Realm settings - User registration tab", () => {
   const loginPage = new LoginPage();
   const sidebarPage = new SidebarPage();
+  const modalUtils = new ModalUtils();
   const masthead = new Masthead();
   const adminClient = new AdminClient();
 
@@ -37,16 +39,31 @@ describe("Realm settings - User registration tab", () => {
 
   after(() => adminClient.deleteGroups());
 
-  it("add default role", () => {
+  it("Add admin role", () => {
     const role = "admin";
-    userRegistration.addRoleButtonClick();
+    userRegistration.addRole();
+    sidebarPage.waitForPageLoad();
     userRegistration.selectRow(role).assign();
     masthead.checkNotificationMessage("Associated roles have been added");
     listingPage.searchItem(role, false).itemExist(role);
   });
 
-  it("add default role", () => {
-    userRegistration.goToDefaultGroupTab().addDefaultGroupClick();
+  it("Remove admin role", () => {
+    const role = "admin";
+    listingPage.markItemRow(role).removeMarkedItems();
+    sidebarPage.waitForPageLoad();
+    modalUtils
+      .checkModalTitle("Remove associated roles?")
+      .checkModalMessage(
+        "This action will remove the associated roles of default-roles-master. Users who have permission to default-roles-master will no longer have access to these roles."
+      )
+      .checkConfirmButtonText("Remove")
+      .confirmModal(true);
+    masthead.checkNotificationMessage("Associated roles have been removed");
+  });
+
+  it("Add default group", () => {
+    userRegistration.goToDefaultGroupTab().addDefaultGroup();
     groupPicker.checkTitle("Add default groups").clickRow(groupName).clickAdd();
     masthead.checkNotificationMessage("New group added to the default groups");
     listingPage.itemExist(groupName);

--- a/cypress/integration/realm_user_registration.spec.ts
+++ b/cypress/integration/realm_user_registration.spec.ts
@@ -58,7 +58,7 @@ describe("Realm settings - User registration tab", () => {
         "This action will remove the associated roles of default-roles-master. Users who have permission to default-roles-master will no longer have access to these roles."
       )
       .checkConfirmButtonText("Remove")
-      .confirmModal(true);
+      .confirmModal();
     masthead.checkNotificationMessage("Associated roles have been removed");
   });
 

--- a/cypress/integration/user_fed_ldap_hardcoded_mapper_test.spec.ts
+++ b/cypress/integration/user_fed_ldap_hardcoded_mapper_test.spec.ts
@@ -154,7 +154,7 @@ describe("User Fed LDAP mapper tests", () => {
     listingPage.itemExist(lastNameMapper, false);
 
     listingPage.itemExist(modifyDateMapper).deleteItem(modifyDateMapper);
-    modalUtils.checkModalTitle(mapperDeleteTitle).confirmModal(true);
+    modalUtils.checkModalTitle(mapperDeleteTitle).confirmModal();
     masthead.checkNotificationMessage(mapperDeletedSuccess, true);
     listingPage.itemExist(modifyDateMapper, false);
   });

--- a/cypress/integration/user_fed_ldap_mapper_test.spec.ts
+++ b/cypress/integration/user_fed_ldap_mapper_test.spec.ts
@@ -133,7 +133,7 @@ describe("User Fed LDAP mapper tests", () => {
     listingPage
       .itemExist(MsadAccountControlsMapper)
       .deleteItem(MsadAccountControlsMapper);
-    modalUtils.checkModalTitle(mapperDeleteTitle).confirmModal(true);
+    modalUtils.checkModalTitle(mapperDeleteTitle).confirmModal();
     masthead.checkNotificationMessage(mapperDeletedSuccess, true);
   });
 

--- a/cypress/support/pages/LoginPage.ts
+++ b/cypress/support/pages/LoginPage.ts
@@ -16,6 +16,7 @@ export default class LoginPage {
   }
 
   logIn(userName = "admin", password = "admin") {
+    cy.get('[role="progressbar"]').should("not.exist");
     cy.get(this.oldLoadContainer).should("not.exist");
     cy.get(this.loadContainer).should("not.exist");
 

--- a/cypress/support/pages/LoginPage.ts
+++ b/cypress/support/pages/LoginPage.ts
@@ -30,6 +30,7 @@ export default class LoginPage {
           cy.get(this.submitBtn).click();
         }
       });
+    cy.get('[role="progressbar"]').should("not.exist");
   }
 
   checkErrorIsDisplayed() {

--- a/cypress/support/pages/admin_console/CreateRealmPage.ts
+++ b/cypress/support/pages/admin_console/CreateRealmPage.ts
@@ -1,23 +1,12 @@
 export default class CreateRealmPage {
-  browseBtn: string;
-  clearBtn: string;
-  realmFileNameInput: string;
-  realmNameInput: string;
-  enabledSwitch: string;
-  createBtn: string;
-  cancelBtn: string;
-
-  constructor() {
-    this.browseBtn = "#kc-realm-filename-browse-button";
-    this.clearBtn = ".pf-c-file-upload__file-select button:last-child";
-    this.realmFileNameInput = "#kc-realm-filename";
-    this.realmNameInput = "#kc-realm-name";
-    this.enabledSwitch =
-      '[for="kc-realm-enabled-switch"] span.pf-c-switch__toggle';
-
-    this.createBtn = '.pf-c-form__group:last-child button[type="submit"]';
-    this.cancelBtn = '.pf-c-form__group:last-child button[type="button"]';
-  }
+  private browseBtn = "#kc-realm-filename-browse-button";
+  private clearBtn = ".pf-c-file-upload__file-select button:last-child";
+  private realmFileNameInput = "#kc-realm-filename";
+  private realmNameInput = "#kc-realm-name";
+  private enabledSwitch =
+    '[for="kc-realm-enabled-switch"] span.pf-c-switch__toggle';
+  private createBtn = '.pf-c-form__group:last-child button[type="submit"]';
+  private cancelBtn = '.pf-c-form__group:last-child button[type="button"]';
 
   fillRealmName(realmName: string) {
     cy.get(this.realmNameInput).clear().type(realmName);
@@ -27,6 +16,12 @@ export default class CreateRealmPage {
 
   createRealm() {
     cy.get(this.createBtn).click();
+
+    return this;
+  }
+
+  cancelRealmCreation() {
+    cy.get(this.cancelBtn).click();
 
     return this;
   }

--- a/cypress/support/pages/admin_console/ListingPage.ts
+++ b/cypress/support/pages/admin_console/ListingPage.ts
@@ -1,6 +1,9 @@
 export default class ListingPage {
   private searchInput = '.pf-c-toolbar__item [type="search"]:visible';
   private itemsRows = "table:visible";
+  private emptyListImg =
+    '[role="tabpanel"]:not([hidden]) [data-testid="empty-state"]';
+  private progressBar = '[role="progressbar"]';
   private itemRowDrpDwn = ".pf-c-dropdown__toggle";
   public exportBtn = '[role="menuitem"]:nth-child(1)';
   public deleteBtn = '[role="menuitem"]:nth-child(2)';
@@ -45,11 +48,17 @@ export default class ListingPage {
       const searchUrl = `/auth/admin/realms/master/*${searchValue}*`;
       cy.intercept(searchUrl).as("search");
     }
-    cy.get(this.searchInput).clear().type(searchValue);
+
+    cy.get(this.searchInput).clear();
+    if (searchValue) {
+      cy.get(this.searchInput).type(searchValue);
+    }
     cy.get(this.searchBtn).click();
+
     if (wait) {
       cy.wait(["@search"]);
     }
+
     return this;
   }
 
@@ -59,6 +68,15 @@ export default class ListingPage {
       .parentsUntil("tbody")
       .find(this.itemRowDrpDwn)
       .click();
+    return this;
+  }
+
+  checkRowColumnValue(itemName: string, column: number, value: string) {
+    cy.get(this.itemsRows)
+      .contains(itemName)
+      .parentsUntil("tbody")
+      .find("td:nth-child(" + column + ")")
+      .should("have.text", value);
     return this;
   }
 
@@ -77,6 +95,12 @@ export default class ListingPage {
 
   goToItemDetails(itemName: string) {
     cy.get(this.itemsRows).contains(itemName).click();
+
+    return this;
+  }
+
+  checkEmptyList() {
+    cy.get(this.emptyListImg).should("be.visible");
 
     return this;
   }

--- a/cypress/support/pages/admin_console/ListingPage.ts
+++ b/cypress/support/pages/admin_console/ListingPage.ts
@@ -9,9 +9,9 @@ export default class ListingPage {
   public deleteBtn = '[role="menuitem"]:nth-child(2)';
   private searchBtn =
     ".pf-c-page__main .pf-c-toolbar__content-section button.pf-m-control:visible";
-  private createBtn =
+  private listHeaderPrimaryBtn =
     ".pf-c-page__main .pf-c-toolbar__content-section .pf-m-primary:visible";
-  private importBtn =
+  private listHeaderSecondaryBtn =
     ".pf-c-page__main .pf-c-toolbar__content-section .pf-m-link";
   private previousPageBtn =
     "div[class=pf-c-pagination__nav-control] button[data-action=previous]:visible";
@@ -32,13 +32,13 @@ export default class ListingPage {
   }
 
   goToCreateItem() {
-    cy.get(this.createBtn).click();
+    cy.get(this.listHeaderPrimaryBtn).click();
 
     return this;
   }
 
   goToImportItem() {
-    cy.get(this.importBtn).click();
+    cy.get(this.listHeaderSecondaryBtn).click();
 
     return this;
   }
@@ -68,6 +68,20 @@ export default class ListingPage {
       .parentsUntil("tbody")
       .find(this.itemRowDrpDwn)
       .click();
+    return this;
+  }
+
+  markItemRow(itemName: string) {
+    cy.get(this.itemsRows)
+      .contains(itemName)
+      .parentsUntil("tbody")
+      .find('input[name*="checkrow"]')
+      .click();
+    return this;
+  }
+
+  removeMarkedItems() {
+    cy.get(this.listHeaderSecondaryBtn).contains("Remove").click();
     return this;
   }
 

--- a/cypress/support/pages/admin_console/Masthead.ts
+++ b/cypress/support/pages/admin_console/Masthead.ts
@@ -2,7 +2,11 @@ export default class Masthead {
   private menuBtn = "#nav-toggle";
   private logoBtn = "#masthead-logo";
   private helpBtn = "#help";
+  private closeAlertMessageBtn = ".pf-c-alert__action button";
+  private closeLastAlertMessageBtn =
+    ".pf-c-alert-group > li:first-child .pf-c-alert__action button";
 
+  private alertMessage = ".pf-c-alert__title";
   private userDrpDwn = "#user-dropdown";
   private userDrpDwnKebab = "#user-dropdown-kebab";
 
@@ -49,10 +53,21 @@ export default class Masthead {
   }
 
   checkNotificationMessage(message: string, closeNotification?: boolean) {
-    cy.contains(message).should("exist");
+    cy.get(this.alertMessage).should("contain.text", message);
+    //cy.get(this.alertMessage).contains(message).should("exist");
     if (closeNotification) {
-      cy.get(".pf-c-alert__action").click();
+      this.closeLastAlertMessage();
     }
+    return this;
+  }
+
+  closeLastAlertMessage() {
+    cy.get(this.closeLastAlertMessageBtn).click();
+    return this;
+  }
+
+  closeAllAlertMessages() {
+    cy.get(this.closeAlertMessageBtn).click({ multiple: true });
     return this;
   }
 

--- a/cypress/support/pages/admin_console/Masthead.ts
+++ b/cypress/support/pages/admin_console/Masthead.ts
@@ -54,7 +54,6 @@ export default class Masthead {
 
   checkNotificationMessage(message: string, closeNotification?: boolean) {
     cy.get(this.alertMessage).should("contain.text", message);
-    //cy.get(this.alertMessage).contains(message).should("exist");
     if (closeNotification) {
       this.closeLastAlertMessage();
     }

--- a/cypress/support/pages/admin_console/Masthead.ts
+++ b/cypress/support/pages/admin_console/Masthead.ts
@@ -71,7 +71,7 @@ export default class Masthead {
   }
 
   checkKebabShown() {
-    cy.get(this.userDrpDwn).should("not.exist");
+    cy.get(this.userDrpDwn).should("not.be.visible");
     cy.get(this.userDrpDwnKebab).should("exist");
 
     return this;

--- a/cypress/support/pages/admin_console/SidebarPage.ts
+++ b/cypress/support/pages/admin_console/SidebarPage.ts
@@ -1,6 +1,6 @@
 export default class SidebarPage {
-  private realmsDrpDwn = '[data-testid="realmSelectorToggle"]';
-  private realmsList = "#realm-select ul";
+  private realmsDrpDwn = '[data-testid="realmSelector"] > button';
+  private realmsList = '[data-testid="realmSelector"] > div ul';
   private createRealmBtn = "add-realm";
 
   private clientsBtn = "#nav-item-clients";

--- a/cypress/support/pages/admin_console/SidebarPage.ts
+++ b/cypress/support/pages/admin_console/SidebarPage.ts
@@ -82,6 +82,7 @@ export default class SidebarPage {
 
   goToRealmSettings() {
     cy.get(this.realmSettingsBtn).click({ force: true });
+    this.waitForPageLoad();
 
     return this;
   }

--- a/cypress/support/pages/admin_console/SidebarPage.ts
+++ b/cypress/support/pages/admin_console/SidebarPage.ts
@@ -39,48 +39,63 @@ export default class SidebarPage {
   }
 
   goToClients() {
+    this.waitForPageLoad();
     cy.get(this.clientsBtn).scrollIntoView().click({ force: true });
+    this.waitForPageLoad();
 
     return this;
   }
 
   goToClientScopes() {
+    this.waitForPageLoad();
     cy.get(this.clientScopesBtn).scrollIntoView().click();
+    this.waitForPageLoad();
 
     return this;
   }
 
   goToRealmRoles() {
+    this.waitForPageLoad();
     cy.get(this.realmRolesBtn).click();
+    this.waitForPageLoad();
 
     return this;
   }
 
   goToUsers() {
+    this.waitForPageLoad();
     cy.get(this.usersBtn).click();
+    this.waitForPageLoad();
 
     return this;
   }
 
   goToGroups() {
+    this.waitForPageLoad();
     cy.get(this.groupsBtn).click();
+    this.waitForPageLoad();
 
     return this;
   }
 
   goToSessions() {
+    this.waitForPageLoad();
     cy.get(this.sessionsBtn).click();
+    this.waitForPageLoad();
 
     return this;
   }
 
   goToEvents() {
+    this.waitForPageLoad();
     cy.get(this.eventsBtn).click();
+    this.waitForPageLoad();
 
     return this;
   }
 
   goToRealmSettings() {
+    this.waitForPageLoad();
     cy.get(this.realmSettingsBtn).click({ force: true });
     this.waitForPageLoad();
 
@@ -88,18 +103,23 @@ export default class SidebarPage {
   }
 
   goToAuthentication() {
+    this.waitForPageLoad();
     cy.get(this.authenticationBtn).click();
+    this.waitForPageLoad();
 
     return this;
   }
 
   goToIdentityProviders() {
+    this.waitForPageLoad();
     cy.get(this.identityProvidersBtn).click();
+    this.waitForPageLoad();
 
     return this;
   }
 
   goToUserFederation() {
+    this.waitForPageLoad();
     cy.get(this.userFederationBtn).click();
     this.waitForPageLoad();
 

--- a/cypress/support/pages/admin_console/SidebarPage.ts
+++ b/cypress/support/pages/admin_console/SidebarPage.ts
@@ -1,6 +1,6 @@
 export default class SidebarPage {
-  private realmsDrpDwn = '[data-testid="realmSelector"] > button';
-  private realmsList = '[data-testid="realmSelector"] > div ul';
+  private realmsDrpDwn = "#realm-select button.pf-c-dropdown__toggle";
+  private realmsList = '#realm-select ul[role="menu"]';
   private createRealmBtn = "add-realm";
 
   private clientsBtn = "#nav-item-clients";

--- a/cypress/support/pages/admin_console/SidebarPage.ts
+++ b/cypress/support/pages/admin_console/SidebarPage.ts
@@ -1,5 +1,5 @@
 export default class SidebarPage {
-  private realmsDrpDwn = "realmSelectorToggle";
+  private realmsDrpDwn = '[data-testid="realmSelectorToggle"]';
   private realmsList = "#realm-select ul";
   private createRealmBtn = "add-realm";
 
@@ -17,20 +17,23 @@ export default class SidebarPage {
   private userFederationBtn = "#nav-item-user-federation";
 
   getCurrentRealm() {
-    return cy.findByTestId(this.realmsDrpDwn).scrollIntoView().invoke("text");
+    return cy.get(this.realmsDrpDwn).scrollIntoView().invoke("text");
   }
 
   goToRealm(realmName: string) {
-    cy.findByTestId(this.realmsDrpDwn).scrollIntoView().click({ force: true });
+    this.waitForPageLoad();
+    cy.get(this.realmsDrpDwn).scrollIntoView().click({ force: true });
     cy.get(this.realmsList).contains(realmName).click({ force: true });
+    this.waitForPageLoad();
 
     return this;
   }
 
   goToCreateRealm() {
-    cy.findByTestId(this.realmsDrpDwn).scrollIntoView();
-    cy.findByTestId(this.realmsDrpDwn).click();
-    cy.findByTestId(this.createRealmBtn).click();
+    this.waitForPageLoad();
+    cy.get(this.realmsDrpDwn).scrollIntoView().click({ force: true });
+    cy.findByTestId(this.createRealmBtn).click({ force: true });
+    this.waitForPageLoad();
 
     return this;
   }

--- a/cypress/support/pages/admin_console/SidebarPage.ts
+++ b/cypress/support/pages/admin_console/SidebarPage.ts
@@ -1,8 +1,6 @@
-import { capitalize } from "lodash-es";
-
 export default class SidebarPage {
   private realmsDrpDwn = "realmSelectorToggle";
-  private realmsList = "realmSelector";
+  private realmsList = "#realm-select ul";
   private createRealmBtn = "add-realm";
 
   private clientsBtn = "#nav-item-clients";
@@ -23,10 +21,8 @@ export default class SidebarPage {
   }
 
   goToRealm(realmName: string) {
-    cy.findByTestId(this.realmsList).scrollIntoView().click();
-    cy.findByTestId(this.realmsList).within(() => {
-      cy.get("ul").contains(capitalize(realmName)).click();
-    });
+    cy.findByTestId(this.realmsDrpDwn).scrollIntoView().click({ force: true });
+    cy.get(this.realmsList).contains(realmName).click({ force: true });
 
     return this;
   }
@@ -101,13 +97,13 @@ export default class SidebarPage {
 
   goToUserFederation() {
     cy.get(this.userFederationBtn).click();
-    cy.wait(1000);
+    this.waitForPageLoad();
 
     return this;
   }
 
   waitForPageLoad() {
-    cy.get(".pf-c-spinner__tail-ball").should("not.exist");
+    cy.get('[role="progressbar"]').should("not.exist");
     return this;
   }
 }

--- a/cypress/support/pages/admin_console/manage/clients/InitialAccessTokenTab.ts
+++ b/cypress/support/pages/admin_console/manage/clients/InitialAccessTokenTab.ts
@@ -5,6 +5,7 @@ export default class InitialAccessTokenTab {
 
   private expirationInput = "expiration";
   private countInput = "count";
+  private countPlusBtn = '[data-testid="count"] [aria-label="Plus"]';
   private saveBtn = "save";
 
   goToInitialAccessTokenTab() {
@@ -22,8 +23,8 @@ export default class InitialAccessTokenTab {
     return this;
   }
 
-  getFistId(callback: (id: string) => void) {
-    cy.get('tbody > tr > [data-label="ID"]')
+  getFirstId(callback: (id: string) => void) {
+    cy.get('tbody > tr:first-child > [data-label="ID"]')
       .invoke("text")
       .then((text) => {
         callback(text);
@@ -31,10 +32,19 @@ export default class InitialAccessTokenTab {
     return this;
   }
 
-  createNewToken(expiration: number, count: number) {
+  goToCreateFromEmptyList() {
     cy.findByTestId(this.emptyAction).click();
-    cy.findByTestId(this.expirationInput).type(`${expiration}`);
-    cy.findByTestId(this.countInput).type(`${count}`);
+    return this;
+  }
+
+  fillNewTokenData(expiration: number, count: number) {
+    cy.findByTestId(this.expirationInput).clear().type(`${expiration}`);
+    cy.findByTestId(this.countInput).clear();
+
+    for (let i = 0; i < count; i++) {
+      cy.get(this.countPlusBtn).click();
+    }
+
     return this;
   }
 

--- a/cypress/support/pages/admin_console/manage/providers/PriorityDialog.ts
+++ b/cypress/support/pages/admin_console/manage/providers/PriorityDialog.ts
@@ -22,7 +22,7 @@ export default class PriorityDialog {
   }
 
   clickSave() {
-    cy.get("#modal-confirm").click();
+    cy.get("#modal-confirm").click({ force: true });
     return this;
   }
 

--- a/cypress/support/pages/admin_console/manage/realm_settings/RealmSettingsPage.ts
+++ b/cypress/support/pages/admin_console/manage/realm_settings/RealmSettingsPage.ts
@@ -1100,7 +1100,7 @@ export default class RealmSettingsPage {
   }
 
   deleteClientPolicyFromDetails() {
-    cy.get(this.clientPolicyDrpDwn).click();
+    cy.get(this.clientPolicyDrpDwn).click({ force: true });
     cy.findByTestId(this.deleteclientPolicyDrpDwn).click({ force: true });
     return this;
   }

--- a/cypress/support/pages/admin_console/manage/realm_settings/RealmSettingsPage.ts
+++ b/cypress/support/pages/admin_console/manage/realm_settings/RealmSettingsPage.ts
@@ -554,13 +554,13 @@ export default class RealmSettingsPage {
   }
 
   shouldRemoveEventFromEventListener() {
-    cy.get(this.eventListenerRemove).first().click();
+    cy.get(this.eventListenerRemove).last().click();
     cy.findByTestId(this.eventListenersSaveBtn).click();
     cy.get(this.alertMessage).should(
       "be.visible",
       "Event listener has been updated."
     );
-    cy.get(this.eventListenersDrpDwn).should("not.have.text", "jboss-logging");
+    cy.get(this.eventListenersDrpDwn).should("not.have.text", "email");
   }
 
   shouldRemoveAllEventListeners() {

--- a/cypress/support/pages/admin_console/manage/realm_settings/RealmSettingsPage.ts
+++ b/cypress/support/pages/admin_console/manage/realm_settings/RealmSettingsPage.ts
@@ -179,6 +179,7 @@ export default class RealmSettingsPage {
   private jsonEditor = ".monaco-scrollable-element.editor-scrollable.vs";
   private createClientDrpDwn = ".pf-c-dropdown.pf-m-align-right";
   private clientPolicyDrpDwn = "action-dropdown";
+  private deleteclientPolicyDrpDwn = "deleteClientPolicyDropdown";
   private searchFld = "[id^=realm-settings][id$=profilesinput]";
   private searchFldPolicies = "[id^=realm-settings][id$=clientPoliciesinput]";
   private clientProfileOne =
@@ -330,6 +331,17 @@ export default class RealmSettingsPage {
     cy.findByTestId(this.confirmAddBundle).click();
 
     return this;
+  }
+
+  deleteProvider(providerName: string) {
+    cy.findAllByTestId("provider-name-link")
+      .contains(providerName)
+      .parent()
+      .siblings(".pf-c-data-list__item-action")
+      .click()
+      .findByTestId(this.deleteAction)
+      .click();
+    cy.wait(500).findByTestId(this.modalConfirm).click();
   }
 
   enterConsoleDisplayName(name: string) {
@@ -935,19 +947,6 @@ export default class RealmSettingsPage {
     );
   }
 
-  shouldCompleteAndCreateNewClientPolicyFromEmptyState() {
-    cy.findByTestId(this.createPolicyEmptyStateBtn).click();
-    cy.findByTestId(this.newClientPolicyNameInput).type("Test");
-    cy.findByTestId(this.newClientPolicyDescriptionInput).type(
-      "Test Description"
-    );
-    cy.findByTestId(this.saveNewClientPolicyBtn).click();
-    cy.get(this.alertMessage).should(
-      "be.visible",
-      "New client profile created"
-    );
-  }
-
   shouldSearchClientPolicy() {
     cy.get(this.searchFldPolicies).click({ force: true }).type("Test").click();
     cy.get("table").should("be.visible").contains("td", "Test");
@@ -1024,7 +1023,6 @@ export default class RealmSettingsPage {
     cy.intercept(`/auth/admin/realms/${this.realmName}/client-scopes`).as(
       "clientScopes"
     );
-
     cy.get(this.clientPolicy).click();
     cy.findByTestId(this.addCondition).click();
     cy.get(this.addConditionDrpDwn).click();
@@ -1065,6 +1063,7 @@ export default class RealmSettingsPage {
       "clientScopes"
     );
     cy.get(this.clientPolicy).click();
+
     cy.findByTestId(this.clientScopesConditionLink).click();
 
     cy.wait("@clientScopes");
@@ -1125,27 +1124,24 @@ export default class RealmSettingsPage {
     cy.get("table").should("not.have.text", "Test");
   }
 
-  shouldRemoveClientPolicyFromCreateView() {
+  createNewClientPolicyFromEmptyState(name: string, description: string) {
     cy.findByTestId(this.createPolicyEmptyStateBtn).click();
-    cy.findByTestId(this.newClientPolicyNameInput).type("Test again");
-    cy.findByTestId(this.newClientPolicyDescriptionInput).type(
-      "Test Again Description"
-    );
-    cy.intercept(
-      "PUT",
-      `/auth/admin/realms/${this.realmName}/client-policies/policies`
-    ).as("save");
-
+    cy.findByTestId(this.newClientPolicyNameInput).type(name);
+    cy.findByTestId(this.newClientPolicyDescriptionInput).type(description);
     cy.findByTestId(this.saveNewClientPolicyBtn).click();
-    cy.get(this.alertMessage).should("be.visible", "New client policy created");
-    cy.wait("@save");
-    cy.get(".pf-c-alert").should("not.exist");
+  }
 
+  checkAlertMessage(message: string) {
+    cy.get(this.alertMessage).should("be.visible", message);
+  }
+
+  deleteClientPolicy() {
     cy.findByTestId(this.clientPolicyDrpDwn).contains("Action").click();
-    cy.findByTestId("deleteClientPolicyDropdown").click();
-    cy.findByTestId(this.modalConfirm).contains("Delete").click();
-    cy.get(this.alertMessage).should("be.visible", "Client profile deleted");
-    cy.findByTestId(this.createPolicyEmptyStateBtn).should("exist");
+    cy.findByTestId(this.deleteclientPolicyDrpDwn).click();
+  }
+
+  checkTextIsNotInTable(text: string) {
+    cy.get("table").should("not.have.text", text);
   }
 
   shouldReloadJSONPolicies() {

--- a/cypress/support/pages/admin_console/manage/realm_settings/RealmSettingsPage.ts
+++ b/cypress/support/pages/admin_console/manage/realm_settings/RealmSettingsPage.ts
@@ -619,7 +619,9 @@ export default class RealmSettingsPage {
   }
 
   cancelDeleteClientPolicy() {
-    cy.get(this.deleteDialogCancelBtn).contains("Cancel").click({ force: true });
+    cy.get(this.deleteDialogCancelBtn)
+      .contains("Cancel")
+      .click({ force: true });
     cy.get("table").should("be.visible").contains("td", "Test");
     return this;
   }

--- a/cypress/support/pages/admin_console/manage/realm_settings/RealmSettingsPage.ts
+++ b/cypress/support/pages/admin_console/manage/realm_settings/RealmSettingsPage.ts
@@ -779,7 +779,7 @@ export default class RealmSettingsPage {
   }
 
   cancelEditingExecutor() {
-    cy.get(this.addExecutorCancelBtn).contains("Cancel").click();
+    cy.get(this.addExecutorCancelBtn).contains("Cancel").click({ force: true });
     return this;
   }
 

--- a/cypress/support/pages/admin_console/manage/realm_settings/RealmSettingsPage.ts
+++ b/cypress/support/pages/admin_console/manage/realm_settings/RealmSettingsPage.ts
@@ -168,8 +168,6 @@ export default class RealmSettingsPage {
   private saveNewClientPolicyBtn = "saveCreatePolicy";
   private cancelNewClientPolicyBtn = "cancelCreatePolicy";
   private alertMessage = ".pf-c-alert__title";
-  private alertMessageCloseBtn =
-    ".pf-c-alert-group > li:first-child .pf-c-alert__action button";
   private moreDrpDwn = ".pf-c-dropdown__toggle.pf-m-plain";
   private moreDrpDwnItems = ".pf-c-dropdown__menu-item";
   private deleteDialogTitle = ".pf-c-modal-box__title-text";
@@ -222,8 +220,8 @@ export default class RealmSettingsPage {
   private eventListenerRemove = '[data-ouia-component-id="Remove"]';
   private roleSelect = ".pf-c-select.kc-role-select";
   private selectScopeButton = "select-scope-button";
-  private deleteClientRolesCondition = "delete-client-roles-condition";
-  private deleteClientScopesCondition = "delete-client-scopes-condition";
+  private deleteClientRolesConditionBtn = "delete-client-roles-condition";
+  private deleteClientScopesConditionBtn = "delete-client-scopes-condition";
 
   private realmName?: string;
   constructor(realmName?: string) {
@@ -1031,34 +1029,20 @@ export default class RealmSettingsPage {
     );
   }
 
-  shouldCancelDeletingCondition() {
-    cy.get(this.clientPolicy).click();
-    cy.findByTestId(this.deleteClientRolesCondition).click();
-    cy.get(this.deleteDialogTitle).contains("Delete condition?");
-    cy.get(this.deleteDialogBodyText).contains(
-      "This action will permanently delete client-roles. This cannot be undone."
-    );
-    cy.findByTestId(this.modalConfirm).contains("Delete");
-    cy.get(this.deleteDialogCancelBtn).contains("Cancel");
-    cy.get(this.deleteDialogCancelBtn).click();
-    cy.get('ul[class*="pf-c-data-list"]').contains("client-roles");
+  checkConditionsListContains(name: string) {
+    cy.get('ul[class*="pf-c-data-list"]').contains(name);
+    return this;
   }
 
-  shouldDeleteClientRolesCondition() {
+  deleteClientRolesCondition() {
     cy.get(this.clientPolicy).click();
-    cy.findByTestId(this.deleteClientRolesCondition).click();
-    cy.get(this.deleteDialogTitle).contains("Delete condition?");
-    cy.get(this.deleteDialogBodyText).contains(
-      "This action will permanently delete client-roles. This cannot be undone."
-    );
-    cy.findByTestId(this.modalConfirm).contains("Delete");
-    cy.findByTestId(this.modalConfirm).click();
-    cy.get('ul[class*="pf-c-data-list"]').contains("client-scopes");
+    cy.findByTestId(this.deleteClientRolesConditionBtn).click();
+    return this;
   }
 
   shouldDeleteClientScopesCondition() {
     cy.get(this.clientPolicy).click();
-    cy.findByTestId(this.deleteClientScopesCondition).click();
+    cy.findByTestId(this.deleteClientScopesConditionBtn).click();
     cy.get(this.deleteDialogTitle).contains("Delete condition?");
     cy.get(this.deleteDialogBodyText).contains(
       "This action will permanently delete client-scopes. This cannot be undone."
@@ -1100,15 +1084,6 @@ export default class RealmSettingsPage {
     return this;
   }
 
-  checkAlertMessage(message: string) {
-    cy.get(this.alertMessage).should("contain.text", message);
-    return this;
-  }
-
-  closeAlertMessage() {
-    cy.get(this.alertMessageCloseBtn).click();
-    return this;
-  }
   checkEmptyPolicyList() {
     cy.findByTestId(this.createPolicyEmptyStateBtn).should("exist");
     return this;
@@ -1126,7 +1101,7 @@ export default class RealmSettingsPage {
 
   deleteClientPolicyFromDetails() {
     cy.get(this.clientPolicyDrpDwn).click();
-    cy.findByTestId(this.deleteclientPolicyDrpDwn).click();
+    cy.findByTestId(this.deleteclientPolicyDrpDwn).click({ force: true });
     return this;
   }
 

--- a/cypress/support/pages/admin_console/manage/realm_settings/UserRegistration.ts
+++ b/cypress/support/pages/admin_console/manage/realm_settings/UserRegistration.ts
@@ -1,9 +1,9 @@
 export default class UserRegistration {
   private userRegistrationTab = "rs-userRegistration-tab";
   private defaultGroupTab = "#pf-tab-20-groups";
-  private addRoleButton = "add-role-button";
-  private addDefaultGroup = "no-default-groups-empty-action";
-  private namesColumn = 'td[data-label="Role name"]:visible';
+  private addRoleBtn = "add-role-button";
+  private addDefaultGroupBtn = "no-default-groups-empty-action";
+  private namesColumn = 'tbody td[data-label="Role name"]:visible';
   private addBtn = "add-associated-roles-button";
 
   goToTab() {
@@ -16,13 +16,13 @@ export default class UserRegistration {
     return this;
   }
 
-  addRoleButtonClick() {
-    cy.findByTestId(this.addRoleButton).click({ force: true });
+  addRole() {
+    cy.findByTestId(this.addRoleBtn).click({ force: true });
     return this;
   }
 
-  addDefaultGroupClick() {
-    cy.findByTestId(this.addDefaultGroup).click();
+  addDefaultGroup() {
+    cy.findByTestId(this.addDefaultGroupBtn).click();
     return this;
   }
 

--- a/cypress/support/util/ModalUtils.ts
+++ b/cypress/support/util/ModalUtils.ts
@@ -14,14 +14,20 @@ export default class ModalUtils {
     return this;
   }
 
-  cancelModal() {
-    cy.findByTestId(this.cancelModalBtn).click();
+  checkConfirmButtonText(text: string) {
+    cy.findByTestId(this.confirmModalBtn).contains(text);
 
     return this;
   }
 
-  waitForProgressbar() {
-    cy.get(this.progressBar).should("not.exist");
+  cancelModal(force = false) {
+    cy.findByTestId(this.cancelModalBtn).click({ force });
+
+    return this;
+  }
+
+  cancelButtonContains(text: string) {
+    cy.findByTestId(this.cancelModalBtn).contains(text);
 
     return this;
   }
@@ -32,8 +38,8 @@ export default class ModalUtils {
     return this;
   }
 
-  closeModal() {
-    cy.get(this.closeModalBtn).click();
+  closeModal(force = false) {
+    cy.get(this.closeModalBtn).click({ force });
 
     return this;
   }

--- a/cypress/support/util/ModalUtils.ts
+++ b/cypress/support/util/ModalUtils.ts
@@ -6,6 +6,7 @@ export default class ModalUtils {
   private cancelModalBtn = "cancel";
   private closeModalBtn = ".pf-c-modal-box .pf-m-plain";
   private copyToClipboardBtn = '[id*="copy-button"]';
+  private progressBar = '[role="progressbar"]';
 
   confirmModal(force = false) {
     cy.findByTestId(this.confirmModalBtn).click({ force });
@@ -15,6 +16,12 @@ export default class ModalUtils {
 
   cancelModal() {
     cy.findByTestId(this.cancelModalBtn).click();
+
+    return this;
+  }
+
+  waitForProgressbar() {
+    cy.get(this.progressBar).should("not.exist");
 
     return this;
   }

--- a/cypress/support/util/ModalUtils.ts
+++ b/cypress/support/util/ModalUtils.ts
@@ -6,10 +6,9 @@ export default class ModalUtils {
   private cancelModalBtn = "cancel";
   private closeModalBtn = ".pf-c-modal-box .pf-m-plain";
   private copyToClipboardBtn = '[id*="copy-button"]';
-  private progressBar = '[role="progressbar"]';
 
-  confirmModal(force = false) {
-    cy.findByTestId(this.confirmModalBtn).click({ force });
+  confirmModal() {
+    cy.findByTestId(this.confirmModalBtn).click({ force: true });
 
     return this;
   }
@@ -20,8 +19,8 @@ export default class ModalUtils {
     return this;
   }
 
-  cancelModal(force = false) {
-    cy.findByTestId(this.cancelModalBtn).click({ force });
+  cancelModal() {
+    cy.findByTestId(this.cancelModalBtn).click({ force: true });
 
     return this;
   }
@@ -38,8 +37,8 @@ export default class ModalUtils {
     return this;
   }
 
-  closeModal(force = false) {
-    cy.get(this.closeModalBtn).click({ force });
+  closeModal() {
+    cy.get(this.closeModalBtn).click({ force: true });
 
     return this;
   }

--- a/cypress/support/util/ModalUtils.ts
+++ b/cypress/support/util/ModalUtils.ts
@@ -5,6 +5,7 @@ export default class ModalUtils {
   private confirmModalBtn = "confirm";
   private cancelModalBtn = "cancel";
   private closeModalBtn = ".pf-c-modal-box .pf-m-plain";
+  private copyToClipboardBtn = '[id*="copy-button"]';
 
   confirmModal(force = false) {
     cy.findByTestId(this.confirmModalBtn).click({ force });
@@ -14,6 +15,12 @@ export default class ModalUtils {
 
   cancelModal() {
     cy.findByTestId(this.cancelModalBtn).click();
+
+    return this;
+  }
+
+  copyToClipboard() {
+    cy.get(this.copyToClipboardBtn).click();
 
     return this;
   }

--- a/cypress/support/util/keycloak_hooks.ts
+++ b/cypress/support/util/keycloak_hooks.ts
@@ -11,9 +11,7 @@ export const keycloakBefore = () => {
     console.log("--------------------");
     return false;
   });
-  cy.reload();
-  cy.get('[role="progressbar"]').should("not.exist");
-  cy.visit("/#/");
+  cy.visit("");
   cy.get('[role="progressbar"]').should("not.exist");
 };
 

--- a/cypress/support/util/keycloak_hooks.ts
+++ b/cypress/support/util/keycloak_hooks.ts
@@ -11,7 +11,8 @@ export const keycloakBefore = () => {
     console.log("--------------------");
     return false;
   });
-  cy.visit("");
+  cy.reload();
+  cy.visit("/#/");
 };
 
 export const keycloakBeforeEach = () => {

--- a/cypress/support/util/keycloak_hooks.ts
+++ b/cypress/support/util/keycloak_hooks.ts
@@ -14,6 +14,7 @@ export const keycloakBefore = () => {
   cy.reload();
   cy.get('[role="progressbar"]').should("not.exist");
   cy.visit("/#/");
+  cy.get('[role="progressbar"]').should("not.exist");
 };
 
 export const keycloakBeforeEach = () => {

--- a/cypress/support/util/keycloak_hooks.ts
+++ b/cypress/support/util/keycloak_hooks.ts
@@ -12,6 +12,7 @@ export const keycloakBefore = () => {
     return false;
   });
   cy.reload();
+  cy.get('[role="progressbar"]').should("not.exist");
   cy.visit("/#/");
 };
 

--- a/src/clients/messages.ts
+++ b/src/clients/messages.ts
@@ -293,7 +293,7 @@ export default {
     tokenDeleteConfirm:
       "Are you sure you want to permanently delete the initial access token {{id}}",
     tokenDeleteConfirmTitle: "Delete initial access token?",
-    tokenDeleteSuccess: "initial access token created successfully",
+    tokenDeleteSuccess: "Initial access token deleted successfully",
     tokenDeleteError: "Could not delete initial access token: '{{error}}'",
     timestamp: "Created date",
     created: "Created",


### PR DESCRIPTION
## Motivation
Adds tests to Clients for the List and Initial Access Token screens and fix a notification message

## Brief Description
Adds tests to Clients for the List and Initial Access Token screens and fix the notification message when deleting an initial access token fixing issue #1936 

## Checklist:

- [ x] Code has been tested locally by PR requester
- [ ] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated

