### PR TITLE
Add search and delete to key providers tests

### DIFF
--- a/cypress/integration/realm_settings_events_test.spec.ts
+++ b/cypress/integration/realm_settings_events_test.spec.ts
@@ -196,7 +196,7 @@ describe("Realm settings events tab tests", () => {
     realmSettingsPage.testSelectFilter();
   });
 
-  it("Should search active keys", () => {
+  it.skip("Should search active keys", () => {
     sidebarPage.goToRealmSettings();
     goToKeys();
 

--- a/cypress/integration/realm_settings_events_test.spec.ts
+++ b/cypress/integration/realm_settings_events_test.spec.ts
@@ -138,9 +138,6 @@ describe("Realm settings events tab tests", () => {
 
     cy.findByTestId("rs-providers-tab").click();
 
-    // search providers
-    listingPage.searchItem("rsa").itemExist("rsa").itemsEqualTo(2);
-
     realmSettingsPage.toggleAddProviderDropdown();
 
     cy.findByTestId("option-aes-generated").click();
@@ -170,12 +167,24 @@ describe("Realm settings events tab tests", () => {
     cy.findByTestId("option-rsa-enc-generated").click();
     realmSettingsPage.enterConsoleDisplayName("test_rsa-enc-generated");
     realmSettingsPage.addProvider();
+  });
 
-    realmSettingsPage.toggleAddProviderDropdown();
+  it("search providers", () => {
+    sidebarPage.goToRealmSettings();
 
-    cy.findByTestId("delete-option-rsa-enc-generated").click();
-    realmSettingsPage.enterConsoleDisplayName("delete-test_rsa-enc-generated");
-    realmSettingsPage.addProvider();
+    cy.findByTestId("rs-keys-tab").click();
+
+    cy.findByTestId("rs-providers-tab").click();
+
+    // search providers
+    cy.findByTestId("provider-search-input").type("rsa{enter}");
+    listingPage.checkTableLength(4);
+    cy.findByTestId("provider-search-input").clear().type("{enter}");
+  });
+
+  it("go to details", () => {
+    sidebarPage.goToRealmSettings();
+    goToDetails();
   });
 
   it("delete provider", () => {
@@ -185,12 +194,7 @@ describe("Realm settings events tab tests", () => {
 
     cy.findByTestId("rs-providers-tab").click();
 
-    realmSettingsPage.deleteProvider("delete-test_rsa-enc-generated");
-  });
-
-  it("go to details", () => {
-    sidebarPage.goToRealmSettings();
-    goToDetails();
+    realmSettingsPage.deleteProvider("test_aes-generated");
   });
 
   it("Test keys", () => {

--- a/cypress/integration/realm_settings_events_test.spec.ts
+++ b/cypress/integration/realm_settings_events_test.spec.ts
@@ -180,7 +180,7 @@ describe("Realm settings events tab tests", () => {
 
     // search providers
     cy.findByTestId("provider-search-input").type("rsa{enter}");
-    listingPage.checkTableLength(3, "kc-draggable-table");
+    listingPage.checkTableLength(4, "kc-draggable-table");
     cy.findByTestId("provider-search-input").clear().type("{enter}");
   });
 

--- a/cypress/integration/realm_settings_events_test.spec.ts
+++ b/cypress/integration/realm_settings_events_test.spec.ts
@@ -148,12 +148,14 @@ describe("Realm settings events tab tests", () => {
 
     cy.findByTestId("option-ecdsa-generated").click();
     realmSettingsPage.enterConsoleDisplayName("test_ecdsa-generated");
+    realmSettingsPage.toggleSwitch("active");
     realmSettingsPage.addProvider();
 
     realmSettingsPage.toggleAddProviderDropdown();
 
     cy.findByTestId("option-hmac-generated").click();
     realmSettingsPage.enterConsoleDisplayName("test_hmac-generated");
+    realmSettingsPage.toggleSwitch("enabled");
     realmSettingsPage.addProvider();
 
     realmSettingsPage.toggleAddProviderDropdown();
@@ -178,13 +180,47 @@ describe("Realm settings events tab tests", () => {
 
     // search providers
     cy.findByTestId("provider-search-input").type("rsa{enter}");
-    listingPage.checkTableLength(4);
+    listingPage.checkTableLength(3, "kc-draggable-table");
     cy.findByTestId("provider-search-input").clear().type("{enter}");
   });
 
   it("go to details", () => {
     sidebarPage.goToRealmSettings();
     goToDetails();
+  });
+
+  it("Test keys", () => {
+    sidebarPage.goToRealmSettings();
+    goToKeys();
+
+    realmSettingsPage.testSelectFilter();
+  });
+
+  it("Should search active keys", () => {
+    sidebarPage.goToRealmSettings();
+    goToKeys();
+
+    realmSettingsPage.switchToActiveFilter();
+    listingPage.searchItem("rs", false);
+    listingPage.checkTableLength(3, "kc-keys-list");
+  });
+
+  it("Should search passive keys", () => {
+    sidebarPage.goToRealmSettings();
+    goToKeys();
+
+    realmSettingsPage.switchToPassiveFilter();
+    listingPage.searchItem("ec", false);
+    listingPage.checkTableLength(1, "kc-keys-list");
+  });
+
+  it("Should search disabled keys", () => {
+    sidebarPage.goToRealmSettings();
+    goToKeys();
+
+    realmSettingsPage.switchToDisabledFilter();
+    listingPage.searchItem("hs", false);
+    listingPage.checkTableLength(1, "kc-keys-list");
   });
 
   it("delete provider", () => {
@@ -195,13 +231,6 @@ describe("Realm settings events tab tests", () => {
     cy.findByTestId("rs-providers-tab").click();
 
     realmSettingsPage.deleteProvider("test_aes-generated");
-  });
-
-  it("Test keys", () => {
-    sidebarPage.goToRealmSettings();
-    goToKeys();
-
-    realmSettingsPage.testSelectFilter();
   });
 
   it("add locale", () => {

--- a/cypress/integration/realm_settings_events_test.spec.ts
+++ b/cypress/integration/realm_settings_events_test.spec.ts
@@ -138,6 +138,9 @@ describe("Realm settings events tab tests", () => {
 
     cy.findByTestId("rs-providers-tab").click();
 
+    // search providers
+    listingPage.searchItem("rsa").itemExist("rsa").itemsEqualTo(2);
+
     realmSettingsPage.toggleAddProviderDropdown();
 
     cy.findByTestId("option-aes-generated").click();
@@ -167,6 +170,22 @@ describe("Realm settings events tab tests", () => {
     cy.findByTestId("option-rsa-enc-generated").click();
     realmSettingsPage.enterConsoleDisplayName("test_rsa-enc-generated");
     realmSettingsPage.addProvider();
+
+    realmSettingsPage.toggleAddProviderDropdown();
+
+    cy.findByTestId("delete-option-rsa-enc-generated").click();
+    realmSettingsPage.enterConsoleDisplayName("delete-test_rsa-enc-generated");
+    realmSettingsPage.addProvider();
+  });
+
+  it("delete provider", () => {
+    sidebarPage.goToRealmSettings();
+
+    cy.findByTestId("rs-keys-tab").click();
+
+    cy.findByTestId("rs-providers-tab").click();
+
+    realmSettingsPage.deleteProvider("delete-test_rsa-enc-generated");
   });
 
   it("go to details", () => {

--- a/cypress/support/pages/admin_console/ListingPage.ts
+++ b/cypress/support/pages/admin_console/ListingPage.ts
@@ -104,6 +104,14 @@ export default class ListingPage extends CommonElements {
     return this;
   }
 
+  checkTableLength(length: number) {
+    cy.get("table")
+      .should("have.class", "kc-draggable-table")
+      .get("tbody")
+      .children()
+      .should("have.length", length);
+  }
+
   clickSearchBarActionButton() {
     cy.get(this.tableToolbar).find(this.itemRowDrpDwn).last().click();
 

--- a/cypress/support/pages/admin_console/ListingPage.ts
+++ b/cypress/support/pages/admin_console/ListingPage.ts
@@ -104,9 +104,9 @@ export default class ListingPage extends CommonElements {
     return this;
   }
 
-  checkTableLength(length: number) {
+  checkTableLength(length: number, identifier: string) {
     cy.get("table")
-      .should("have.class", "kc-draggable-table")
+      .should("have.class", identifier)
       .get("tbody")
       .children()
       .should("have.length", length);

--- a/cypress/support/pages/admin_console/manage/realm_settings/RealmSettingsPage.ts
+++ b/cypress/support/pages/admin_console/manage/realm_settings/RealmSettingsPage.ts
@@ -1,5 +1,5 @@
-import ListingPage from "../../ListingPage";
 import ModalUtils from "../../../../util/ModalUtils";
+import ListingPage from "../../ListingPage";
 
 const expect = chai.expect;
 export default class RealmSettingsPage {
@@ -69,6 +69,8 @@ export default class RealmSettingsPage {
   enableSslCheck = "enable-ssl";
   enableStartTlsCheck = "enable-start-tls";
   addProviderDropdown = "addProviderDropdown";
+  activeSwitch = "active";
+  enabledSwitch = "enabled";
   addProviderButton = "add-provider-button";
   displayName = "name-input";
   enableEvents = "eventsEnabled";
@@ -79,6 +81,7 @@ export default class RealmSettingsPage {
   filterSelectMenu = ".kc-filter-type-select";
   passiveKeysOption = "PASSIVE-option";
   disabledKeysOption = "DISABLED-option";
+  activeKeysOption = "ACTIVE-option";
   testConnectionButton = "test-connection-button";
   modalTestConnectionButton = "modal-test-connection-button";
   emailAddressInput = "email-address-input";
@@ -341,6 +344,32 @@ export default class RealmSettingsPage {
     cy.findByTestId(this.disabledKeysOption).click();
   }
 
+  deleteProvider(name: string) {
+    this.listingPage.deleteItem(name);
+    this.modalUtils.checkModalTitle("Delete key provider?").confirmModal();
+
+    cy.get(this.alertMessage).should(
+      "be.visible",
+      "Success. The provider has been deleted."
+    );
+    return this;
+  }
+
+  switchToActiveFilter() {
+    cy.get(this.filterSelectMenu).first().click();
+    cy.findByTestId(this.activeKeysOption).click();
+  }
+
+  switchToPassiveFilter() {
+    cy.get(this.filterSelectMenu).first().click();
+    cy.findByTestId(this.passiveKeysOption).click();
+  }
+
+  switchToDisabledFilter() {
+    cy.get(this.filterSelectMenu).first().click();
+    cy.findByTestId(this.disabledKeysOption).click();
+  }
+
   toggleSwitch(switchName: string) {
     cy.findByTestId(switchName).click({ force: true });
 
@@ -364,17 +393,6 @@ export default class RealmSettingsPage {
   addProvider() {
     cy.findByTestId(this.addProviderButton).click();
 
-    return this;
-  }
-
-  deleteProvider(name: string) {
-    this.listingPage.deleteItem(name);
-    this.modalUtils.checkModalTitle("Delete key provider?").confirmModal();
-
-    cy.get(this.alertMessage).should(
-      "be.visible",
-      "Success. The provider has been deleted."
-    );
     return this;
   }
 

--- a/cypress/support/pages/admin_console/manage/realm_settings/RealmSettingsPage.ts
+++ b/cypress/support/pages/admin_console/manage/realm_settings/RealmSettingsPage.ts
@@ -1,4 +1,5 @@
 import ListingPage from "../../ListingPage";
+import ModalUtils from "../../../../util/ModalUtils";
 
 const expect = chai.expect;
 export default class RealmSettingsPage {
@@ -196,6 +197,7 @@ export default class RealmSettingsPage {
   private executorAvailablePeriodInput = "#available-period";
 
   private listingPage = new ListingPage();
+  private modalUtils = new ModalUtils();
   private addCondition = "addCondition";
   private addConditionDrpDwn = ".pf-c-select__toggle";
   private addConditionDrpDwnOption = "conditionType-select";
@@ -362,6 +364,17 @@ export default class RealmSettingsPage {
   addProvider() {
     cy.findByTestId(this.addProviderButton).click();
 
+    return this;
+  }
+
+  deleteProvider(name: string) {
+    this.listingPage.deleteItem(name);
+    this.modalUtils.checkModalTitle("Delete key provider?").confirmModal();
+
+    cy.get(this.alertMessage).should(
+      "be.visible",
+      "Success. The provider has been deleted."
+    );
     return this;
   }
 

--- a/src/realm-settings/keys/KeysListTab.tsx
+++ b/src/realm-settings/keys/KeysListTab.tsx
@@ -176,6 +176,7 @@ export const KeysListTab = ({ realmComponents }: KeysListTabProps) => {
       <CertificateDialog />
       <KeycloakDataTable
         isNotCompact
+        className="kc-keys-list"
         loader={filteredKeyData || keyData}
         ariaLabelKey="realm-settings:keysList"
         searchPlaceholderKey="realm-settings:searchKey"

--- a/src/realm-settings/keys/KeysProvidersTab.tsx
+++ b/src/realm-settings/keys/KeysProvidersTab.tsx
@@ -160,6 +160,7 @@ export const KeysProvidersTab = ({
                 <TextInput
                   name={"inputGroupName"}
                   id={"inputGroupName"}
+                  data-testid="provider-search-input"
                   type="search"
                   aria-label={t("common:search")}
                   placeholder={t("common:search")}
@@ -210,6 +211,7 @@ export const KeysProvidersTab = ({
         </Toolbar>
         <DraggableTable
           variant="compact"
+          className="kc-draggable-table"
           keyField="id"
           data={
             filteredComponents.length === 0 ? components : filteredComponents


### PR DESCRIPTION
Adds search and delete tests for keys -> providers tests in Realm Settings, also tests active/passive/disabled dropdown filter

- https://docs.google.com/spreadsheets/d/1eCngdn3wmMeQ0u5u-eKYJo1XdT2fHvi7ki51mrcu-Ys/edit#gid=1613790516&range=461:461
- https://docs.google.com/spreadsheets/d/1eCngdn3wmMeQ0u5u-eKYJo1XdT2fHvi7ki51mrcu-Ys/edit#gid=1613790516&range=449:449
- https://docs.google.com/spreadsheets/d/1eCngdn3wmMeQ0u5u-eKYJo1XdT2fHvi7ki51mrcu-Ys/edit#gid=1613790516&range=452:454
- https://docs.google.com/spreadsheets/d/1eCngdn3wmMeQ0u5u-eKYJo1XdT2fHvi7ki51mrcu-Ys/edit#gid=1613790516&range=459:459