### PR TITLE
Change order of client sections

### DIFF
--- a/src/clients/ClientSettings.tsx
+++ b/src/clients/ClientSettings.tsx
@@ -56,17 +56,17 @@ export const ClientSettings = ({
   );
 
   const sections = useMemo(() => {
-    let result = ["generalSettings"];
+    let result = ["generalSettings", "accessSettings"];
 
     if (protocol === "saml") {
       result = [...result, "samlCapabilityConfig", "signatureAndEncryption"];
     } else if (!client.bearerOnly) {
       result = [...result, "capabilityConfig"];
     } else {
-      return [...result, "accessSettings"];
+      return [result];
     }
 
-    return [...result, "accessSettings", "loginSettings", "logoutSettings"];
+    return [...result, "loginSettings", "logoutSettings"];
   }, [protocol, client]);
 
   return (

--- a/src/clients/ClientSettings.tsx
+++ b/src/clients/ClientSettings.tsx
@@ -63,7 +63,7 @@ export const ClientSettings = ({
     } else if (!client.bearerOnly) {
       result = [...result, "capabilityConfig"];
     } else {
-      return [result];
+      return result;
     }
 
     return [...result, "loginSettings", "logoutSettings"];


### PR DESCRIPTION
## Motivation
Fixes https://github.com/keycloak/keycloak-admin-ui/issues/1434.

## Brief Description
Issue https://github.com/keycloak/keycloak-admin-ui/issues/1434 requests that SAML client settings match the [design](https://marvelapp.com/prototype/880h4f8/screen/82212914) by adding two missing fields (`Always display in console` and `Front channel logout`) and changing the section order. The two missing fields were actually added as part of [this PR](https://github.com/keycloak/keycloak-admin-ui/pull/2165) to fix a [duplicate issue](https://github.com/keycloak/keycloak-admin-ui/issues/2026). So this fix just changes the order to match the original design.

## Verification Steps
Verify that the SAML client exactly matches the original design here:
https://marvelapp.com/prototype/880h4f8/screen/82212914

## Checklist:
- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [x] Help has been implemented
- [x] Unit tests have been created/updated

## Additional Notes
None