### PR TITLE
Fixes client profile links

### DIFF
--- a/src/realm-settings/NewClientPolicyForm.tsx
+++ b/src/realm-settings/NewClientPolicyForm.tsx
@@ -36,6 +36,8 @@ import type ClientPolicyRepresentation from "@keycloak/keycloak-admin-client/lib
 import { toNewClientPolicyCondition } from "./routes/AddCondition";
 import { useServerInfo } from "../context/server-info/ServerInfoProvider";
 import { toEditClientPolicyCondition } from "./routes/EditCondition";
+import { toClientProfile } from "./routes/ClientProfile";
+
 import {
   EditClientPolicyParams,
   toEditClientPolicy,
@@ -667,7 +669,10 @@ export default function NewClientPolicyForm() {
                                 <Link
                                   key={profile}
                                   data-testid="profile-name-link"
-                                  to={""}
+                                  to={toClientProfile({
+                                    realm,
+                                    profileName: profile,
+                                  })}
                                   className="kc-profile-link"
                                 >
                                   {profile}


### PR DESCRIPTION
## Motivation
Fixes https://github.com/keycloak/keycloak-admin-ui/issues/1788.

## Brief Description
The navigation destination for client profile links was empty, added the appropriate link.

## Verification Steps
See https://github.com/keycloak/keycloak-admin-ui/issues/1788 for steps to reproduce, verify that clicking any of the client profiles will now navigate to that particular client profile, instead of jumping to the realm homepage.

## Checklist:
- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [x] Help has been implemented
- [x] Unit tests have been created/updated

## Additional Notes
None