### PR TITLE
Remove no-proxy argument from Keycloak server

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -52,8 +52,10 @@ jobs:
 
       - name: Start Keycloak Server
         working-directory: ${{ env.KEYCLOAK_SERVER_BIN }}
-        run: |
-          KEYCLOAK_ADMIN=admin KEYCLOAK_ADMIN_PASSWORD=admin ./kc.sh start-dev --proxy=none -Dkeycloak.profile.feature.admin2=enabled -Dkeycloak.profile.feature.declarative_user_profile=enabled &
+        run: ./kc.sh start-dev -Dkeycloak.profile.feature.admin2=enabled -Dkeycloak.profile.feature.declarative_user_profile=enabled &
+        env:
+          KEYCLOAK_ADMIN: admin
+          KEYCLOAK_ADMIN_PASSWORD: admin
 
       - name: Set up Node
         uses: actions/setup-node@v2


### PR DESCRIPTION
Removes the `--proxy=none` option passed to the Keycloak server which is currently preventing the server from starting correctly.