### PR TITLE
Use a single admin client instance for all tests

### DIFF
--- a/cypress/integration/authentication_test.spec.ts
+++ b/cypress/integration/authentication_test.spec.ts
@@ -6,7 +6,7 @@ import ListingPage from "../support/pages/admin_console/ListingPage";
 import DuplicateFlowModal from "../support/pages/admin_console/manage/authentication/DuplicateFlowModal";
 import FlowDetails from "../support/pages/admin_console/manage/authentication/FlowDetail";
 import RequiredActions from "../support/pages/admin_console/manage/authentication/RequiredActions";
-import AdminClient from "../support/util/AdminClient";
+import adminClient from "../support/util/AdminClient";
 import PasswordPolicies from "../support/pages/admin_console/manage/authentication/PasswordPolicies";
 
 describe("Authentication test", () => {
@@ -122,11 +122,11 @@ describe("Authentication test", () => {
     });
 
     before(() => {
-      new AdminClient().createRealm("Test");
+      adminClient.createRealm("Test");
     });
 
     after(() => {
-      new AdminClient().deleteRealm("Test");
+      adminClient.deleteRealm("Test");
     });
 
     it("should enable delete account", () => {

--- a/cypress/integration/client_authorization_test.spec.ts
+++ b/cypress/integration/client_authorization_test.spec.ts
@@ -2,7 +2,7 @@ import {
   keycloakBefore,
   keycloakBeforeEach,
 } from "../support/util/keycloak_hooks";
-import AdminClient from "../support/util/AdminClient";
+import adminClient from "../support/util/AdminClient";
 import LoginPage from "../support/pages/LoginPage";
 import ListingPage from "../support/pages/admin_console/ListingPage";
 import Masthead from "../support/pages/admin_console/Masthead";
@@ -11,7 +11,6 @@ import AuthorizationTab from "../support/pages/admin_console/manage/clients/Auth
 import ModalUtils from "../support/util/ModalUtils";
 
 describe("Client authentication subtab", () => {
-  const adminClient = new AdminClient();
   const loginPage = new LoginPage();
   const listingPage = new ListingPage();
   const masthead = new Masthead();

--- a/cypress/integration/client_scopes_test.spec.ts
+++ b/cypress/integration/client_scopes_test.spec.ts
@@ -13,7 +13,7 @@ import {
 } from "../support/util/keycloak_hooks";
 import RoleMappingTab from "../support/pages/admin_console/manage/RoleMappingTab";
 import ModalUtils from "../support/util/ModalUtils";
-import AdminClient from "../support/util/AdminClient";
+import adminClient from "../support/util/AdminClient";
 
 let itemId = "client_scope_crud";
 const loginPage = new LoginPage();
@@ -43,18 +43,16 @@ describe("Client Scopes test", () => {
   };
 
   before(async () => {
-    const client = new AdminClient();
     for (let i = 0; i < 5; i++) {
       clientScope.name = clientScopeName + i;
-      await client.createClientScope(clientScope);
+      await adminClient.createClientScope(clientScope);
     }
   });
 
   after(async () => {
-    const client = new AdminClient();
     for (let i = 0; i < 5; i++) {
-      if (await client.existsClientScope(clientScopeName + i)) {
-        await client.deleteClientScope(clientScopeName + i);
+      if (await adminClient.existsClientScope(clientScopeName + i)) {
+        await adminClient.deleteClientScope(clientScopeName + i);
       }
     }
   });

--- a/cypress/integration/clients_saml_test.spec.ts
+++ b/cypress/integration/clients_saml_test.spec.ts
@@ -3,7 +3,7 @@ import Masthead from "../support/pages/admin_console/Masthead";
 import ListingPage from "../support/pages/admin_console/ListingPage";
 import SidebarPage from "../support/pages/admin_console/SidebarPage";
 import ModalUtils from "../support/util/ModalUtils";
-import AdminClient from "../support/util/AdminClient";
+import adminClient from "../support/util/AdminClient";
 import {
   keycloakBefore,
   keycloakBeforeEach,
@@ -20,7 +20,7 @@ describe("Clients SAML tests", () => {
     const samlClientName = "saml";
 
     before(() => {
-      new AdminClient().createClient({
+      adminClient.createClient({
         protocol: "saml",
         clientId: samlClientName,
         publicClient: false,
@@ -30,7 +30,7 @@ describe("Clients SAML tests", () => {
     });
 
     after(() => {
-      new AdminClient().deleteClient(samlClientName);
+      adminClient.deleteClient(samlClientName);
     });
 
     beforeEach(() => {
@@ -62,7 +62,7 @@ describe("Clients SAML tests", () => {
     const clientId = "saml-keys";
 
     before(() => {
-      new AdminClient().createClient({
+      adminClient.createClient({
         clientId,
         protocol: "saml",
       });
@@ -71,7 +71,7 @@ describe("Clients SAML tests", () => {
     });
 
     after(() => {
-      new AdminClient().deleteClient(clientId);
+      adminClient.deleteClient(clientId);
     });
 
     beforeEach(() => {

--- a/cypress/integration/clients_test.spec.ts
+++ b/cypress/integration/clients_test.spec.ts
@@ -8,7 +8,7 @@ import SidebarPage from "../support/pages/admin_console/SidebarPage";
 import CreateClientPage from "../support/pages/admin_console/manage/clients/CreateClientPage";
 import ModalUtils from "../support/util/ModalUtils";
 import AdvancedTab from "../support/pages/admin_console/manage/clients/AdvancedTab";
-import AdminClient from "../support/util/AdminClient";
+import adminClient from "../support/util/AdminClient";
 import InitialAccessTokenTab from "../support/pages/admin_console/manage/clients/InitialAccessTokenTab";
 import {
   keycloakBefore,
@@ -28,7 +28,6 @@ const modalUtils = new ModalUtils();
 
 describe("Clients test", () => {
   describe("Client details - Client scopes subtab", () => {
-    const client = new AdminClient();
     const clientScopesTab = new ClientScopesTab();
     const clientId = "client-scopes-subtab-test";
     const clientScopeName = "client-scope-test";
@@ -48,23 +47,23 @@ describe("Clients test", () => {
     const msgScopeMappingRemoved = "Scope mapping successfully removed";
 
     before(async () => {
-      client.createClient({
+      adminClient.createClient({
         clientId,
         protocol: "openid-connect",
         publicClient: false,
       });
       for (let i = 0; i < 5; i++) {
         clientScope.name = clientScopeName + i;
-        await client.createClientScope(clientScope);
-        await client.addDefaultClientScopeInClient(
+        await adminClient.createClientScope(clientScope);
+        await adminClient.addDefaultClientScopeInClient(
           clientScopeName + i,
           clientId
         );
       }
       clientScope.name = clientScopeNameDefaultType;
-      await client.createClientScope(clientScope);
+      await adminClient.createClientScope(clientScope);
       clientScope.name = clientScopeNameOptionalType;
-      await client.createClientScope(clientScope);
+      await adminClient.createClientScope(clientScope);
     });
 
     beforeEach(() => {
@@ -78,12 +77,12 @@ describe("Clients test", () => {
     });
 
     after(async () => {
-      client.deleteClient(clientId);
+      adminClient.deleteClient(clientId);
       for (let i = 0; i < 5; i++) {
-        await client.deleteClientScope(clientScopeName + i);
+        await adminClient.deleteClientScope(clientScopeName + i);
       }
-      await client.deleteClientScope(clientScopeNameDefaultType);
-      await client.deleteClientScope(clientScopeNameOptionalType);
+      await adminClient.deleteClientScope(clientScopeNameDefaultType);
+      await adminClient.deleteClientScope(clientScopeNameOptionalType);
     });
 
     it("should list client scopes", () => {
@@ -345,7 +344,7 @@ describe("Clients test", () => {
     });
 
     afterEach(() => {
-      new AdminClient().deleteClient(client);
+      adminClient.deleteClient(client);
     });
 
     it("Clustering", () => {
@@ -375,7 +374,7 @@ describe("Clients test", () => {
     before(() => {
       keycloakBefore();
       loginPage.logIn();
-      new AdminClient().createClient({
+      adminClient.createClient({
         protocol: "openid-connect",
         clientId: serviceAccountName,
         publicClient: false,
@@ -391,7 +390,7 @@ describe("Clients test", () => {
     });
 
     after(() => {
-      new AdminClient().deleteClient(serviceAccountName);
+      adminClient.deleteClient(serviceAccountName);
     });
 
     it("List", () => {
@@ -429,7 +428,7 @@ describe("Clients test", () => {
     });
 
     before(() => {
-      new AdminClient().createClient({
+      adminClient.createClient({
         protocol: "openid-connect",
         clientId: mappingClient,
         publicClient: false,
@@ -437,7 +436,7 @@ describe("Clients test", () => {
     });
 
     after(() => {
-      new AdminClient().deleteClient(mappingClient);
+      adminClient.deleteClient(mappingClient);
     });
 
     it("Add mapping to openid client", () => {
@@ -455,7 +454,7 @@ describe("Clients test", () => {
     before(() => {
       keycloakBefore();
       loginPage.logIn();
-      new AdminClient().createClient({
+      adminClient.createClient({
         protocol: "openid-connect",
         clientId: keysName,
         publicClient: false,
@@ -469,7 +468,7 @@ describe("Clients test", () => {
     });
 
     after(() => {
-      new AdminClient().deleteClient(keysName);
+      adminClient.deleteClient(keysName);
     });
 
     it("Change use JWKS Url", () => {
@@ -530,7 +529,7 @@ describe("Clients test", () => {
     before(() => {
       keycloakBefore();
       loginPage.logIn();
-      new AdminClient().createClient({
+      adminClient.createClient({
         clientId,
         protocol: "openid-connect",
         publicClient: false,
@@ -543,7 +542,7 @@ describe("Clients test", () => {
     });
 
     after(() => {
-      new AdminClient().deleteClient(clientId);
+      adminClient.deleteClient(clientId);
     });
 
     beforeEach(() => {

--- a/cypress/integration/group_test.spec.ts
+++ b/cypress/integration/group_test.spec.ts
@@ -8,7 +8,7 @@ import Masthead from "../support/pages/admin_console/Masthead";
 import SidebarPage from "../support/pages/admin_console/SidebarPage";
 import LoginPage from "../support/pages/LoginPage";
 import ViewHeaderPage from "../support/pages/ViewHeaderPage";
-import AdminClient from "../support/util/AdminClient";
+import adminClient from "../support/util/AdminClient";
 import { keycloakBefore } from "../support/util/keycloak_hooks";
 import ModalUtils from "../support/util/ModalUtils";
 
@@ -147,13 +147,12 @@ describe("Group test", () => {
     const detailPage = new GroupDetailPage();
 
     before(async () => {
-      const client = new AdminClient();
-      const createdGroups = await client.createSubGroups(groups);
+      const createdGroups = await adminClient.createSubGroups(groups);
       for (let i = 0; i < 5; i++) {
         const username = "user" + i;
-        client.createUserInGroup(username, createdGroups[i % 3].id);
+        adminClient.createUserInGroup(username, createdGroups[i % 3].id);
       }
-      client.createUser({ username: "new", enabled: true });
+      adminClient.createUser({ username: "new", enabled: true });
     });
 
     beforeEach(() => {
@@ -163,7 +162,6 @@ describe("Group test", () => {
     });
 
     after(async () => {
-      const adminClient = new AdminClient();
       await adminClient.deleteGroups();
       for (let i = 0; i < 5; i++) {
         const username = "user" + i;

--- a/cypress/integration/partial_export_test.spec.ts
+++ b/cypress/integration/partial_export_test.spec.ts
@@ -2,15 +2,14 @@ import PartialExportModal from "../support/pages/admin_console/configure/realm_s
 import RealmSettings from "../support/pages/admin_console/configure/realm_settings/RealmSettings";
 import SidebarPage from "../support/pages/admin_console/SidebarPage";
 import LoginPage from "../support/pages/LoginPage";
-import AdminClient from "../support/util/AdminClient";
+import adminClient from "../support/util/AdminClient";
 import { keycloakBefore } from "../support/util/keycloak_hooks";
 
 describe("Partial realm export", () => {
   const REALM_NAME = "Partial-export-test-realm";
-  const client = new AdminClient();
 
-  before(() => client.createRealm(REALM_NAME));
-  after(() => client.deleteRealm(REALM_NAME));
+  before(() => adminClient.createRealm(REALM_NAME));
+  after(() => adminClient.deleteRealm(REALM_NAME));
 
   const loginPage = new LoginPage();
   const sidebarPage = new SidebarPage();

--- a/cypress/integration/partial_import_test.spec.ts
+++ b/cypress/integration/partial_import_test.spec.ts
@@ -7,7 +7,7 @@ import {
   keycloakBefore,
   keycloakBeforeEach,
 } from "../support/util/keycloak_hooks";
-import AdminClient from "../support/util/AdminClient";
+import adminClient from "../support/util/AdminClient";
 
 describe("Partial import test", () => {
   const TEST_REALM = "partial-import-test-realm";
@@ -33,8 +33,7 @@ describe("Partial import test", () => {
   });
 
   afterEach(async () => {
-    const client = new AdminClient();
-    await client.deleteRealm(TEST_REALM);
+    await adminClient.deleteRealm(TEST_REALM);
   });
 
   it("Opens and closes partial import dialog", () => {

--- a/cypress/integration/realm_roles_test.spec.ts
+++ b/cypress/integration/realm_roles_test.spec.ts
@@ -9,7 +9,7 @@ import {
   keycloakBefore,
   keycloakBeforeEach,
 } from "../support/util/keycloak_hooks";
-import AdminClient from "../support/util/AdminClient";
+import adminClient from "../support/util/AdminClient";
 
 let itemId = "realm_role_crud";
 const loginPage = new LoginPage();
@@ -110,7 +110,6 @@ describe("Realm roles test", () => {
   describe("edit role details", () => {
     const editRoleName = "going to edit";
     const description = "some description";
-    const adminClient = new AdminClient();
     before(() => {
       adminClient.createRealmRole({
         name: editRoleName,

--- a/cypress/integration/realm_settings_client_policies_test.spec.ts
+++ b/cypress/integration/realm_settings_client_policies_test.spec.ts
@@ -5,7 +5,7 @@ import {
   keycloakBefore,
   keycloakBeforeEach,
 } from "../support/util/keycloak_hooks";
-import AdminClient from "../support/util/AdminClient";
+import adminClient from "../support/util/AdminClient";
 import ModalUtils from "../support/util/ModalUtils";
 import Masthead from "../support/pages/admin_console/Masthead";
 
@@ -30,12 +30,12 @@ describe("Realm settings client policies tab tests", () => {
 
   before(() => {
     keycloakBefore();
-    new AdminClient().createRealm(realmName);
+    adminClient.createRealm(realmName);
     loginPage.logIn();
   });
 
   after(() => {
-    new AdminClient().deleteRealm(realmName);
+    adminClient.deleteRealm(realmName);
   });
 
   it("Complete new client form and cancel", () => {

--- a/cypress/integration/realm_settings_client_profiles_test.spec.ts
+++ b/cypress/integration/realm_settings_client_profiles_test.spec.ts
@@ -5,7 +5,7 @@ import {
   keycloakBefore,
   keycloakBeforeEach,
 } from "../support/util/keycloak_hooks";
-import AdminClient from "../support/util/AdminClient";
+import adminClient from "../support/util/AdminClient";
 import ModalUtils from "../support/util/ModalUtils";
 import Masthead from "../support/pages/admin_console/Masthead";
 
@@ -28,12 +28,12 @@ describe("Realm settings client profiles tab tests", () => {
 
   before(() => {
     keycloakBefore();
-    new AdminClient().createRealm(realmName);
+    adminClient.createRealm(realmName);
     loginPage.logIn();
   });
 
   after(async () => {
-    await new AdminClient().deleteRealm(realmName);
+    await adminClient.deleteRealm(realmName);
   });
 
   it("Go to client policies profiles tab", () => {

--- a/cypress/integration/realm_settings_events_test.spec.ts
+++ b/cypress/integration/realm_settings_events_test.spec.ts
@@ -5,7 +5,7 @@ import Masthead from "../support/pages/admin_console/Masthead";
 import ModalUtils from "../support/util/ModalUtils";
 import { keycloakBefore } from "../support/util/keycloak_hooks";
 import ListingPage from "../support/pages/admin_console/ListingPage";
-import AdminClient from "../support/util/AdminClient";
+import adminClient from "../support/util/AdminClient";
 
 const loginPage = new LoginPage();
 const sidebarPage = new SidebarPage();
@@ -24,11 +24,11 @@ describe("Realm settings events tab tests", () => {
   });
 
   before(async () => {
-    await new AdminClient().createRealm(realmName);
+    await adminClient.createRealm(realmName);
   });
 
   after(async () => {
-    await new AdminClient().deleteRealm(realmName);
+    await adminClient.deleteRealm(realmName);
   });
 
   const goToDetails = () => {

--- a/cypress/integration/realm_settings_tabs_test.spec.ts
+++ b/cypress/integration/realm_settings_tabs_test.spec.ts
@@ -3,7 +3,7 @@ import LoginPage from "../support/pages/LoginPage";
 import RealmSettingsPage from "../support/pages/admin_console/manage/realm_settings/RealmSettingsPage";
 import Masthead from "../support/pages/admin_console/Masthead";
 import { keycloakBefore } from "../support/util/keycloak_hooks";
-import AdminClient from "../support/util/AdminClient";
+import adminClient from "../support/util/AdminClient";
 
 const loginPage = new LoginPage();
 const sidebarPage = new SidebarPage();
@@ -20,11 +20,11 @@ describe("Realm settings tabs tests", () => {
   });
 
   before(async () => {
-    await new AdminClient().createRealm(realmName);
+    await adminClient.createRealm(realmName);
   });
 
   after(async () => {
-    await new AdminClient().deleteRealm(realmName);
+    await adminClient.deleteRealm(realmName);
   });
 
   it("Go to general tab", () => {

--- a/cypress/integration/realm_settings_user_profile_tab.spec.ts
+++ b/cypress/integration/realm_settings_user_profile_tab.spec.ts
@@ -2,14 +2,13 @@ import ListingPage from "../support/pages/admin_console/ListingPage";
 import UserProfile from "../support/pages/admin_console/manage/realm_settings/UserProfile";
 import SidebarPage from "../support/pages/admin_console/SidebarPage";
 import LoginPage from "../support/pages/LoginPage";
-import AdminClient from "../support/util/AdminClient";
+import adminClient from "../support/util/AdminClient";
 import { keycloakBefore } from "../support/util/keycloak_hooks";
 import ModalUtils from "../support/util/ModalUtils";
 
 const loginPage = new LoginPage();
 const sidebarPage = new SidebarPage();
 const userProfileTab = new UserProfile();
-const adminClient = new AdminClient();
 const listingPage = new ListingPage();
 const modalUtils = new ModalUtils();
 

--- a/cypress/integration/realm_test.spec.ts
+++ b/cypress/integration/realm_test.spec.ts
@@ -2,7 +2,7 @@ import LoginPage from "../support/pages/LoginPage";
 import SidebarPage from "../support/pages/admin_console/SidebarPage";
 import CreateRealmPage from "../support/pages/admin_console/CreateRealmPage";
 import Masthead from "../support/pages/admin_console/Masthead";
-import AdminClient from "../support/util/AdminClient";
+import adminClient from "../support/util/AdminClient";
 import {
   keycloakBefore,
   keycloakBeforeEach,
@@ -12,7 +12,6 @@ const masthead = new Masthead();
 const loginPage = new LoginPage();
 const sidebarPage = new SidebarPage();
 const createRealmPage = new CreateRealmPage();
-const adminClient = new AdminClient();
 
 describe("Realms test", () => {
   const testRealmName =

--- a/cypress/integration/realm_user_registration.spec.ts
+++ b/cypress/integration/realm_user_registration.spec.ts
@@ -5,7 +5,7 @@ import UserRegistration, {
 import Masthead from "../support/pages/admin_console/Masthead";
 import SidebarPage from "../support/pages/admin_console/SidebarPage";
 import LoginPage from "../support/pages/LoginPage";
-import AdminClient from "../support/util/AdminClient";
+import adminClient from "../support/util/AdminClient";
 import {
   keycloakBefore,
   keycloakBeforeEach,
@@ -17,7 +17,6 @@ describe("Realm settings - User registration tab", () => {
   const sidebarPage = new SidebarPage();
   const modalUtils = new ModalUtils();
   const masthead = new Masthead();
-  const adminClient = new AdminClient();
 
   const listingPage = new ListingPage();
   const groupPicker = new GroupPickerDialog();

--- a/cypress/integration/users_test.spec.ts
+++ b/cypress/integration/users_test.spec.ts
@@ -11,7 +11,7 @@ import {
   keycloakBeforeEach,
 } from "../support/util/keycloak_hooks";
 import UserGroupsPage from "../support/pages/admin_console/manage/users/UserGroupsPage";
-import AdminClient from "../support/util/AdminClient";
+import adminClient from "../support/util/AdminClient";
 import CredentialsPage from "../support/pages/admin_console/manage/users/CredentialsPage";
 
 let groupName = "group";
@@ -31,7 +31,6 @@ describe("User creation", () => {
 
   let itemId = "user_crud";
   let itemIdWithCred = "user_crud_cred";
-  const adminClient = new AdminClient();
 
   before(() => {
     for (let i = 0; i <= 2; i++) {

--- a/cypress/support/util/AdminClient.ts
+++ b/cypress/support/util/AdminClient.ts
@@ -7,17 +7,14 @@ import type UserProfileConfig from "@keycloak/keycloak-admin-client/lib/defs/use
 import type RoleRepresentation from "@keycloak/keycloak-admin-client/lib/defs/roleRepresentation";
 import { merge } from "lodash-es";
 
-export default class AdminClient {
-  private client: KeycloakAdminClient;
-  constructor() {
-    this.client = new KeycloakAdminClient({
-      baseUrl: `${Cypress.env("KEYCLOAK_SERVER")}/auth`,
-      realmName: "master",
-    });
-  }
+class AdminClient {
+  private readonly client = new KeycloakAdminClient({
+    baseUrl: `${Cypress.env("KEYCLOAK_SERVER")}/auth`,
+    realmName: "master",
+  });
 
-  private async login() {
-    await this.client.auth({
+  private login() {
+    return this.client.auth({
       username: "admin",
       password: "admin",
       grantType: "password",
@@ -174,3 +171,7 @@ export default class AdminClient {
     return await this.client.roles.delByName({ name });
   }
 }
+
+const adminClient = new AdminClient();
+
+export default adminClient;


### PR DESCRIPTION
As discussed in the team meeting, this allows all tests to use the same admin client instance. This reduces the amount of times we need to construct an instance in individual tests.