### PR TITLE
Speed up CI by skipping account v2 theme in build

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Build Keycloak Server
         working-directory: ${{ env.KEYCLOAK_SERVER_PATH }}
-        run: mvn clean install --no-snapshot-updates --batch-mode --errors -DskipTests -Pdistribution,admin-preview
+        run: mvn clean install --no-snapshot-updates --batch-mode --errors -DskipTests -DskipAccount2 -Pdistribution,admin-preview
 
       - name: Configure distribution path
         working-directory: ${{ env.KEYCLOAK_SERVER_PATH }}


### PR DESCRIPTION
Skips the build of the account v2 theme so the build for Keycloak server is sped up. This shaves 1½ minutes off the total time to run the Cypress tests.