### PR TITLE
Always preserve session cookies for all tests

### DIFF
--- a/cypress/integration/client_authorization_test.spec.ts
+++ b/cypress/integration/client_authorization_test.spec.ts
@@ -1,7 +1,4 @@
-import {
-  keycloakBefore,
-  keycloakBeforeEach,
-} from "../support/util/keycloak_hooks";
+import { keycloakBefore } from "../support/util/keycloak_hooks";
 import adminClient from "../support/util/AdminClient";
 import LoginPage from "../support/pages/LoginPage";
 import ListingPage from "../support/pages/admin_console/ListingPage";
@@ -37,10 +34,6 @@ describe("Client authentication subtab", () => {
 
   after(() => {
     adminClient.deleteClient(clientId);
-  });
-
-  beforeEach(() => {
-    keycloakBeforeEach();
   });
 
   it("Should update the resource server settings", () => {

--- a/cypress/integration/client_scopes_test.spec.ts
+++ b/cypress/integration/client_scopes_test.spec.ts
@@ -7,10 +7,7 @@ import ListingPage, {
 } from "../support/pages/admin_console/ListingPage";
 import SidebarPage from "../support/pages/admin_console/SidebarPage";
 import CreateClientScopePage from "../support/pages/admin_console/manage/client_scopes/CreateClientScopePage";
-import {
-  keycloakBefore,
-  keycloakBeforeEach,
-} from "../support/util/keycloak_hooks";
+import { keycloakBefore } from "../support/util/keycloak_hooks";
 import RoleMappingTab from "../support/pages/admin_console/manage/RoleMappingTab";
 import ModalUtils from "../support/util/ModalUtils";
 import adminClient from "../support/util/AdminClient";
@@ -65,7 +62,6 @@ describe("Client Scopes test", () => {
     });
 
     beforeEach(() => {
-      keycloakBeforeEach();
       sidebarPage.goToClientScopes();
     });
 
@@ -146,7 +142,6 @@ describe("Client Scopes test", () => {
     });
 
     beforeEach(() => {
-      keycloakBeforeEach();
       sidebarPage.goToClientScopes();
     });
 
@@ -211,7 +206,6 @@ describe("Client Scopes test", () => {
     });
 
     beforeEach(() => {
-      keycloakBeforeEach();
       sidebarPage.goToClientScopes();
     });
 
@@ -272,7 +266,6 @@ describe("Client Scopes test", () => {
     });
 
     beforeEach(() => {
-      keycloakBeforeEach();
       sidebarPage.goToClientScopes();
     });
 

--- a/cypress/integration/clients_saml_test.spec.ts
+++ b/cypress/integration/clients_saml_test.spec.ts
@@ -4,10 +4,7 @@ import ListingPage from "../support/pages/admin_console/ListingPage";
 import SidebarPage from "../support/pages/admin_console/SidebarPage";
 import ModalUtils from "../support/util/ModalUtils";
 import adminClient from "../support/util/AdminClient";
-import {
-  keycloakBefore,
-  keycloakBeforeEach,
-} from "../support/util/keycloak_hooks";
+import { keycloakBefore } from "../support/util/keycloak_hooks";
 
 const loginPage = new LoginPage();
 const masthead = new Masthead();
@@ -34,7 +31,6 @@ describe("Clients SAML tests", () => {
     });
 
     beforeEach(() => {
-      keycloakBeforeEach();
       sidebarPage.goToClients();
       listingPage.searchItem(samlClientName).goToItemDetails(samlClientName);
     });
@@ -75,7 +71,6 @@ describe("Clients SAML tests", () => {
     });
 
     beforeEach(() => {
-      keycloakBeforeEach();
       sidebarPage.goToClients();
       listingPage.searchItem(clientId).goToItemDetails(clientId);
       cy.findByTestId("keysTab").click();

--- a/cypress/integration/clients_test.spec.ts
+++ b/cypress/integration/clients_test.spec.ts
@@ -10,10 +10,7 @@ import ModalUtils from "../support/util/ModalUtils";
 import AdvancedTab from "../support/pages/admin_console/manage/clients/AdvancedTab";
 import adminClient from "../support/util/AdminClient";
 import InitialAccessTokenTab from "../support/pages/admin_console/manage/clients/InitialAccessTokenTab";
-import {
-  keycloakBefore,
-  keycloakBeforeEach,
-} from "../support/util/keycloak_hooks";
+import { keycloakBefore } from "../support/util/keycloak_hooks";
 import RoleMappingTab from "../support/pages/admin_console/manage/RoleMappingTab";
 import KeysTab from "../support/pages/admin_console/manage/clients/KeysTab";
 import ClientScopesTab from "../support/pages/admin_console/manage/clients/ClientScopesTab";
@@ -208,7 +205,6 @@ describe("Clients test", () => {
     });
 
     beforeEach(() => {
-      keycloakBeforeEach();
       sidebarPage.goToClients();
     });
 
@@ -360,7 +356,6 @@ describe("Clients test", () => {
     });
 
     beforeEach(() => {
-      keycloakBeforeEach();
       sidebarPage.goToClients();
 
       client = "client_" + (Math.random() + 1).toString(36).substring(7);
@@ -418,7 +413,6 @@ describe("Clients test", () => {
     });
 
     beforeEach(() => {
-      keycloakBeforeEach();
       sidebarPage.goToClients();
     });
 
@@ -495,7 +489,6 @@ describe("Clients test", () => {
     });
 
     beforeEach(() => {
-      keycloakBeforeEach();
       sidebarPage.goToClients();
       listingPage.searchItem(keysName).goToItemDetails(keysName);
     });
@@ -530,10 +523,6 @@ describe("Clients test", () => {
       loginPage.logIn();
       sidebarPage.goToClients();
       listingPage.searchItem(clientName).goToItemDetails(clientName);
-    });
-
-    beforeEach(() => {
-      keycloakBeforeEach();
     });
 
     it("Displays the correct tabs", () => {
@@ -576,10 +565,6 @@ describe("Clients test", () => {
 
     after(() => {
       adminClient.deleteClient(clientId);
-    });
-
-    beforeEach(() => {
-      keycloakBeforeEach();
     });
 
     it("Shows an explainer text for bearer only clients", () => {

--- a/cypress/integration/masthead_test.spec.ts
+++ b/cypress/integration/masthead_test.spec.ts
@@ -2,10 +2,7 @@ import ListingPage from "../support/pages/admin_console/ListingPage";
 import LoginPage from "../support/pages/LoginPage";
 import SidebarPage from "../support/pages/admin_console/SidebarPage";
 import Masthead from "../support/pages/admin_console/Masthead";
-import {
-  keycloakBefore,
-  keycloakBeforeEach,
-} from "../support/util/keycloak_hooks";
+import { keycloakBefore } from "../support/util/keycloak_hooks";
 
 const loginPage = new LoginPage();
 const masthead = new Masthead();
@@ -33,10 +30,6 @@ describe("Masthead tests in desktop mode", () => {
     loginPage.logIn();
   });
 
-  beforeEach(() => {
-    keycloakBeforeEach();
-  });
-
   it("Test dropdown in desktop mode", () => {
     goToAcctMgtTest();
 
@@ -60,10 +53,6 @@ describe("Masthead tests with kebab menu", () => {
     keycloakBefore();
     loginPage.logIn();
     masthead.setMobileMode(true);
-  });
-
-  beforeEach(() => {
-    keycloakBeforeEach();
   });
 
   it("Test dropdown in mobile mode", () => {

--- a/cypress/integration/partial_import_test.spec.ts
+++ b/cypress/integration/partial_import_test.spec.ts
@@ -3,10 +3,7 @@ import SidebarPage from "../support/pages/admin_console/SidebarPage";
 import LoginPage from "../support/pages/LoginPage";
 import PartialImportModal from "../support/pages/admin_console/configure/realm_settings/PartialImportModal";
 import RealmSettings from "../support/pages/admin_console/configure/realm_settings/RealmSettings";
-import {
-  keycloakBefore,
-  keycloakBeforeEach,
-} from "../support/util/keycloak_hooks";
+import { keycloakBefore } from "../support/util/keycloak_hooks";
 import adminClient from "../support/util/AdminClient";
 
 describe("Partial import test", () => {
@@ -23,7 +20,6 @@ describe("Partial import test", () => {
   });
 
   beforeEach(() => {
-    keycloakBeforeEach();
     // doing this from the UI has the added bonus of putting you in the test realm
     sidebarPage.goToCreateRealm();
     createRealmPage.fillRealmName(TEST_REALM).createRealm();

--- a/cypress/integration/realm_roles_test.spec.ts
+++ b/cypress/integration/realm_roles_test.spec.ts
@@ -5,10 +5,7 @@ import ListingPage from "../support/pages/admin_console/ListingPage";
 import SidebarPage from "../support/pages/admin_console/SidebarPage";
 import CreateRealmRolePage from "../support/pages/admin_console/manage/realm_roles/CreateRealmRolePage";
 import AssociatedRolesPage from "../support/pages/admin_console/manage/realm_roles/AssociatedRolesPage";
-import {
-  keycloakBefore,
-  keycloakBeforeEach,
-} from "../support/util/keycloak_hooks";
+import { keycloakBefore } from "../support/util/keycloak_hooks";
 import adminClient from "../support/util/AdminClient";
 
 let itemId = "realm_role_crud";
@@ -27,7 +24,6 @@ describe("Realm roles test", () => {
   });
 
   beforeEach(() => {
-    keycloakBeforeEach();
     sidebarPage.goToRealmRoles();
   });
 

--- a/cypress/integration/realm_settings_client_policies_test.spec.ts
+++ b/cypress/integration/realm_settings_client_policies_test.spec.ts
@@ -1,10 +1,7 @@
 import SidebarPage from "../support/pages/admin_console/SidebarPage";
 import LoginPage from "../support/pages/LoginPage";
 import RealmSettingsPage from "../support/pages/admin_console/manage/realm_settings/RealmSettingsPage";
-import {
-  keycloakBefore,
-  keycloakBeforeEach,
-} from "../support/util/keycloak_hooks";
+import { keycloakBefore } from "../support/util/keycloak_hooks";
 import adminClient from "../support/util/AdminClient";
 import ModalUtils from "../support/util/ModalUtils";
 import Masthead from "../support/pages/admin_console/Masthead";
@@ -19,7 +16,6 @@ describe("Realm settings client policies tab tests", () => {
   const realmSettingsPage = new RealmSettingsPage(realmName);
 
   beforeEach(() => {
-    keycloakBeforeEach();
     sidebarPage
       .waitForPageLoad()
       .goToRealm(realmName)

--- a/cypress/integration/realm_settings_client_profiles_test.spec.ts
+++ b/cypress/integration/realm_settings_client_profiles_test.spec.ts
@@ -1,10 +1,7 @@
 import SidebarPage from "../support/pages/admin_console/SidebarPage";
 import LoginPage from "../support/pages/LoginPage";
 import RealmSettingsPage from "../support/pages/admin_console/manage/realm_settings/RealmSettingsPage";
-import {
-  keycloakBefore,
-  keycloakBeforeEach,
-} from "../support/util/keycloak_hooks";
+import { keycloakBefore } from "../support/util/keycloak_hooks";
 import adminClient from "../support/util/AdminClient";
 import ModalUtils from "../support/util/ModalUtils";
 import Masthead from "../support/pages/admin_console/Masthead";
@@ -21,7 +18,6 @@ describe("Realm settings client profiles tab tests", () => {
   const realmSettingsPage = new RealmSettingsPage(realmName);
 
   beforeEach(() => {
-    keycloakBeforeEach();
     sidebarPage.waitForPageLoad().goToRealm(realmName).goToRealmSettings();
     realmSettingsPage.goToClientPoliciesTab().goToClientProfilesList();
   });

--- a/cypress/integration/realm_test.spec.ts
+++ b/cypress/integration/realm_test.spec.ts
@@ -3,10 +3,7 @@ import SidebarPage from "../support/pages/admin_console/SidebarPage";
 import CreateRealmPage from "../support/pages/admin_console/CreateRealmPage";
 import Masthead from "../support/pages/admin_console/Masthead";
 import adminClient from "../support/util/AdminClient";
-import {
-  keycloakBefore,
-  keycloakBeforeEach,
-} from "../support/util/keycloak_hooks";
+import { keycloakBefore } from "../support/util/keycloak_hooks";
 
 const masthead = new Masthead();
 const loginPage = new LoginPage();
@@ -24,10 +21,6 @@ describe("Realms test", () => {
     before(() => {
       keycloakBefore();
       loginPage.logIn();
-    });
-
-    beforeEach(() => {
-      keycloakBeforeEach();
     });
 
     after(() => {

--- a/cypress/integration/realm_user_registration.spec.ts
+++ b/cypress/integration/realm_user_registration.spec.ts
@@ -6,10 +6,7 @@ import Masthead from "../support/pages/admin_console/Masthead";
 import SidebarPage from "../support/pages/admin_console/SidebarPage";
 import LoginPage from "../support/pages/LoginPage";
 import adminClient from "../support/util/AdminClient";
-import {
-  keycloakBefore,
-  keycloakBeforeEach,
-} from "../support/util/keycloak_hooks";
+import { keycloakBefore } from "../support/util/keycloak_hooks";
 import ModalUtils from "../support/util/ModalUtils";
 
 describe("Realm settings - User registration tab", () => {
@@ -31,7 +28,6 @@ describe("Realm settings - User registration tab", () => {
   });
 
   beforeEach(() => {
-    keycloakBeforeEach();
     sidebarPage.goToRealmSettings();
     userRegistration.goToTab();
   });

--- a/cypress/integration/users_test.spec.ts
+++ b/cypress/integration/users_test.spec.ts
@@ -6,10 +6,7 @@ import ListingPage from "../support/pages/admin_console/ListingPage";
 import UserDetailsPage from "../support/pages/admin_console/manage/users/UserDetailsPage";
 import AttributesTab from "../support/pages/admin_console/manage/AttributesTab";
 import ModalUtils from "../support/util/ModalUtils";
-import {
-  keycloakBefore,
-  keycloakBeforeEach,
-} from "../support/util/keycloak_hooks";
+import { keycloakBefore } from "../support/util/keycloak_hooks";
 import UserGroupsPage from "../support/pages/admin_console/manage/users/UserGroupsPage";
 import adminClient from "../support/util/AdminClient";
 import CredentialsPage from "../support/pages/admin_console/manage/users/CredentialsPage";
@@ -46,7 +43,6 @@ describe("User creation", () => {
   });
 
   beforeEach(() => {
-    keycloakBeforeEach();
     sidebarPage.goToUsers();
   });
 

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -23,3 +23,12 @@ import "./commands";
 if (!Cypress.env("KEYCLOAK_SERVER")) {
   Cypress.env("KEYCLOAK_SERVER", "http://localhost:8180");
 }
+
+// Always preserve session related cookies.
+Cypress.Cookies.defaults({
+  preserve: isSessionCookie,
+});
+
+function isSessionCookie({ name }: Cypress.Cookie) {
+  return name.startsWith("KEYCLOAK_") || name.startsWith("AUTH_SESSION_");
+}

--- a/cypress/support/util/keycloak_hooks.ts
+++ b/cypress/support/util/keycloak_hooks.ts
@@ -14,7 +14,3 @@ export const keycloakBefore = () => {
   cy.visit("");
   cy.get('[role="progressbar"]').should("not.exist");
 };
-
-export const keycloakBeforeEach = () => {
-  Cypress.Cookies.preserveOnce("KEYCLOAK_SESSION", "KEYCLOAK_IDENTITY");
-};


### PR DESCRIPTION
This changes ensures that the Keycloak session cookies are preserved between tests. This remove the need to manually call `keycloakBeforeEach()` for each test case.