### PR TITLE
fixes empty key value convert

### DIFF
--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -99,4 +99,16 @@ describe("Tests the form convert util functions", () => {
       },
     });
   });
+
+  it("convert empty to empty object", () => {
+    const given = { attributes: [{ key: "", value: "" }] };
+
+    //when
+    const values = convertFormValuesToObject(given);
+
+    //then
+    expect(values).toEqual({
+      attributes: {},
+    });
+  });
 });

--- a/src/util.ts
+++ b/src/util.ts
@@ -74,9 +74,8 @@ const isAttributeArray = (value: any) => {
     return false;
   }
 
-  return (
-    value.filter((e) => Object.hasOwn(e, "key") && Object.hasOwn(e, "value"))
-      .length !== 0
+  return value.some(
+    (e) => Object.hasOwn(e, "key") && Object.hasOwn(e, "value")
   );
 };
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -77,8 +77,8 @@ const isAttributeArray = (value: any) => {
   return (
     value.filter(
       (e) =>
-        Object.prototype.hasOwnProperty.call(e, "key") &&
-        Object.prototype.hasOwnProperty.call(e, "value")
+        Object.hasOwn(e, "key") &&
+        Object.hasOwn(e, "value")
     ).length !== 0
   );
 };

--- a/src/util.ts
+++ b/src/util.ts
@@ -73,7 +73,14 @@ const isAttributeArray = (value: any) => {
   if (!Array.isArray(value)) {
     return false;
   }
-  return value.filter((e) => e.key && e.value).length !== 0;
+
+  return (
+    value.filter(
+      (e) =>
+        Object.prototype.hasOwnProperty.call(e, "key") &&
+        Object.prototype.hasOwnProperty.call(e, "value")
+    ).length !== 0
+  );
 };
 
 const isEmpty = (obj: any) => Object.keys(obj).length === 0;

--- a/src/util.ts
+++ b/src/util.ts
@@ -75,11 +75,8 @@ const isAttributeArray = (value: any) => {
   }
 
   return (
-    value.filter(
-      (e) =>
-        Object.hasOwn(e, "key") &&
-        Object.hasOwn(e, "value")
-    ).length !== 0
+    value.filter((e) => Object.hasOwn(e, "key") && Object.hasOwn(e, "value"))
+      .length !== 0
   );
 };
 


### PR DESCRIPTION
Empty attributes `attributes: [{ key: "", value: "" }]` where not detected as such, this fixes that