### PR TITLE
changed to be disabled when not enabled

### DIFF
--- a/src/authentication/RequiredActions.tsx
+++ b/src/authentication/RequiredActions.tsx
@@ -154,12 +154,8 @@ export const RequiredActions = () => {
             <Switch
               id={`default-${row.name}`}
               label={t("common:on")}
-              isDisabled={!!isUnregisteredAction(row.data)}
-              labelOff={
-                isUnregisteredAction(row.data)
-                  ? t("disabledOff")
-                  : t("common:off")
-              }
+              isDisabled={!row.enabled}
+              labelOff={!row.enabled ? t("disabledOff") : t("common:off")}
               isChecked={row.defaultAction}
               onChange={() => {
                 updateAction(row.data, "defaultAction");


### PR DESCRIPTION
used to be that it would use disabled to indicate that it had been registered
now it only is disable when it's not enabled.

fixes: #1964