### PR TITLE
Disable test retries for Cypress

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -5,10 +5,6 @@
     "chromeWebSecurity": false,
     "viewportWidth": 1360,
     "viewportHeight": 768,
-    "retries": {
-        "runMode": 2,
-        "openMode": 0
-      },
     "defaultCommandTimeout": 30000,
     "slowTestThreshold": 30000,
     "videoCompression": false,


### PR DESCRIPTION
Disables the test retries for Cypress in order to make it more apparent which tests are flaky. The idea is to keep this PR open and rebased and provide the actual test fixes in other PRs until we see a green CI here consistently.