### PR TITLE
Disable Dependabot updates for react-flow-renderer

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,8 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: use-react-router-breadcrumbs
         update-types: ["version-update:semver-major"]
+      - dependency-name: react-flow-renderer
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: maven
     directory: keycloak-theme
     open-pull-requests-limit: 999


### PR DESCRIPTION
The new version of `react-flow-renderer` has some breaking changes which will require a manual upgrade. For that reason, let's disable this dependency update for now.