### PR TITLE
Restore previously skipped tests

### DIFF
--- a/cypress/integration/realm_settings_events_test.spec.ts
+++ b/cypress/integration/realm_settings_events_test.spec.ts
@@ -183,8 +183,7 @@ describe("Realm settings events tab tests", () => {
     realmSettingsPage.testSelectFilter();
   });
 
-  // TODO: Fix this test so it passes.
-  it.skip("add locale", () => {
+  it("add locale", () => {
     sidebarPage.goToRealmSettings();
 
     cy.findByTestId("rs-localization-tab").click();


### PR DESCRIPTION
After doing some testing locally it looks like all tests are passing, including the skipped ones. Therefore this PR restores all skipped tests back to their original state.