### PR TITLE
Fix bugs when admin has limited roles.

### DIFF
--- a/src/authentication/routes/Authentication.ts
+++ b/src/authentication/routes/Authentication.ts
@@ -9,7 +9,7 @@ export const AuthenticationRoute: RouteDef = {
   path: "/:realm/authentication/:tab?",
   component: lazy(() => import("../AuthenticationSection")),
   breadcrumb: (t) => t("authentication"),
-  access: "view-realm",
+  access: ["view-realm", "view-identity-providers", "view-clients"],
 };
 
 export const toAuthentication = (

--- a/src/authentication/routes/Flow.ts
+++ b/src/authentication/routes/Flow.ts
@@ -14,7 +14,7 @@ export const FlowRoute: RouteDef = {
   path: "/:realm/authentication/:id/:usedBy/:builtIn?",
   component: lazy(() => import("../FlowDetails")),
   breadcrumb: (t) => t("authentication:flowDetails"),
-  access: "manage-authorization",
+  access: "view-authorization",
 };
 
 export const toFlow = (params: FlowParams): LocationDescriptorObject => ({

--- a/src/components/form-access/FormAccess.tsx
+++ b/src/components/form-access/FormAccess.tsx
@@ -34,7 +34,7 @@ export type FormAccessProps = FormProps & {
    * An override property if fine grained access has been setup for this form.
    * @type {boolean}
    */
-  fineGrainedAccess?: boolean;
+  fineGrainedAccess?: boolean | undefined;
 
   /**
    * Set unWrap when you don't want this component to wrap your "children" in a {@link Form} component.
@@ -55,8 +55,12 @@ export type FormAccessProps = FormProps & {
 export const FormAccess: FunctionComponent<FormAccessProps> = ({
   children,
   role,
+<<<<<<< HEAD
   fineGrainedAccess = false,
   isReadOnly = false,
+=======
+  fineGrainedAccess,
+>>>>>>> 7b64ee57 (Fix bugs when admin has limited roles.)
   unWrap = false,
   ...rest
 }) => {
@@ -113,7 +117,8 @@ export const FormAccess: FunctionComponent<FormAccessProps> = ({
     });
   };
 
-  const isDisabled = isReadOnly || (!hasAccess(role) && !fineGrainedAccess);
+  let isDisabled = isReadOnly || !hasAccess(role);
+  if (fineGrainedAccess !== undefined) isDisabled = !fineGrainedAccess;
 
   return (
     <>

--- a/src/components/form-access/FormAccess.tsx
+++ b/src/components/form-access/FormAccess.tsx
@@ -34,7 +34,7 @@ export type FormAccessProps = FormProps & {
    * An override property if fine grained access has been setup for this form.
    * @type {boolean}
    */
-  fineGrainedAccess?: boolean | undefined;
+  fineGrainedAccess?: boolean;
 
   /**
    * Set unWrap when you don't want this component to wrap your "children" in a {@link Form} component.
@@ -55,12 +55,8 @@ export type FormAccessProps = FormProps & {
 export const FormAccess: FunctionComponent<FormAccessProps> = ({
   children,
   role,
-<<<<<<< HEAD
   fineGrainedAccess = false,
   isReadOnly = false,
-=======
-  fineGrainedAccess,
->>>>>>> 7b64ee57 (Fix bugs when admin has limited roles.)
   unWrap = false,
   ...rest
 }) => {
@@ -117,8 +113,7 @@ export const FormAccess: FunctionComponent<FormAccessProps> = ({
     });
   };
 
-  let isDisabled = isReadOnly || !hasAccess(role);
-  if (fineGrainedAccess !== undefined) isDisabled = !fineGrainedAccess;
+  const isDisabled = isReadOnly || (!hasAccess(role) && !fineGrainedAccess);
 
   return (
     <>

--- a/src/realm/add/NewRealmForm.tsx
+++ b/src/realm/add/NewRealmForm.tsx
@@ -24,7 +24,7 @@ import { toDashboard } from "../../dashboard/routes/Dashboard";
 export default function NewRealmForm() {
   const { t } = useTranslation("realm");
   const history = useHistory();
-  const { refresh } = useWhoAmI();
+  const { refresh, whoAmI } = useWhoAmI();
   const { refresh: refreshRealms } = useRealms();
   const adminClient = useAdminClient();
   const { addAlert, addError } = useAlerts();
@@ -59,7 +59,8 @@ export default function NewRealmForm() {
         <FormAccess
           isHorizontal
           onSubmit={handleSubmit(save)}
-          role="manage-realm"
+          role="view-realm"
+          fineGrainedAccess={whoAmI.canCreateRealm()}
         >
           <JsonFileUpload
             id="kc-realm-filename"

--- a/src/realm/add/NewRealmForm.tsx
+++ b/src/realm/add/NewRealmForm.tsx
@@ -60,7 +60,7 @@ export default function NewRealmForm() {
           isHorizontal
           onSubmit={handleSubmit(save)}
           role="view-realm"
-          fineGrainedAccess={whoAmI.canCreateRealm()}
+          isReadOnly={!whoAmI.canCreateRealm()}
         >
           <JsonFileUpload
             id="kc-realm-filename"

--- a/src/realm/routes/AddRealm.ts
+++ b/src/realm/routes/AddRealm.ts
@@ -9,7 +9,7 @@ export const AddRealmRoute: RouteDef = {
   path: "/:realm/add-realm",
   component: lazy(() => import("../add/NewRealmForm")),
   breadcrumb: (t) => t("realm:createRealm"),
-  access: "manage-realm",
+  access: "view-realm",
 };
 
 export const toAddRealm = (

--- a/src/sessions/routes/Sessions.ts
+++ b/src/sessions/routes/Sessions.ts
@@ -9,7 +9,7 @@ export const SessionsRoute: RouteDef = {
   path: "/:realm/sessions",
   component: lazy(() => import("../SessionsSection")),
   breadcrumb: (t) => t("sessions:title"),
-  access: "view-realm",
+  access: ["view-realm", "view-clients", "view-users"],
 };
 
 export const toSessions = (


### PR DESCRIPTION
## Motivation
Fixes #2097

## Verification Steps
See https://www.keycloak.org/docs/latest/server_admin/#_admin_permissions

All left navigation that are visible should work when the admin has limited permissions.  If user does not have enough permission to render the screen then the navigation link should not be shown.

Also, a master realm user should be able to create realms with only "create-realm" access and should not need full "admin" access.

## Checklist:

- [X] Code has been tested locally by PR requester
- [N/A] User-visible strings are using the react-i18next framework (useTranslation)
- [N/A] Help has been implemented
- [N/A] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated

## Additional Notes
A separate comprehensive test needs to be written for admin role settings.
