### PR TITLE
Adds all missing user fed kerberos tests

### DIFF
--- a/cypress/support/pages/admin_console/manage/providers/ProviderPage.ts
+++ b/cypress/support/pages/admin_console/manage/providers/ProviderPage.ts
@@ -48,7 +48,7 @@ export default class ProviderPage {
   private ldapGroupsDnInput = "groups.dn";
   private ldapRolesDnInput = "roles.dn";
 
-  // mapper types
+  // Mapper types
   private msadUserAcctMapper = "msad-user-account-control-mapper";
   private msadLdsUserAcctMapper = "msad-lds-user-account-control-mapper";
   private userAttLdapMapper = "user-attribute-ldap-mapper";
@@ -69,6 +69,13 @@ export default class ProviderPage {
 
   private groupName = "aa-uf-mappers-group";
   private clientName = "aa-uf-mappers-client";
+
+  private maxLifespan = "kerberos-cache-lifespan";
+
+  // Kerberos settings switch input values
+  debugSwitch = "debug";
+  firstLoginSwitch = "update-first-login";
+  passwordAuthSwitch = "allow-password-authentication";
 
   changeCacheTime(unit: string, time: string) {
     switch (unit) {
@@ -130,6 +137,22 @@ export default class ProviderPage {
     if (keytab) {
       cy.get(`[${this.kerberosKeytabInput}]`).type(keytab);
     }
+    return this;
+  }
+
+  fillMaxLifespanData(lifespan: string) {
+    cy.findByTestId(this.maxLifespan).type("x");
+    cy.findByTestId(this.maxLifespan).clear().type(lifespan).blur();
+    return this;
+  }
+
+  toggleSwitch(switchName: string) {
+    cy.findByTestId(switchName).click({ force: true });
+    return this;
+  }
+
+  verifyToggle(switchName: string, value: "on" | "off") {
+    cy.findByTestId(switchName).should("have.value", value);
     return this;
   }
 

--- a/src/user-federation/kerberos/KerberosSettingsRequired.tsx
+++ b/src/user-federation/kerberos/KerberosSettingsRequired.tsx
@@ -225,6 +225,7 @@ export const KerberosSettingsRequired = ({
             render={({ onChange, value }) => (
               <Switch
                 id={"kc-debug"}
+                data-testid="debug"
                 onChange={(value) => onChange([`${value}`])}
                 isChecked={value?.[0] === "true"}
                 label={t("common:on")}
@@ -252,6 +253,7 @@ export const KerberosSettingsRequired = ({
             render={({ onChange, value }) => (
               <Switch
                 id={"kc-allow-password-authentication"}
+                data-testid="allow-password-authentication"
                 onChange={(value) => onChange([`${value}`])}
                 isChecked={value?.[0] === "true"}
                 label={t("common:on")}
@@ -320,6 +322,7 @@ export const KerberosSettingsRequired = ({
             render={({ onChange, value }) => (
               <Switch
                 id={"kc-update-first-login"}
+                data-testid="update-first-login"
                 onChange={(value) => onChange([`${value}`])}
                 isChecked={value?.[0] === "true"}
                 label={t("common:on")}


### PR DESCRIPTION
## Motivation
https://docs.google.com/spreadsheets/d/1eCngdn3wmMeQ0u5u-eKYJo1XdT2fHvi7ki51mrcu-Ys/edit#gid=1613790516&range=A741

## Brief Description
Added tests for all cache policy types and general settings switches (rows 743, 744, 746, 747, and 750 in the [test coverage dashboard](https://docs.google.com/spreadsheets/d/1eCngdn3wmMeQ0u5u-eKYJo1XdT2fHvi7ki51mrcu-Ys/edit#gid=1613790516).

## Verification Steps
The user fed kerberos test runs without errors.

## Checklist:
- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [x] Help has been implemented
- [x] Unit tests have been created/updated

## Additional Notes
Tests passed locally in cypress UI and headless.