### PR TITLE
Update Keycloak development server to version 17.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY . .
 
 RUN mvn -f /app/keycloak-theme/pom.xml install
 
-FROM quay.io/keycloak/keycloak:16.1.0
+FROM quay.io/keycloak/keycloak:17.0.0-legacy
 COPY --from=builder /app/keycloak-theme/target/classes /opt/jboss/keycloak/themes/keycloak.v2
 
 EXPOSE 8080

--- a/start.mjs
+++ b/start.mjs
@@ -11,7 +11,7 @@ import cliProgress from "cli-progress";
 import colors from "colors";
 
 const args = process.argv.slice(2);
-const version = args[0] && !args[0].startsWith("-") ? args[0] : "16.1.0";
+const version = args[0] && !args[0].startsWith("-") ? args[0] : "17.0.0";
 
 const folder = "server";
 const fileName = path.join(folder, `keycloak-${version}.tar.gz`);
@@ -110,7 +110,7 @@ if (!fs.existsSync(fileName)) {
   });
 
   request(
-    `https://github.com/keycloak/keycloak/releases/download/${version}/keycloak-${version}.tar.gz`,
+    `https://github.com/keycloak/keycloak/releases/download/${version}/keycloak-legacy-${version}.tar.gz`,
     file,
     progressBar
   );


### PR DESCRIPTION
Updates both the Docker and scripted development server to the latest version of Keycloak. This does not yet move us to the Quarkus version, for this a separate issue has been created (#2104).