### PR TITLE
Change to using quarkus features option and add fine grained auth

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Start Keycloak Server
         working-directory: ${{ env.KEYCLOAK_SERVER_BIN }}
-        run: ./kc.sh start-dev -Dkeycloak.profile.feature.admin2=enabled -Dkeycloak.profile.feature.declarative_user_profile=enabled &
+        run: ./kc.sh start-dev --features=admin2,admin-fine-grained-authz,declarative-user-profile &
         env:
           KEYCLOAK_ADMIN: admin
           KEYCLOAK_ADMIN_PASSWORD: admin

--- a/start.mjs
+++ b/start.mjs
@@ -63,8 +63,7 @@ const run = () => {
     [
       "start-dev",
       "--http-port=8180",
-      "-Dkeycloak.profile.feature.admin2=enabled",
-      "-Dkeycloak.profile.feature.declarative_user_profile=enabled",
+      "--features=admin2,admin-fine-grained-authz,declarative-user-profile",
       ...args,
     ],
     {


### PR DESCRIPTION
## Motivation
Make use of keycloak-quarkus features option and add fine grained authorization.  This is now preferred to using the java system properties.

## Brief Description
Based on https://www.keycloak.org/server/features

## Verification Steps
I am unable to run the start.mjs file on my box, so I need someone else to verify that this works.

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated

