### PR TITLE
Allow access to clipboard in Cypress tests

### DIFF
--- a/cypress/support/pages/admin_console/manage/clients/AuthorizationTab.ts
+++ b/cypress/support/pages/admin_console/manage/clients/AuthorizationTab.ts
@@ -1,6 +1,7 @@
 import type PolicyRepresentation from "@keycloak/keycloak-admin-client/lib/defs/policyRepresentation";
 import type ResourceRepresentation from "@keycloak/keycloak-admin-client/lib/defs/resourceRepresentation";
 import type ScopeRepresentation from "@keycloak/keycloak-admin-client/lib/defs/scopeRepresentation";
+import grantClipboardAccess from "../../../../util/grantClipboardAccess";
 
 type PermissionType = "resource" | "scope";
 
@@ -133,6 +134,7 @@ export default class AuthorizationTab {
   }
 
   copy() {
+    grantClipboardAccess();
     cy.findByTestId(this.exportCopyButton).click();
     return this;
   }

--- a/cypress/support/util/grantClipboardAccess.ts
+++ b/cypress/support/util/grantClipboardAccess.ts
@@ -1,0 +1,13 @@
+export default function grantClipboardAccess() {
+  // Use the Chrome debugger protocol to grant access to the clipboard.
+  // https://chromedevtools.github.io/devtools-protocol/tot/Browser/#method-grantPermissions
+  cy.wrap(
+    Cypress.automation("remote:debugger:protocol", {
+      command: "Browser.grantPermissions",
+      params: {
+        permissions: ["clipboardReadWrite", "clipboardSanitizedWrite"],
+        origin: window.location.origin,
+      },
+    })
+  );
+}


### PR DESCRIPTION
Adds a utility method to allow access to the clipboard during Cypress tests. This allows the client authorization tests to pass as expected.