### PR TITLE
Adds tests for searching LDAP mappers

### DIFF
--- a/cypress/integration/user_fed_ldap_mapper_test.spec.ts
+++ b/cypress/integration/user_fed_ldap_mapper_test.spec.ts
@@ -45,9 +45,22 @@ const mapperDeleteTitle = "Delete mapping?";
 const msadUserAcctMapper = "msad-user-account-control-mapper";
 const msadLdsUserAcctMapper = "msad-lds-user-account-control-mapper";
 const userAttLdapMapper = "user-attribute-ldap-mapper";
-const certLdapMapper = "certificate-ldap-mapper";
 const fullNameLdapMapper = "full-name-ldap-mapper";
 const groupLdapMapper = "group-ldap-mapper";
+const certLdapMapper = "certificate-ldap-mapper";
+
+const mapperNames = [
+  `${msadUserAcctMapper}-test`,
+  `${msadLdsUserAcctMapper}-test`,
+  `${userAttLdapMapper}-test`,
+  `${fullNameLdapMapper}-test`,
+  `${groupLdapMapper}-test`,
+];
+const multiMapperNames = mapperNames.slice(2);
+const singleMapperName = mapperNames.slice(4);
+const uniqueSearchTerm = "group";
+const multipleSearchTerm = "ldap";
+const nonexistingSearchTerm = "redhat";
 
 // Used by "Delete default mappers" test
 const creationDateMapper = "creation date";
@@ -170,7 +183,8 @@ describe("User Fed LDAP mapper tests", () => {
     masthead.checkNotificationMessage(mapperDeletedSuccess);
   });
 
-  // create one of each mapper type
+  // create one of each non-hardcoded mapper type except
+  // certificate ldap mapper which was already tested in CRUD section
   it("Create user account control mapper", () => {
     providersPage.clickExistingCard(ldapName);
     providersPage.goToMappers();
@@ -187,15 +201,6 @@ describe("User Fed LDAP mapper tests", () => {
     providersPage.save("ldap-mapper");
     masthead.checkNotificationMessage(mapperCreatedSuccess);
     listingPage.itemExist(msadLdsUserAcctMapper, true);
-  });
-
-  it("Create certificate ldap mapper", () => {
-    providersPage.clickExistingCard(ldapName);
-    providersPage.goToMappers();
-    providersPage.createNewMapper(certLdapMapper);
-    providersPage.save("ldap-mapper");
-    masthead.checkNotificationMessage(mapperCreatedSuccess);
-    listingPage.itemExist(certLdapMapper, true);
   });
 
   it("Create user attribute ldap mapper", () => {
@@ -223,6 +228,34 @@ describe("User Fed LDAP mapper tests", () => {
     providersPage.save("ldap-mapper");
     masthead.checkNotificationMessage(mapperCreatedSuccess);
     listingPage.itemExist(groupLdapMapper, true);
+  });
+
+  it("Should return one search result for mapper with unique string", () => {
+    providersPage.clickExistingCard(ldapName);
+    providersPage.goToMappers();
+    listingPage.searchItem(uniqueSearchTerm, false);
+    singleMapperName.map((mapperName) => listingPage.itemExist(mapperName));
+  });
+
+  it("Should return multiple search results for mappers that share common string", () => {
+    providersPage.clickExistingCard(ldapName);
+    providersPage.goToMappers();
+    listingPage.searchItem(multipleSearchTerm, false);
+    multiMapperNames.map((mapperName) => listingPage.itemExist(mapperName));
+  });
+
+  it("Should return all mappers in search results when no string is specified", () => {
+    providersPage.clickExistingCard(ldapName);
+    providersPage.goToMappers();
+    listingPage.searchItem("", false);
+    mapperNames.map((mapperName) => listingPage.itemExist(mapperName));
+  });
+
+  it("Should return no search results for string that does not exist in any mappers", () => {
+    providersPage.clickExistingCard(ldapName);
+    providersPage.goToMappers();
+    listingPage.searchItem(nonexistingSearchTerm, false);
+    cy.findByTestId(listingPage.emptyState).should("exist");
   });
 
   // *** test cleanup ***


### PR DESCRIPTION
## Motivation
https://docs.google.com/spreadsheets/d/1eCngdn3wmMeQ0u5u-eKYJo1XdT2fHvi7ki51mrcu-Ys/edit#gid=1613790516&range=720:722

## Brief Description
Added tests for searching LDAP mappers, including tests for strings that return one result, multiple results, all results, and no results. Also sped up the test a bit by removing the certificate ldap mapper test, it is already being tested in the CRUD test section so it was essentially being tested twice.

## Verification Steps
The LDAP mappers test runs without errors.

## Checklist:
- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation)
- [x] Help has been implemented
- [x] Unit tests have been created/updated

## Additional Notes
Tests passed locally in cypress UI and headless.