### PR TITLE
Add componentId to LDAP provider test connection/authorization

### DIFF
--- a/src/user-federation/custom/CustomProviderSettings.tsx
+++ b/src/user-federation/custom/CustomProviderSettings.tsx
@@ -95,8 +95,8 @@ export default function CustomProviderSettings() {
             label={t("consoleDisplayName")}
             labelIcon={
               <HelpItem
-                helpText="users-federation-help:consoleDisplayNameHelp"
-                fieldLabelId="users-federation:consoleDisplayName"
+                helpText="user-federation-help:consoleDisplayNameHelp"
+                fieldLabelId="user-federation:consoleDisplayName"
               />
             }
             helperTextInvalid={t("validateName")}

--- a/src/user-federation/kerberos/KerberosSettingsRequired.tsx
+++ b/src/user-federation/kerberos/KerberosSettingsRequired.tsx
@@ -64,8 +64,8 @@ export const KerberosSettingsRequired = ({
           label={t("consoleDisplayName")}
           labelIcon={
             <HelpItem
-              helpText="users-federation-help:consoleDisplayNameHelp"
-              fieldLabelId="users-federation:consoleDisplayName"
+              helpText="user-federation-help:consoleDisplayNameHelp"
+              fieldLabelId="user-federation:consoleDisplayName"
             />
           }
           fieldId="kc-console-display-name"
@@ -119,8 +119,8 @@ export const KerberosSettingsRequired = ({
           label={t("kerberosRealm")}
           labelIcon={
             <HelpItem
-              helpText="users-federation-help:kerberosRealmHelp"
-              fieldLabelId="users-federation:kc-kerberos-realm"
+              helpText="user-federation-help:kerberosRealmHelp"
+              fieldLabelId="user-federation:kc-kerberos-realm"
             />
           }
           fieldId="kc-kerberos-realm"
@@ -150,8 +150,8 @@ export const KerberosSettingsRequired = ({
           label={t("serverPrincipal")}
           labelIcon={
             <HelpItem
-              helpText="users-federation-help:serverPrincipalHelp"
-              fieldLabelId="users-federation:serverPrincipal"
+              helpText="user-federation-help:serverPrincipalHelp"
+              fieldLabelId="user-federation:serverPrincipal"
             />
           }
           fieldId="kc-server-principal"
@@ -181,8 +181,8 @@ export const KerberosSettingsRequired = ({
           label={t("keyTab")}
           labelIcon={
             <HelpItem
-              helpText="users-federation-help:keyTabHelp"
-              fieldLabelId="users-federation:keyTab"
+              helpText="user-federation-help:keyTabHelp"
+              fieldLabelId="user-federation:keyTab"
             />
           }
           fieldId="kc-key-tab"
@@ -210,8 +210,8 @@ export const KerberosSettingsRequired = ({
           label={t("debug")}
           labelIcon={
             <HelpItem
-              helpText="users-federation-help:debugHelp"
-              fieldLabelId="users-federation:debug"
+              helpText="user-federation-help:debugHelp"
+              fieldLabelId="user-federation:debug"
             />
           }
           fieldId="kc-debug"
@@ -238,8 +238,8 @@ export const KerberosSettingsRequired = ({
           label={t("allowPasswordAuthentication")}
           labelIcon={
             <HelpItem
-              helpText="users-federation-help:allowPasswordAuthenticationHelp"
-              fieldLabelId="users-federation:allowPasswordAuthentication"
+              helpText="user-federation-help:allowPasswordAuthenticationHelp"
+              fieldLabelId="user-federation:allowPasswordAuthentication"
             />
           }
           fieldId="kc-allow-password-authentication"
@@ -266,8 +266,8 @@ export const KerberosSettingsRequired = ({
             label={t("editMode")}
             labelIcon={
               <HelpItem
-                helpText="users-federation-help:editModeKerberosHelp"
-                fieldLabelId="users-federation:editMode"
+                helpText="user-federation-help:editModeKerberosHelp"
+                fieldLabelId="user-federation:editMode"
               />
             }
             isRequired
@@ -306,8 +306,8 @@ export const KerberosSettingsRequired = ({
           label={t("updateFirstLogin")}
           labelIcon={
             <HelpItem
-              helpText="users-federation-help:updateFirstLoginHelp"
-              fieldLabelId="users-federation:updateFirstLogin"
+              helpText="user-federation-help:updateFirstLoginHelp"
+              fieldLabelId="user-federation:updateFirstLogin"
             />
           }
           fieldId="kc-update-first-login"

--- a/src/user-federation/ldap/LdapSettingsAdvanced.tsx
+++ b/src/user-federation/ldap/LdapSettingsAdvanced.tsx
@@ -35,8 +35,8 @@ export const LdapSettingsAdvanced = ({
           label={t("enableLdapv3Password")}
           labelIcon={
             <HelpItem
-              helpText="users-federation-help:enableLdapv3PasswordHelp"
-              fieldLabelId="users-federation:enableLdapv3Password"
+              helpText="user-federation-help:enableLdapv3PasswordHelp"
+              fieldLabelId="user-federation:enableLdapv3Password"
             />
           }
           fieldId="kc-enable-ldapv3-password"
@@ -63,8 +63,8 @@ export const LdapSettingsAdvanced = ({
           label={t("validatePasswordPolicy")}
           labelIcon={
             <HelpItem
-              helpText="users-federation-help:validatePasswordPolicyHelp"
-              fieldLabelId="users-federation:validatePasswordPolicy"
+              helpText="user-federation-help:validatePasswordPolicyHelp"
+              fieldLabelId="user-federation:validatePasswordPolicy"
             />
           }
           fieldId="kc-validate-password-policy"
@@ -91,8 +91,8 @@ export const LdapSettingsAdvanced = ({
           label={t("trustEmail")}
           labelIcon={
             <HelpItem
-              helpText="users-federation-help:trustEmailHelp"
-              fieldLabelId="users-federation:trustEmail"
+              helpText="user-federation-help:trustEmailHelp"
+              fieldLabelId="user-federation:trustEmail"
             />
           }
           fieldId="kc-trust-email"

--- a/src/user-federation/ldap/LdapSettingsConnection.tsx
+++ b/src/user-federation/ldap/LdapSettingsConnection.tsx
@@ -50,6 +50,8 @@ const convertFormToSettings = (form: UseFormMethods) => {
     settings[key] = Array.isArray(value) ? value[0] : "";
   });
 
+  settings["componentId"] = get(form.getValues(), "id");
+
   return settings;
 };
 
@@ -105,8 +107,8 @@ export const LdapSettingsConnection = ({
           label={t("connectionURL")}
           labelIcon={
             <HelpItem
-              helpText="users-federation-help:consoleDisplayConnectionUrlHelp"
-              fieldLabelId="users-federation:connectionURL"
+              helpText="user-federation-help:consoleDisplayConnectionUrlHelp"
+              fieldLabelId="user-federation:connectionURL"
             />
           }
           fieldId="kc-console-connection-url"
@@ -135,8 +137,8 @@ export const LdapSettingsConnection = ({
           label={t("enableStartTls")}
           labelIcon={
             <HelpItem
-              helpText="users-federation-help:enableStartTlsHelp"
-              fieldLabelId="users-federation:enableStartTls"
+              helpText="user-federation-help:enableStartTlsHelp"
+              fieldLabelId="user-federation:enableStartTls"
             />
           }
           fieldId="kc-enable-start-tls"
@@ -163,8 +165,8 @@ export const LdapSettingsConnection = ({
           label={t("useTruststoreSpi")}
           labelIcon={
             <HelpItem
-              helpText="users-federation-help:useTruststoreSpiHelp"
-              fieldLabelId="users-federation:useTruststoreSpi"
+              helpText="user-federation-help:useTruststoreSpiHelp"
+              fieldLabelId="user-federation:useTruststoreSpi"
             />
           }
           fieldId="kc-use-truststore-spi"
@@ -197,8 +199,8 @@ export const LdapSettingsConnection = ({
           label={t("connectionPooling")}
           labelIcon={
             <HelpItem
-              helpText="users-federation-help:connectionPoolingHelp"
-              fieldLabelId="users-federation:connectionPooling"
+              helpText="user-federation-help:connectionPoolingHelp"
+              fieldLabelId="user-federation:connectionPooling"
             />
           }
           fieldId="kc-connection-pooling"
@@ -224,8 +226,8 @@ export const LdapSettingsConnection = ({
           label={t("connectionTimeout")}
           labelIcon={
             <HelpItem
-              helpText="users-federation-help:connectionTimeoutHelp"
-              fieldLabelId="users-federation:consoleTimeout"
+              helpText="user-federation-help:connectionTimeoutHelp"
+              fieldLabelId="user-federation:consoleTimeout"
             />
           }
           fieldId="kc-console-connection-timeout"
@@ -251,8 +253,8 @@ export const LdapSettingsConnection = ({
           label={t("bindType")}
           labelIcon={
             <HelpItem
-              helpText="users-federation-help:bindTypeHelp"
-              fieldLabelId="users-federation:bindType"
+              helpText="user-federation-help:bindTypeHelp"
+              fieldLabelId="user-federation:bindType"
             />
           }
           fieldId="kc-bind-type"
@@ -291,8 +293,8 @@ export const LdapSettingsConnection = ({
               label={t("bindDn")}
               labelIcon={
                 <HelpItem
-                  helpText="users-federation-help:bindDnHelp"
-                  fieldLabelId="users-federation:bindDn"
+                  helpText="user-federation-help:bindDnHelp"
+                  fieldLabelId="user-federation:bindDn"
                 />
               }
               fieldId="kc-console-bind-dn"
@@ -316,8 +318,8 @@ export const LdapSettingsConnection = ({
               label={t("bindCredentials")}
               labelIcon={
                 <HelpItem
-                  helpText="users-federation-help:bindCredentialsHelp"
-                  fieldLabelId="users-federation:bindCredentials"
+                  helpText="user-federation-help:bindCredentialsHelp"
+                  fieldLabelId="user-federation:bindCredentials"
                 />
               }
               fieldId="kc-console-bind-credentials"

--- a/src/user-federation/ldap/LdapSettingsGeneral.tsx
+++ b/src/user-federation/ldap/LdapSettingsGeneral.tsx
@@ -115,14 +115,7 @@ export const LdapSettingsGeneral = ({
           isRequired
         >
           {/* These hidden fields are required so data object written back matches data retrieved */}
-          <TextInput
-            hidden
-            type="text"
-            id="kc-console-id"
-            name="id"
-            defaultValue=""
-            ref={form.register}
-          />
+          <TextInput hidden type="text" id="kc-console-id" name="id" />
           <TextInput
             hidden
             type="text"

--- a/src/user-federation/ldap/LdapSettingsGeneral.tsx
+++ b/src/user-federation/ldap/LdapSettingsGeneral.tsx
@@ -107,14 +107,22 @@ export const LdapSettingsGeneral = ({
           label={t("consoleDisplayName")}
           labelIcon={
             <HelpItem
-              helpText="users-federation-help:consoleDisplayNameHelp"
-              fieldLabelId="users-federation:consoleDisplayName"
+              helpText="user-federation-help:consoleDisplayNameHelp"
+              fieldLabelId="user-federation:consoleDisplayName"
             />
           }
           fieldId="kc-console-display-name"
           isRequired
         >
           {/* These hidden fields are required so data object written back matches data retrieved */}
+          <TextInput
+            hidden
+            type="text"
+            id="kc-console-id"
+            name="id"
+            defaultValue=""
+            ref={form.register}
+          />
           <TextInput
             hidden
             type="text"
@@ -161,8 +169,8 @@ export const LdapSettingsGeneral = ({
           label={t("vendor")}
           labelIcon={
             <HelpItem
-              helpText="users-federation-help:vendorHelp"
-              fieldLabelId="users-federation:vendor"
+              helpText="user-federation-help:vendorHelp"
+              fieldLabelId="user-federation:vendor"
             />
           }
           fieldId="kc-vendor"

--- a/src/user-federation/ldap/LdapSettingsKerberosIntegration.tsx
+++ b/src/user-federation/ldap/LdapSettingsKerberosIntegration.tsx
@@ -41,8 +41,8 @@ export const LdapSettingsKerberosIntegration = ({
           label={t("allowKerberosAuthentication")}
           labelIcon={
             <HelpItem
-              helpText="users-federation-help:allowKerberosAuthenticationHelp"
-              fieldLabelId="users-federation:allowKerberosAuthentication"
+              helpText="user-federation-help:allowKerberosAuthenticationHelp"
+              fieldLabelId="user-federation:allowKerberosAuthentication"
             />
           }
           fieldId="kc-allow-kerberos-authentication"
@@ -71,8 +71,8 @@ export const LdapSettingsKerberosIntegration = ({
               label={t("kerberosRealm")}
               labelIcon={
                 <HelpItem
-                  helpText="users-federation-help:kerberosRealmHelp"
-                  fieldLabelId="users-federation:kerberosRealm"
+                  helpText="user-federation-help:kerberosRealmHelp"
+                  fieldLabelId="user-federation:kerberosRealm"
                 />
               }
               fieldId="kc-kerberos-realm"
@@ -102,8 +102,8 @@ export const LdapSettingsKerberosIntegration = ({
               label={t("serverPrincipal")}
               labelIcon={
                 <HelpItem
-                  helpText="users-federation-help:serverPrincipalHelp"
-                  fieldLabelId="users-federation:serverPrincipal"
+                  helpText="user-federation-help:serverPrincipalHelp"
+                  fieldLabelId="user-federation:serverPrincipal"
                 />
               }
               fieldId="kc-server-principal"
@@ -133,8 +133,8 @@ export const LdapSettingsKerberosIntegration = ({
               label={t("keyTab")}
               labelIcon={
                 <HelpItem
-                  helpText="users-federation-help:keyTabHelp"
-                  fieldLabelId="users-federation:keyTab"
+                  helpText="user-federation-help:keyTabHelp"
+                  fieldLabelId="user-federation:keyTab"
                 />
               }
               fieldId="kc-key-tab"
@@ -164,8 +164,8 @@ export const LdapSettingsKerberosIntegration = ({
               label={t("debug")}
               labelIcon={
                 <HelpItem
-                  helpText="users-federation-help:debugHelp"
-                  fieldLabelId="users-federation:debug"
+                  helpText="user-federation-help:debugHelp"
+                  fieldLabelId="user-federation:debug"
                 />
               }
               fieldId="kc-debug"
@@ -194,8 +194,8 @@ export const LdapSettingsKerberosIntegration = ({
           label={t("useKerberosForPasswordAuthentication")}
           labelIcon={
             <HelpItem
-              helpText="users-federation-help:useKerberosForPasswordAuthenticationHelp"
-              fieldLabelId="users-federation:useKerberosForPasswordAuthentication"
+              helpText="user-federation-help:useKerberosForPasswordAuthenticationHelp"
+              fieldLabelId="user-federation:useKerberosForPasswordAuthentication"
             />
           }
           fieldId="kc-use-kerberos-password-authentication"


### PR DESCRIPTION
## Motivation
Fixes https://github.com/keycloak/keycloak-admin-ui/issues/1391.

## Brief Description
Added componentId to 'Test connection' and 'Test authentication' calls so the payload is the same as the old console. Verified that it works with LDAP server (see verification steps). Also fixed several broken help IDs in the LDAP provider form, I suspect they were the victim of an overzealous search/replace for user --> users.

## Verification Steps
1. Go to User Fed and create a new LDAP provider.
2. Add the following (leave everything else as the default):
- **Connection URL**: `ldap://ldap.forumsys.com:389`
- **Users DN**: `dc=example,dc=com`
3. Click **Test connection**. It should say that it succeeded, and the payload in the Network call should include componentId.
4. Add the following (leave everything else as the default):
- **Authentication Type**: `Simple`
- **Bind DN**: `cn=read-only-admin,dc=example,dc=com`
- **Bind Credential**: `password`
5. Click **Test Authentication**. It should say that it succeeded, and the payload in the Network call should include componentId. 

## Checklist:
- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [x] Help has been implemented
- [x] Unit tests have been created/updated

## Additional Notes
None