### PR TITLE
Make theme deployable from archive

### DIFF
--- a/keycloak-theme/.gitignore
+++ b/keycloak-theme/.gitignore
@@ -1,4 +1,3 @@
-src/
 node/
 # https://github.com/github/gitignore/blob/master/Maven.gitignore
 target/

--- a/keycloak-theme/README.md
+++ b/keycloak-theme/README.md
@@ -1,25 +1,13 @@
-# Keycloak Admin Console V2 Maven Build
+# Keycloak Theme (Maven Build)
 
-The Maven build prepares the admin console to be deployed as a theme on the Keycloak server.
+This directory contains the Maven build for the Keycloak theme. It allows the theme to be built as a JAR which can be included when running the Keycloak server.
 
-# Build Instructions
+## Building
 
 ```bash
 mvn install
 ```
 
-# Deployment
+## Deployment
 
-The jar created with `mvn install` needs to be deployed to a Maven repository. From there, it will become part of the Keycloak server build.
-
-For development, you can also just copy the contents of `./target/classes` to `<keycloak server>/themes/keycloak.v2`. Then restart the server.
-
-# To Run
-
-Until New Admin Console becomes the default, you will need to start Keycloak server like this:
-
-```bash
-$> bin/standalone.sh -Dkeycloak.profile.feature.admin2=enabled
-```
-
-Then go to `Realm Settings --> Themes` and set Admin Console Theme to `keycloak.v2`.
+First build the this repository with the instructions above, then [build the Keycloak sever](https://github.com/keycloak/keycloak/blob/main/docs/building.md). Start the Keycloak server and navigate to `Realm Settings` ➡️ `Themes` and set admin theme to `keycloak.v2`.

--- a/keycloak-theme/pom.xml
+++ b/keycloak-theme/pom.xml
@@ -119,17 +119,6 @@
 
         <plugins>
             <plugin>
-                <artifactId>maven-clean-plugin</artifactId>
-                <version>3.2.0</version>
-                <configuration>
-                    <filesets>
-                        <fileset>
-                            <directory>src</directory>
-                        </fileset>
-                    </filesets>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
                 <version>1.12.1</version>
@@ -144,6 +133,9 @@
                         <goals>
                             <goal>npm</goal>
                         </goals>
+                        <configuration>
+                            <arguments>ci</arguments>
+                        </configuration>
                     </execution>
                     <execution>
                         <id>npm run build</id>
@@ -171,7 +163,7 @@
                             <goal>copy-resources</goal>
                         </goals>
                         <configuration>
-                            <outputDirectory>src/main/resources/admin/resources</outputDirectory>
+                            <outputDirectory>target/classes/theme/keycloak.v2/admin/resources</outputDirectory>
                             <resources>
                                 <resource>
                                     <directory>../build</directory>
@@ -207,8 +199,8 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <file>target/classes/admin/resources/index.html</file>
-                    <outputFile>target/classes/admin/index.ftl</outputFile>
+                    <file>target/classes/theme/keycloak.v2/admin/resources/index.html</file>
+                    <outputFile>target/classes/theme/keycloak.v2/admin/index.ftl</outputFile>
                     <regex>false</regex>
                     <replacements>
                         <replacement>
@@ -238,7 +230,7 @@
   </script>
 </body>
 ]]>
-                            </value>
+</value>
                         </replacement>
                     </replacements>
 

--- a/keycloak-theme/src/main/resources/META-INF/keycloak-themes.json
+++ b/keycloak-theme/src/main/resources/META-INF/keycloak-themes.json
@@ -1,0 +1,10 @@
+{
+  "themes": [
+    {
+      "name": "keycloak.v2",
+      "types": [
+        "admin"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Changes the build so the theme can be [deployed as an archive](https://www.keycloak.org/docs/latest/server_development/index.html#deploying-themes). This allows the theme to be added into the Keycloak installation as a JAR, without the need to extract it.

This also helps eliminate the need to build the Keycloak server and theme together, which can simplify our integration tests and possibly reduce the time needed to run the tests in a future change.

Merge together with: https://github.com/keycloak/keycloak/pull/11281