### PR TITLE
Run Cypress tests on Chrome when running headlessly

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "start:rh-sso": "THEME_NAME=rh-sso snowpack dev",
     "test": "jest",
     "start:cypress": "cypress open",
-    "start:cypress-tests": "cypress run",
+    "start:cypress-tests": "cypress run --browser chrome",
     "prepare": "husky install"
   },
   "dependencies": {


### PR DESCRIPTION
This more accurately reflects what browser our actual users are running. Another advantage is that this will use a recent version of Chrome, whereas Cypress ships with a version of Electron that is locked to the Cypress version.