### PR TITLE
fixed msg error when clientScope created with whitespace (#1997)

### DIFF
--- a/src/client-scopes/details/ScopeForm.tsx
+++ b/src/client-scopes/details/ScopeForm.tsx
@@ -78,7 +78,11 @@ export const ScopeForm = ({ clientScope, save }: ScopeFormProps) => {
         helperTextInvalid={t("common:required")}
       >
         <TextInput
-          ref={register({ required: true })}
+          ref={register({
+            required: true,
+            validate: (value: string) =>
+              !!value.trim() || t("common:required").toString(),
+          })}
           type="text"
           id="kc-name"
           name="name"

--- a/src/client-scopes/form/ClientScopeForm.tsx
+++ b/src/client-scopes/form/ClientScopeForm.tsx
@@ -106,7 +106,7 @@ export default function ClientScopeForm() {
 
   const save = async (clientScopes: ClientScopeDefaultOptionalType) => {
     try {
-      clientScopes.name = clientScopes.name?.trim();
+      clientScopes.name = clientScopes.name?.trim().replace(/ /g, "_");
       clientScopes = convertFormValuesToObject(
         clientScopes
       ) as ClientScopeDefaultOptionalType;


### PR DESCRIPTION
## Motivation
Closes #1997 

## Brief Description
During creation of new client scope, if name contains white-space, error message is shown

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated

## Additional Notes
<!-- 
Add images and/or screen caps to illustrate what was changed if this pull request adds to or modifies existing user-visible appearance/output. 
-->
