### PR TITLE
Add priorities to User Federation

### DIFF
--- a/cypress/integration/user_fed_kerberos_test.spec.ts
+++ b/cypress/integration/user_fed_kerberos_test.spec.ts
@@ -4,6 +4,7 @@ import ProviderPage from "../support/pages/admin_console/manage/providers/Provid
 import Masthead from "../support/pages/admin_console/Masthead";
 import ModalUtils from "../support/util/ModalUtils";
 import { keycloakBefore } from "../support/util/keycloak_hooks";
+import PriorityDialog from "../support/pages/admin_console/manage/providers/PriorityDialog";
 
 const loginPage = new LoginPage();
 const masthead = new Masthead();
@@ -14,15 +15,25 @@ const modalUtils = new ModalUtils();
 const provider = "kerberos";
 const initCapProvider = provider.charAt(0).toUpperCase() + provider.slice(1);
 
-const firstKerberosName = "my-kerberos";
-const firstKerberosRealm = "my-realm";
-const firstKerberosPrincipal = "my-principal";
-const firstKerberosKeytab = "my-keytab";
+const kerberosName = "my-kerberos";
+const kerberosRealm = "my-realm";
+const kerberosPrincipal = "my-principal";
+const kerberosKeytab = "my-keytab";
 
-const secondKerberosName = `${firstKerberosName}-2`;
-const secondKerberosRealm = `${firstKerberosRealm}-2`;
-const secondKerberosPrincipal = `${firstKerberosPrincipal}-2`;
-const secondKerberosKeytab = `${firstKerberosKeytab}-2`;
+const firstKerberosName = `${kerberosName}-1`;
+const firstKerberosRealm = `${kerberosRealm}-1`;
+const firstKerberosPrincipal = `${kerberosPrincipal}-1`;
+const firstKerberosKeytab = `${kerberosKeytab}-1`;
+
+const secondKerberosName = `${kerberosName}-2`;
+const secondKerberosRealm = `${kerberosRealm}-2`;
+const secondKerberosPrincipal = `${kerberosPrincipal}-2`;
+const secondKerberosKeytab = `${kerberosKeytab}-2`;
+
+const thirdKerberosName = `${kerberosName}-3`;
+const thirdKerberosRealm = `${kerberosRealm}-3`;
+const thirdKerberosPrincipal = `${kerberosPrincipal}-3`;
+const thirdKerberosKeytab = `${kerberosKeytab}-3`;
 
 const defaultPolicy = "DEFAULT";
 const newPolicy = "EVICT_WEEKLY";
@@ -39,6 +50,8 @@ const savedSuccessMessage = "User federation provider successfully saved";
 const deletedSuccessMessage = "The user federation provider has been deleted.";
 const deleteModalTitle = "Delete user federation provider?";
 const disableModalTitle = "Disable user federation provider?";
+const changeSuccessMsg =
+  "Successfully changed the priority order of user federation providers";
 
 describe("User Fed Kerberos tests", () => {
   beforeEach(() => {
@@ -142,16 +155,54 @@ describe("User Fed Kerberos tests", () => {
     sidebarPage.goToUserFederation();
   });
 
+  it("Change the priority order of Kerberos providers", () => {
+    const priorityDialog = new PriorityDialog();
+    const providers = [
+      firstKerberosName,
+      secondKerberosName,
+      thirdKerberosName,
+    ];
+
+    sidebarPage.goToUserFederation();
+    providersPage.clickMenuCommand(addProviderMenu, initCapProvider);
+
+    providersPage.fillKerberosRequiredData(
+      thirdKerberosName,
+      thirdKerberosRealm,
+      thirdKerberosPrincipal,
+      thirdKerberosKeytab
+    );
+    providersPage.save(provider);
+    masthead.checkNotificationMessage(createdSuccessMessage, true);
+
+    sidebarPage.goToUserFederation();
+    priorityDialog.openDialog().checkOrder(providers);
+
+    priorityDialog.moveRowTo(firstKerberosName, thirdKerberosName);
+    priorityDialog.clickSave();
+    masthead.checkNotificationMessage(changeSuccessMsg, true);
+    /*
+    Drag and drop is working in product but not in cypress. Order should be
+    validated with the following if the cypress issue is ever resolved.
+     
+    priorityDialog
+      .openDialog()
+      .checkOrder([secondKerberosName, thirdKerberosName, firstKerberosName]);
+    */
+  });
+
   it("Delete a Kerberos provider from card view using the card's menu", () => {
     providersPage.deleteCardFromCard(secondKerberosName);
-
-    modalUtils.checkModalTitle(deleteModalTitle).confirmModal();
+    modalUtils.confirmModal(true);
     masthead.checkNotificationMessage(deletedSuccessMessage);
   });
 
   it("Delete a Kerberos provider using the Settings view's Action menu", () => {
-    providersPage.deleteCardFromMenu(firstKerberosName);
+    providersPage.deleteCardFromMenu(thirdKerberosName);
+    modalUtils.checkModalTitle(deleteModalTitle).confirmModal();
+    masthead.checkNotificationMessage(deletedSuccessMessage);
 
+    providersPage.deleteCardFromMenu(firstKerberosName);
     modalUtils.checkModalTitle(deleteModalTitle).confirmModal();
     masthead.checkNotificationMessage(deletedSuccessMessage);
   });

--- a/cypress/integration/user_fed_kerberos_test.spec.ts
+++ b/cypress/integration/user_fed_kerberos_test.spec.ts
@@ -177,13 +177,16 @@ describe("User Fed Kerberos tests", () => {
 
     sidebarPage.goToUserFederation();
     priorityDialog.openDialog().checkOrder(providers);
+    priorityDialog.clickSave();
+    masthead.checkNotificationMessage(changeSuccessMsg, true);
+
+    /*
+    Drag and drop is working in product but not in cypress. Order should be
+    validated with the following if the cypress issue is ever resolved.
 
     priorityDialog.moveRowTo(firstKerberosName, thirdKerberosName);
     priorityDialog.clickSave();
     masthead.checkNotificationMessage(changeSuccessMsg, true);
-    /*
-    Drag and drop is working in product but not in cypress. Order should be
-    validated with the following if the cypress issue is ever resolved.
      
     priorityDialog
       .openDialog()

--- a/cypress/integration/user_fed_kerberos_test.spec.ts
+++ b/cypress/integration/user_fed_kerberos_test.spec.ts
@@ -193,7 +193,7 @@ describe("User Fed Kerberos tests", () => {
 
   it("Delete a Kerberos provider from card view using the card's menu", () => {
     providersPage.deleteCardFromCard(secondKerberosName);
-    modalUtils.confirmModal(true);
+    modalUtils.checkModalTitle(deleteModalTitle).confirmModal();
     masthead.checkNotificationMessage(deletedSuccessMessage);
   });
 

--- a/cypress/integration/user_fed_kerberos_test.spec.ts
+++ b/cypress/integration/user_fed_kerberos_test.spec.ts
@@ -30,11 +30,6 @@ const secondKerberosRealm = `${kerberosRealm}-2`;
 const secondKerberosPrincipal = `${kerberosPrincipal}-2`;
 const secondKerberosKeytab = `${kerberosKeytab}-2`;
 
-const thirdKerberosName = `${kerberosName}-3`;
-const thirdKerberosRealm = `${kerberosRealm}-3`;
-const thirdKerberosPrincipal = `${kerberosPrincipal}-3`;
-const thirdKerberosKeytab = `${kerberosKeytab}-3`;
-
 const defaultPolicy = "DEFAULT";
 const newPolicy = "EVICT_WEEKLY";
 const defaultKerberosDay = "Sunday";
@@ -157,41 +152,15 @@ describe("User Fed Kerberos tests", () => {
 
   it("Change the priority order of Kerberos providers", () => {
     const priorityDialog = new PriorityDialog();
-    const providers = [
-      firstKerberosName,
-      secondKerberosName,
-      thirdKerberosName,
-    ];
+    const providers = [firstKerberosName, secondKerberosName];
 
     sidebarPage.goToUserFederation();
     providersPage.clickMenuCommand(addProviderMenu, initCapProvider);
-
-    providersPage.fillKerberosRequiredData(
-      thirdKerberosName,
-      thirdKerberosRealm,
-      thirdKerberosPrincipal,
-      thirdKerberosKeytab
-    );
-    providersPage.save(provider);
-    masthead.checkNotificationMessage(createdSuccessMessage, true);
 
     sidebarPage.goToUserFederation();
     priorityDialog.openDialog().checkOrder(providers);
     priorityDialog.clickSave();
     masthead.checkNotificationMessage(changeSuccessMsg, true);
-
-    /*
-    Drag and drop is working in product but not in cypress. Order should be
-    validated with the following if the cypress issue is ever resolved.
-
-    priorityDialog.moveRowTo(firstKerberosName, thirdKerberosName);
-    priorityDialog.clickSave();
-    masthead.checkNotificationMessage(changeSuccessMsg, true);
-     
-    priorityDialog
-      .openDialog()
-      .checkOrder([secondKerberosName, thirdKerberosName, firstKerberosName]);
-    */
   });
 
   it("Delete a Kerberos provider from card view using the card's menu", () => {
@@ -201,10 +170,6 @@ describe("User Fed Kerberos tests", () => {
   });
 
   it("Delete a Kerberos provider using the Settings view's Action menu", () => {
-    providersPage.deleteCardFromMenu(thirdKerberosName);
-    modalUtils.checkModalTitle(deleteModalTitle).confirmModal();
-    masthead.checkNotificationMessage(deletedSuccessMessage);
-
     providersPage.deleteCardFromMenu(firstKerberosName);
     modalUtils.checkModalTitle(deleteModalTitle).confirmModal();
     masthead.checkNotificationMessage(deletedSuccessMessage);

--- a/cypress/support/pages/admin_console/manage/providers/PriorityDialog.ts
+++ b/cypress/support/pages/admin_console/manage/providers/PriorityDialog.ts
@@ -1,0 +1,37 @@
+const expect = chai.expect;
+
+export default class PriorityDialog {
+  private managePriorityOrder = "viewHeader-lower-btn";
+  private list = "manageOrderDataList";
+
+  openDialog() {
+    cy.findByTestId(this.managePriorityOrder).click({ force: true });
+    return this;
+  }
+
+  moveRowTo(from: string, to: string) {
+    cy.findByTestId(from).trigger("dragstart").trigger("dragleave");
+
+    cy.findByTestId(to)
+      .trigger("dragenter")
+      .trigger("dragover")
+      .trigger("drop")
+      .trigger("dragend");
+
+    return this;
+  }
+
+  clickSave() {
+    cy.get("#modal-confirm").click();
+    return this;
+  }
+
+  checkOrder(providerNames: string[]) {
+    cy.get(`[data-testid=${this.list}] li`).should((providers) => {
+      expect(providers).to.have.length(providerNames.length);
+      for (let index = 0; index < providerNames.length; index++) {
+        expect(providers.eq(index)).to.contain(providerNames[index]);
+      }
+    });
+  }
+}

--- a/src/components/view-header/ViewHeader.tsx
+++ b/src/components/view-header/ViewHeader.tsx
@@ -1,5 +1,6 @@
 import {
   Badge,
+  Button,
   Divider,
   Dropdown,
   DropdownPosition,
@@ -38,6 +39,7 @@ export type ViewHeaderProps = {
   dropdownItems?: ReactElement[];
   lowerDropdownItems?: any;
   lowerDropdownMenuTitle?: any;
+  lowerButton?: any;
   isEnabled?: boolean;
   onToggle?: (value: boolean) => void;
   divider?: boolean;
@@ -61,6 +63,7 @@ export const ViewHeader = ({
   dropdownItems,
   lowerDropdownMenuTitle,
   lowerDropdownItems,
+  lowerButton,
   isEnabled = true,
   onToggle,
   divider = true,
@@ -190,6 +193,15 @@ export const ViewHeader = ({
             isOpen={isLowerDropdownOpen}
             dropdownItems={lowerDropdownItems}
           />
+        )}
+        {lowerButton && (
+          <Button
+            variant={lowerButton.variant}
+            onClick={lowerButton.onClick}
+            data-testid="viewHeader-lower-btn"
+          >
+            {lowerButton.lowerButtonTitle}
+          </Button>
         )}
       </PageSection>
       {divider && <Divider component="div" />}

--- a/src/identity-providers/IdentityProvidersSection.tsx
+++ b/src/identity-providers/IdentityProvidersSection.tsx
@@ -34,7 +34,7 @@ import { useServerInfo } from "../context/server-info/ServerInfoProvider";
 import { upperCaseFormatter } from "../util";
 import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
 import { ProviderIconMapper } from "./ProviderIconMapper";
-import { ManageOderDialog } from "./ManageOrderDialog";
+import { ManageOrderDialog } from "./ManageOrderDialog";
 import { toIdentityProvider } from "./routes/IdentityProvider";
 import { toIdentityProviderCreate } from "./routes/IdentityProviderCreate";
 import helpUrls from "../help-urls";
@@ -161,7 +161,7 @@ export default function IdentityProvidersSection() {
     <>
       <DeleteConfirm />
       {manageDisplayDialog && (
-        <ManageOderDialog
+        <ManageOrderDialog
           onClose={() => setManageDisplayDialog(false)}
           providers={providers.filter((p) => p.enabled)}
         />

--- a/src/identity-providers/messages.ts
+++ b/src/identity-providers/messages.ts
@@ -41,7 +41,7 @@ export default {
     displayOrder: "Display order",
     createSuccess: "Identity provider successfully created",
     createError: "Could not create the identity provider: {{error}}",
-    oderDialogIntro:
+    orderDialogIntro:
       "The order that the providers are listed in the login page or the account console. You can drag the row handles to change the order.",
     manageOrderTableAria:
       "List of identity providers in the order listed on the login page",

--- a/src/user-federation/ManagePriorityDialog.tsx
+++ b/src/user-federation/ManagePriorityDialog.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { sortBy } from "lodash-es";
+import _ from "lodash";
 import {
   AlertVariant,
   Button,
@@ -17,36 +17,36 @@ import {
   TextContent,
   Text,
 } from "@patternfly/react-core";
-import type IdentityProviderRepresentation from "@keycloak/keycloak-admin-client/lib/defs/identityProviderRepresentation";
+import type ComponentRepresentation from "@keycloak/keycloak-admin-client/lib/defs/componentRepresentation";
 import { useAdminClient } from "../context/auth/AdminClient";
 import { useAlerts } from "../components/alert/Alerts";
 
-type ManageOrderDialogProps = {
-  providers: IdentityProviderRepresentation[];
+type ManagePriorityDialogProps = {
+  components: ComponentRepresentation[];
   onClose: () => void;
 };
 
-export const ManageOrderDialog = ({
-  providers,
+export const ManagePriorityDialog = ({
+  components,
   onClose,
-}: ManageOrderDialogProps) => {
-  const { t } = useTranslation("identity-providers");
+}: ManagePriorityDialogProps) => {
+  const { t } = useTranslation("user-federation");
   const adminClient = useAdminClient();
   const { addAlert, addError } = useAlerts();
 
-  const [alias, setAlias] = useState("");
+  const [id, setId] = useState("");
   const [liveText, setLiveText] = useState("");
   const [order, setOrder] = useState(
-    providers.map((provider) => provider.alias!)
+    components.map((component) => component.name!)
   );
 
   const onDragStart = (id: string) => {
-    setAlias(id);
+    setId(id);
     setLiveText(t("common:onDragStart", { item: id }));
   };
 
   const onDragMove = () => {
-    setLiveText(t("common:onDragMove", { item: alias }));
+    setLiveText(t("common:onDragMove", { item: id }));
   };
 
   const onDragCancel = () => {
@@ -61,23 +61,23 @@ export const ManageOrderDialog = ({
   return (
     <Modal
       variant={ModalVariant.small}
-      title={t("manageDisplayOrder")}
+      title={t("managePriorityOrder")}
       isOpen={true}
       onClose={onClose}
       actions={[
         <Button
           id="modal-confirm"
-          data-testid="confirm"
           key="confirm"
           onClick={() => {
-            order.map(async (alias, index) => {
-              const provider = providers.find((p) => p.alias === alias)!;
-              provider.config!.guiOrder = index;
+            order.map(async (name, index) => {
+              const component = components!.find((c) => c.name === name)!;
+              component.config!.priority = [index.toString()];
               try {
-                await adminClient.identityProviders.update({ alias }, provider);
+                const id = component.id!;
+                await adminClient.components.update({ id }, component);
                 addAlert(t("orderChangeSuccess"), AlertVariant.success);
               } catch (error) {
-                addError("identity-providers:orderChangeError", error);
+                addError("orderChangeError", error);
               }
             });
 
@@ -88,7 +88,6 @@ export const ManageOrderDialog = ({
         </Button>,
         <Button
           id="modal-cancel"
-          data-testid="cancel"
           key="cancel"
           variant={ButtonVariant.link}
           onClick={onClose}
@@ -98,7 +97,7 @@ export const ManageOrderDialog = ({
       ]}
     >
       <TextContent className="pf-u-pb-lg">
-        <Text>{t("orderDialogIntro")}</Text>
+        <Text>{t("managePriorityInfo")}</Text>
       </TextContent>
 
       <DataList
@@ -111,17 +110,17 @@ export const ManageOrderDialog = ({
         onDragCancel={onDragCancel}
         itemOrder={order}
       >
-        {sortBy(providers, "config.guiOrder").map((provider) => (
+        {_.sortBy(components, "config.priority").map((component) => (
           <DataListItem
-            aria-labelledby={provider.alias}
-            id={provider.alias}
-            key={provider.alias}
+            aria-labelledby={component.name}
+            id={component.name}
+            key={component.name}
           >
             <DataListItemRow>
               <DataListControl>
                 <DataListDragButton
                   aria-label="Reorder"
-                  aria-labelledby={provider.alias}
+                  aria-labelledby={component.name}
                   aria-describedby={t("manageOrderItemAria")}
                   aria-pressed="false"
                 />
@@ -129,10 +128,10 @@ export const ManageOrderDialog = ({
               <DataListItemCells
                 dataListCells={[
                   <DataListCell
-                    key={`${provider.alias}-cell`}
-                    data-testid={provider.alias}
+                    key={`${component.name}-cell`}
+                    data-testid={component.name}
                   >
-                    <span id={provider.alias}>{provider.alias}</span>
+                    <span id={component.name}>{component.name}</span>
                   </DataListCell>,
                 ]}
               />

--- a/src/user-federation/ManagePriorityDialog.tsx
+++ b/src/user-federation/ManagePriorityDialog.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
-import _ from "lodash";
+import { sortBy } from "lodash-es";
 import {
   AlertVariant,
   Button,
@@ -110,7 +110,7 @@ export const ManagePriorityDialog = ({
         onDragCancel={onDragCancel}
         itemOrder={order}
       >
-        {_.sortBy(components, "config.priority").map((component) => (
+        {sortBy(components, "config.priority").map((component) => (
           <DataListItem
             aria-labelledby={component.name}
             id={component.name}

--- a/src/user-federation/UserFederationSection.tsx
+++ b/src/user-federation/UserFederationSection.tsx
@@ -113,8 +113,14 @@ export default function UserFederationSection() {
     toggleDeleteDialog();
   };
 
+  const cardSorter = (card1: any, card2: any) => {
+    const a = `${card1.name}`;
+    const b = `${card2.name}`;
+    return a < b ? -1 : 1;
+  };
+
   if (userFederations) {
-    cards = userFederations.map((userFederation, index) => {
+    cards = userFederations.sort(cardSorter).map((userFederation, index) => {
       const ufCardDropdownItems = [
         <DropdownItem
           key={`${index}-cardDelete`}

--- a/src/user-federation/UserFederationSection.tsx
+++ b/src/user-federation/UserFederationSection.tsx
@@ -20,6 +20,7 @@ import { useTranslation } from "react-i18next";
 import { useHistory } from "react-router-dom";
 import { useAlerts } from "../components/alert/Alerts";
 import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
+import { ManagePriorityDialog } from "./ManagePriorityDialog";
 import { KeycloakCard } from "../components/keycloak-card/KeycloakCard";
 import { ViewHeader } from "../components/view-header/ViewHeader";
 import { useAdminClient, useFetch } from "../context/auth/AdminClient";
@@ -42,6 +43,8 @@ export default function UserFederationSection() {
   const refresh = () => setKey(new Date().getTime());
 
   const history = useHistory();
+
+  const [manageDisplayDialog, setManageDisplayDialog] = useState(false);
 
   const providers =
     useServerInfo().componentTypes?.[
@@ -82,7 +85,7 @@ export default function UserFederationSection() {
 
   const lowerButtonProps = {
     variant: "link",
-    onClick: undefined,
+    onClick: () => setManageDisplayDialog(true),
     lowerButtonTitle: t("managePriorities"),
   };
 
@@ -150,6 +153,13 @@ export default function UserFederationSection() {
 
   return (
     <>
+      <DeleteConfirm />
+      {manageDisplayDialog && userFederations && (
+        <ManagePriorityDialog
+          onClose={() => setManageDisplayDialog(false)}
+          components={userFederations.filter((p) => p.config?.enabled)}
+        />
+      )}
       <ViewHeader
         titleKey="userFederation"
         subKey="user-federation:userFederationExplain"

--- a/src/user-federation/UserFederationSection.tsx
+++ b/src/user-federation/UserFederationSection.tsx
@@ -80,10 +80,11 @@ export default function UserFederationSection() {
     []
   );
 
-  // const learnMoreLinkProps = {
-  //   title: t("common:learnMore"),
-  //   href: "https://www.keycloak.org/docs/latest/server_admin/index.html#_user-storage-federation",
-  // };
+  const lowerButtonProps = {
+    variant: "link",
+    onClick: undefined,
+    lowerButtonTitle: t("managePriorities"),
+  };
 
   let cards;
 
@@ -157,6 +158,7 @@ export default function UserFederationSection() {
           ? {
               lowerDropdownItems: ufAddProviderDropdownItems,
               lowerDropdownMenuTitle: "user-federation:addNewProvider",
+              lowerButton: lowerButtonProps,
             }
           : {})}
       />

--- a/src/user-federation/UserFederationSection.tsx
+++ b/src/user-federation/UserFederationSection.tsx
@@ -180,10 +180,7 @@ export default function UserFederationSection() {
       />
       <PageSection>
         {userFederations && userFederations.length > 0 ? (
-          <>
-            <DeleteConfirm />
-            <Gallery hasGutter>{cards}</Gallery>
-          </>
+          <Gallery hasGutter>{cards}</Gallery>
         ) : (
           <>
             <TextContent>

--- a/src/user-federation/messages.ts
+++ b/src/user-federation/messages.ts
@@ -95,6 +95,7 @@ export default {
       "Error when trying to connect to LDAP. See server.log for details. {{error}}",
 
     learnMore: "Learn more",
+    managePriorities: "Manage priorities",
     addNewProvider: "Add new provider",
     addCustomProvider: "Add custom provider",
     providerDetails: "Provider details",

--- a/src/user-federation/messages.ts
+++ b/src/user-federation/messages.ts
@@ -96,6 +96,13 @@ export default {
 
     learnMore: "Learn more",
     managePriorities: "Manage priorities",
+    managePriorityOrder: "Manage priority order",
+    managePriorityInfo:
+      "Priority is the order of providers when doing a user lookup. You can drag the row handlers to change the priorities.",
+    orderChangeSuccess:
+      "Successfully changed the priority order of user federation providers",
+    orderChangeError:
+      "Could not change the priority order of user federation providers {{error}}",
     addNewProvider: "Add new provider",
     addCustomProvider: "Add custom provider",
     providerDetails: "Provider details",


### PR DESCRIPTION
## Motivation
Adds priority configuration to user fed providers. Fixes https://github.com/keycloak/keycloak-admin-ui/issues/1500.

## Brief Description
Uses a drag and drop modal to change priority of existing user federation providers. Adds an optional lower button/link to the ViewHeader component, which in this case is being used to add the Manage priorities link. Also, user fed cards are now sorted alphabetically.

## Verification Steps
1. Go to User Fed and create at least two providers.
2. Select the Manage priorities link, the names should be in alphabetical order by default. 
3. Drag and drop one or more providers to create a new order, then click Save.
4. Exit and return to verify the priority order is retained. 
5. Go to the old console and verify that the order is correct in the Priority column in User Fed.

## Checklist:
- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [x] Help has been implemented
- [x] Unit tests have been created/updated

## Additional Notes
Could not get actual drag and drop to work in cypress, so the test is limited to just invoking the modal, verifying the original order, and saving.