### PR TITLE
Tweak some settings to (hopefully) fix package pruning

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,6 @@ jobs:
         uses: actions/delete-package-versions@v2
         with:
           package-name: org.keycloak.keycloak-admin-ui
-          num-old-versions-to-delete: 100
           delete-only-pre-release-versions: true
 
       - name: Publish Admin UI


### PR DESCRIPTION
The pruning of the Maven package we are publishing has been broken for a while. Tweaking these settings hopefully might cause it to work again.