### PR TITLE
Use 'del' to remove passing test videos

### DIFF
--- a/cypress/plugins/index.ts
+++ b/cypress/plugins/index.ts
@@ -1,8 +1,8 @@
 // The Webpack preprocessor does not include any types so it will have to be ignored.
 // @ts-ignore
 import webpackPreprocessor from "@cypress/webpack-batteries-included-preprocessor";
+import del from "del";
 import ForkTsCheckerWebpackPlugin from "fork-ts-checker-webpack-plugin";
-import fs from "fs";
 import path from "path";
 
 // ***********************************************************
@@ -37,7 +37,8 @@ const configurePlugins: Cypress.PluginConfig = (on) => {
       webpackOptions,
     })
   );
-  on("after:spec", (spec, results) => {
+
+  on("after:spec", async (spec, results) => {
     if (!results.video) {
       return;
     }
@@ -47,9 +48,9 @@ const configurePlugins: Cypress.PluginConfig = (on) => {
       attempts.some(({ state }) => state === "failed")
     );
 
-    // delete the video if the spec passed and no tests retried
+    // Delete the video if the spec passed and no tests were retried.
     if (!failures) {
-      fs.rmSync(results.video);
+      await del(results.video);
     }
   });
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "cypress": "^9.5.2",
         "cypress-file-upload": "^5.0.8",
         "decompress": "^4.2.1",
+        "del": "^6.0.0",
         "eslint": "^8.11.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-cypress": "^2.12.1",
@@ -8734,6 +8735,28 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/del": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/del/-/del-6.0.0.tgz",
+      "integrity": "sha512-1shh9DQ23L16oXSZKB2JxpL7iMy2E0S9d517ptA1P8iw0alkPtQcrKH7ru31rYtKwF499HkTu+DRzq3TCKDFRQ==",
+      "dev": true,
+      "dependencies": {
+        "globby": "^11.0.1",
+        "graceful-fs": "^4.2.4",
+        "is-glob": "^4.0.1",
+        "is-path-cwd": "^2.2.0",
+        "is-path-inside": "^3.0.2",
+        "p-map": "^4.0.0",
+        "rimraf": "^3.0.2",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -12064,6 +12087,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-path-cwd": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
+      "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/is-path-inside": {
@@ -28683,6 +28715,22 @@
         "isobject": "^3.0.1"
       }
     },
+    "del": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/del/-/del-6.0.0.tgz",
+      "integrity": "sha512-1shh9DQ23L16oXSZKB2JxpL7iMy2E0S9d517ptA1P8iw0alkPtQcrKH7ru31rYtKwF499HkTu+DRzq3TCKDFRQ==",
+      "dev": true,
+      "requires": {
+        "globby": "^11.0.1",
+        "graceful-fs": "^4.2.4",
+        "is-glob": "^4.0.1",
+        "is-path-cwd": "^2.2.0",
+        "is-path-inside": "^3.0.2",
+        "p-map": "^4.0.0",
+        "rimraf": "^3.0.2",
+        "slash": "^3.0.0"
+      }
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -31218,6 +31266,12 @@
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
+    },
+    "is-path-cwd": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
+      "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
+      "dev": true
     },
     "is-path-inside": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "cypress": "^9.5.2",
     "cypress-file-upload": "^5.0.8",
     "decompress": "^4.2.1",
+    "del": "^6.0.0",
     "eslint": "^8.11.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-cypress": "^2.12.1",


### PR DESCRIPTION
Depending on how the tests are ran removing the video files can cause an exception (especially when running in parallel). This aligns with what the Cypress documentation [recommends](https://docs.cypress.io/guides/guides/screenshots-and-videos#Only-upload-videos-for-specs-with-failing-or-retried-tests).

Also includes changes to properly await the deletion of the files.