### PR TITLE
Change tab order in user details

### DIFF
--- a/src/user/UsersTabs.tsx
+++ b/src/user/UsersTabs.tsx
@@ -203,6 +203,13 @@ const UsersTabs = () => {
                 <UserCredentials user={user} />
               </Tab>
               <Tab
+                eventKey="role-mapping"
+                data-testid="role-mapping-tab"
+                title={<TabTitleText>{t("roleMapping")}</TabTitleText>}
+              >
+                <UserRoleMapping id={id} name={user.username!} />
+              </Tab>
+              <Tab
                 eventKey="groups"
                 data-testid="user-groups-tab"
                 title={<TabTitleText>{t("common:groups")}</TabTitleText>}
@@ -215,13 +222,6 @@ const UsersTabs = () => {
                 title={<TabTitleText>{t("consents")}</TabTitleText>}
               >
                 <UserConsents />
-              </Tab>
-              <Tab
-                eventKey="role-mapping"
-                data-testid="role-mapping-tab"
-                title={<TabTitleText>{t("roleMapping")}</TabTitleText>}
-              >
-                <UserRoleMapping id={id} name={user.username!} />
               </Tab>
               {hasAccess("view-identity-providers") && (
                 <Tab


### PR DESCRIPTION
## Motivation
Fixes https://github.com/keycloak/keycloak-admin-ui/issues/1716.

## Brief Description
Simple fix to change order of User details tabs to match design.

## Verification Steps
1. Go to Users and select a user to get details.
2. Verify that the order is now Details, Attributes, Credentials, Role mapping, Groups, Consents, and Identity provider links.

## Checklist:
- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [x] Help has been implemented
- [x] Unit tests have been created/updated

## Additional Notes
None