### PR TITLE
fixed Consent screen text was not shown

### DIFF
--- a/src/client-scopes/details/ScopeForm.tsx
+++ b/src/client-scopes/details/ScopeForm.tsx
@@ -52,6 +52,8 @@ export const ScopeForm = ({ clientScope, save }: ScopeFormProps) => {
   const displayOnConsentScreen = useWatch({
     control,
     name: "attributes.display.on.consent.screen",
+    defaultValue:
+      clientScope.attributes?.["display.on.consent.screen"] ?? "true",
   });
 
   useEffect(() => {
@@ -199,7 +201,7 @@ export const ScopeForm = ({ clientScope, save }: ScopeFormProps) => {
         <Controller
           name="attributes.display.on.consent.screen"
           control={control}
-          defaultValue="true"
+          defaultValue={displayOnConsentScreen}
           render={({ onChange, value }) => (
             <Switch
               id="kc-display.on.consent.screen-switch"


### PR DESCRIPTION
## Motivation
Closes #2051 & #1991 

## Brief Description
Fixed **Consent screen text** input was not shown when switch **Display on consent screen** was turned ON. Also fixed issue when **Consent screen text** was impossible to set/modify.
![Screenshot from 2022-02-24 15-13-38](https://user-images.githubusercontent.com/89014675/155540857-29d7a70a-ba99-429f-bbc6-9c636488bf5e.png)

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated

## Additional Notes
<!-- 
Add images and/or screen caps to illustrate what was changed if this pull request adds to or modifies existing user-visible appearance/output. 
-->
