### PR TITLE
Adds LDAP connection and general tests

### DIFF
--- a/cypress/integration/user_fed_ldap_hardcoded_mapper_test.spec.ts
+++ b/cypress/integration/user_fed_ldap_hardcoded_mapper_test.spec.ts
@@ -24,12 +24,16 @@ const allCapProvider = provider.toUpperCase();
 const ldapName = "ldap-mappers-testing";
 const ldapVendor = "Active Directory";
 
-const connectionUrl = "ldap://";
-const firstBindType = "simple";
-const firstBindDn = "user-1";
-const firstBindCreds = "password1";
+// connection and authentication settings
+const connectionUrlValid = "ldap://ldap.forumsys.com:389";
+const bindTypeSimple = "simple";
+const truststoreSpiOnlyLdaps = "Only for ldaps";
+const connectionTimeoutTwoSecs = "2000";
+const bindDnCnDc = "cn=read-only-admin,dc=example,dc=com";
+const bindCredsValid = "password";
 
-const firstEditMode = "READ_ONLY";
+// ldap searching and updating
+const editModeReadOnly = "READ_ONLY";
 const firstUsersDn = "user-dn-1";
 const firstUserLdapAtt = "uid";
 const firstRdnLdapAtt = "uid";
@@ -83,15 +87,20 @@ describe("User Fed LDAP mapper tests", () => {
         providersPage.clickMenuCommand(addProviderMenu, allCapProvider);
       }
     });
-    providersPage.fillLdapRequiredGeneralData(ldapName, ldapVendor);
-    providersPage.fillLdapRequiredConnectionData(
-      connectionUrl,
-      firstBindType,
-      firstBindDn,
-      firstBindCreds
+    providersPage.fillLdapGeneralData(ldapName, ldapVendor);
+    providersPage.fillLdapConnectionData(
+      connectionUrlValid,
+      bindTypeSimple,
+      truststoreSpiOnlyLdaps,
+      connectionTimeoutTwoSecs,
+      bindDnCnDc,
+      bindCredsValid
     );
-    providersPage.fillLdapRequiredSearchingData(
-      firstEditMode,
+    providersPage.toggleSwitch(providersPage.enableStartTls);
+    providersPage.toggleSwitch(providersPage.connectionPooling);
+
+    providersPage.fillLdapSearchingData(
+      editModeReadOnly,
       firstUsersDn,
       firstUserLdapAtt,
       firstRdnLdapAtt,

--- a/cypress/integration/user_fed_ldap_mapper_test.spec.ts
+++ b/cypress/integration/user_fed_ldap_mapper_test.spec.ts
@@ -20,12 +20,16 @@ const allCapProvider = provider.toUpperCase();
 const ldapName = "ldap-mappers-testing";
 const ldapVendor = "Active Directory";
 
-const connectionUrl = "ldap://";
-const firstBindType = "simple";
-const firstBindDn = "user-1";
-const firstBindCreds = "password1";
+// connection and authentication settings
+const connectionUrlValid = "ldap://ldap.forumsys.com:389";
+const bindTypeSimple = "simple";
+const truststoreSpiOnlyLdaps = "Only for ldaps";
+const connectionTimeoutTwoSecs = "2000";
+const bindDnCnDc = "cn=read-only-admin,dc=example,dc=com";
+const bindCredsValid = "password";
 
-const firstEditMode = "READ_ONLY";
+// ldap searching and updating
+const editModeReadOnly = "READ_ONLY";
 const firstUsersDn = "user-dn-1";
 const firstUserLdapAtt = "uid";
 const firstRdnLdapAtt = "uid";
@@ -88,15 +92,20 @@ describe("User Fed LDAP mapper tests", () => {
         providersPage.clickMenuCommand(addProviderMenu, allCapProvider);
       }
     });
-    providersPage.fillLdapRequiredGeneralData(ldapName, ldapVendor);
-    providersPage.fillLdapRequiredConnectionData(
-      connectionUrl,
-      firstBindType,
-      firstBindDn,
-      firstBindCreds
+    providersPage.fillLdapGeneralData(ldapName, ldapVendor);
+    providersPage.fillLdapConnectionData(
+      connectionUrlValid,
+      bindTypeSimple,
+      truststoreSpiOnlyLdaps,
+      connectionTimeoutTwoSecs,
+      bindDnCnDc,
+      bindCredsValid
     );
-    providersPage.fillLdapRequiredSearchingData(
-      firstEditMode,
+    providersPage.toggleSwitch(providersPage.enableStartTls);
+    providersPage.toggleSwitch(providersPage.connectionPooling);
+
+    providersPage.fillLdapSearchingData(
+      editModeReadOnly,
       firstUsersDn,
       firstUserLdapAtt,
       firstRdnLdapAtt,

--- a/cypress/integration/user_fed_ldap_test.spec.ts
+++ b/cypress/integration/user_fed_ldap_test.spec.ts
@@ -239,7 +239,6 @@ describe("User Fed LDAP tests", () => {
     cy.wait("@getProvider");
     providersPage.disableEnabledSwitch(allCapProvider);
     modalUtils.checkModalTitle(disableModalTitle).confirmModal();
-    cy.wait("@getProvider");
     masthead.checkNotificationMessage(savedSuccessMessage);
     sidebarPage.goToUserFederation();
     expect(cy.contains("Disabled").should("exist"));

--- a/cypress/support/pages/admin_console/manage/providers/ProviderPage.ts
+++ b/cypress/support/pages/admin_console/manage/providers/ProviderPage.ts
@@ -1,16 +1,16 @@
 export default class ProviderPage {
-  // KerberosSettingsRequired required input values
+  // KerberosSettingsRequired input values
   private kerberosNameInput = "kerberos-name";
   private kerberosRealmInput = "kerberos-realm";
   private kerberosPrincipalInput = "kerberos-principal";
   private kerberosKeytabInput = "kerberos-keytab";
 
-  // LdapSettingsGeneral required input values
+  // LdapSettingsGeneral input values
   private ldapNameInput = "ldap-name";
   private ldapVendorInput = "#kc-vendor";
   private ldapVendorList = "#kc-vendor + ul";
 
-  // LdapSettingsConnection required input values
+  // LdapSettingsConnection input values
   connectionUrlInput = "ldap-connection-url";
   truststoreSpiInput = "#kc-use-truststore-spi";
   truststoreSpiList = "#kc-use-truststore-spi + ul";
@@ -19,8 +19,10 @@ export default class ProviderPage {
   private bindTypeList = "#kc-bind-type + ul";
   bindDnInput = "ldap-bind-dn";
   bindCredsInput = "ldap-bind-credentials";
+  private testConnectionBtn = "test-connection-button";
+  private testAuthBtn = "test-auth-button";
 
-  // LdapSettingsSearching required input values
+  // LdapSettingsSearching input values
   private ldapEditModeInput = "#kc-edit-mode";
   private ldapEditModeList = "#kc-edit-mode + ul";
   private ldapUsersDnInput = "ldap-users-dn";
@@ -39,7 +41,7 @@ export default class ProviderPage {
   private cachePolicyInput = "#kc-cache-policy";
   private cachePolicyList = "#kc-cache-policy + ul";
 
-  // Mapper required input values
+  // Mapper input values
   private userModelAttInput = "user.model.attribute";
   private ldapAttInput = "ldap.attribute";
   private userModelAttNameInput = "user.model.attribute";
@@ -120,8 +122,6 @@ export default class ProviderPage {
   deleteCardFromCard(card: string) {
     cy.findByTestId(`${card}-dropdown`).click();
     cy.findByTestId("card-delete").click();
-    // cy.get(`[data-testid=${card}-dropdown]`).click();
-    // cy.get('[data-testid="card-delete"]').click();
     return this;
   }
 
@@ -129,8 +129,6 @@ export default class ProviderPage {
     this.clickExistingCard(card);
     cy.findByTestId(this.actionDropdown).click();
     cy.findByTestId(this.deleteCmd).click();
-    // cy.get('[data-testid="action-dropdown"]').click();
-    // cy.get(`[data-testid="delete-cmd"]`).click();
     return this;
   }
 
@@ -142,19 +140,15 @@ export default class ProviderPage {
   ) {
     if (name) {
       cy.findByTestId(this.kerberosNameInput).clear().type(name);
-      // cy.get(`[${this.kerberosNameInput}]`).type(name);
     }
     if (realm) {
       cy.findByTestId(this.kerberosRealmInput).clear().type(realm);
-      // cy.get(`[${this.kerberosRealmInput}]`).type(realm);
     }
     if (principal) {
       cy.findByTestId(this.kerberosPrincipalInput).clear().type(principal);
-      // cy.get(`[${this.kerberosPrincipalInput}]`).type(principal);
     }
     if (keytab) {
       cy.findByTestId(this.kerberosKeytabInput).clear().type(keytab);
-      // cy.get(`[${this.kerberosKeytabInput}]`).type(keytab);
     }
     return this;
   }
@@ -180,11 +174,12 @@ export default class ProviderPage {
     cy.findByTestId(fieldName).should("have.value", value);
   }
 
-  fillLdapRequiredGeneralData(name: string, vendor?: string) {
-    if (name) {
-      cy.findByTestId(this.ldapNameInput).clear().type(name);
-      // cy.get(`[${this.ldapNameInput}]`).clear().type(name);
-    }
+  verifySelect(selectInput: string, value: string) {
+    cy.get(selectInput).should("contain", value);
+  }
+
+  fillLdapGeneralData(name: string, vendor?: string) {
+    cy.findByTestId(this.ldapNameInput).clear().type(name);
     if (vendor) {
       cy.get(this.ldapVendorInput).click();
       cy.get(this.ldapVendorList).contains(vendor).click();
@@ -192,81 +187,62 @@ export default class ProviderPage {
     return this;
   }
 
-  fillLdapRequiredConnectionData(
+  fillLdapConnectionData(
     connectionUrl: string,
-    truststoreSpi: string,
-    connectionTimeout: string,
     bindType: string,
+    truststoreSpi?: string,
+    connectionTimeout?: string,
     bindDn?: string,
     bindCreds?: string
   ) {
-    if (connectionUrl) {
-      cy.findByTestId(this.connectionUrlInput).clear().type(connectionUrl);
-      // cy.get(`[${this.ldapConnectionUrlInput}]`).type(connectionUrl);
-    }
+    cy.findByTestId(this.connectionUrlInput).clear().type(connectionUrl);
+
+    cy.get(this.bindTypeInput).click();
+    cy.get(this.bindTypeList).contains(bindType).click();
 
     if (truststoreSpi) {
       cy.get(this.truststoreSpiInput).click();
       cy.get(this.truststoreSpiList).contains(truststoreSpi).click();
-      // cy.findByTestId(this.truststoreSpiInput).type(truststoreSpi);
-      // cy.get(`[${this.ldapConnectionUrlInput}]`).type(connectionUrl);
     }
-
     if (connectionTimeout) {
       cy.findByTestId(this.connectionTimeoutInput)
         .clear()
         .type(connectionTimeout);
-      // cy.get(`[${this.ldapConnectionUrlInput}]`).type(connectionUrl);
-    }
-    if (bindType) {
-      cy.get(this.bindTypeInput).click();
-      cy.get(this.bindTypeList).contains(bindType).click();
     }
     if (bindDn) {
       cy.findByTestId(this.bindDnInput).clear().type(bindDn);
-      // cy.get(`[${this.ldapBindDnInput}]`).type(bindDn);
     }
     if (bindCreds) {
       cy.findByTestId(this.bindCredsInput).clear().type(bindCreds);
-      // cy.get(`[${this.ldapBindCredsInput}]`).type(bindCreds);
     }
     return this;
   }
 
-  fillLdapRequiredSearchingData(
+  fillLdapSearchingData(
     editMode: string,
     usersDn: string,
-    userLdapAtt: string,
-    rdnLdapAtt: string,
-    uuidLdapAtt: string,
-    userObjClasses: string
+    userLdapAtt?: string,
+    rdnLdapAtt?: string,
+    uuidLdapAtt?: string,
+    userObjClasses?: string
   ) {
-    if (editMode) {
-      cy.get(this.ldapEditModeInput).click();
-      cy.get(this.ldapEditModeList).contains(editMode).click();
-    }
+    cy.get(this.ldapEditModeInput).click();
+    cy.get(this.ldapEditModeList).contains(editMode).click();
 
-    if (usersDn) {
-      cy.findByTestId(this.ldapUsersDnInput).clear().type(usersDn);
-      // cy.get(`[${this.ldapUsersDnInput}]`).type(usersDn);
-    }
+    cy.findByTestId(this.ldapUsersDnInput).clear().type(usersDn);
     if (userLdapAtt) {
       cy.findByTestId(this.ldapUserLdapAttInput).clear().type(userLdapAtt);
-      // cy.get(`[${this.ldapUserLdapAttInput}]`).type(userLdapAtt);
     }
     if (rdnLdapAtt) {
       cy.findByTestId(this.ldapRdnLdapAttInput).clear().type(rdnLdapAtt);
-      // cy.get(`[${this.ldapRdnLdapAttInput}]`).type(rdnLdapAtt);
     }
     if (uuidLdapAtt) {
       cy.findByTestId(this.ldapUuidLdapAttInput).clear().type(uuidLdapAtt);
-      // cy.get(`[${this.ldapUuidLdapAttInput}]`).type(uuidLdapAtt);
     }
     if (userObjClasses) {
       cy.findByTestId(this.ldapUserObjClassesInput)
         .clear()
         .type(userObjClasses);
-      // cy.get(`[${this.ldapUserObjClassesInput}]`).type(userObjClasses);
     }
     return this;
   }
@@ -278,21 +254,18 @@ export default class ProviderPage {
   }
 
   goToMappers() {
-    // cy.get(`[data-testid="ldap-mappers-tab"]`).click();
     cy.findByTestId(this.mappersTab).click();
   }
 
   createRole(roleName: string) {
     cy.findByTestId(this.rolesTab).click();
-    // cy.wait(1000);
+    cy.wait(1000);
     cy.findByTestId(this.createRoleBtn).click();
-    // cy.get(`[${this.createRoleBtn}]`).click();
-    // cy.wait(1000);
+    cy.wait(1000);
     cy.get(this.roleNameField).clear().type(roleName);
-    // cy.wait(1000);
+    cy.wait(1000);
     cy.findByTestId(this.realmRolesSaveBtn).click();
-    // cy.get(`[${this.realmRolesSaveBtn}]`).click();
-    // cy.wait(1000);
+    cy.wait(1000);
   }
 
   createNewMapper(mapperType: string) {
@@ -301,13 +274,12 @@ export default class ProviderPage {
     const ldapDnValue = "ou=groups";
 
     cy.contains("Add").click();
-    // cy.wait(1000);
+    cy.wait(1000);
 
     cy.get("#kc-providerId").click();
     cy.get("button").contains(mapperType).click();
 
     cy.findByTestId("ldap-mapper-name").clear().type(`${mapperType}-test`);
-    // cy.get(`[data-testid="ldap-mapper-name"]`).type(`${mapperType}-test`);
 
     switch (mapperType) {
       case this.msadUserAcctMapper:
@@ -340,7 +312,6 @@ export default class ProviderPage {
 
       case this.roleLdapMapper:
         cy.findByTestId(this.ldapRolesDnInput).clear().type(ldapDnValue);
-        // cy select clientID dropdown and choose clientName (var)
         cy.get(this.clientIdSelect).click();
         cy.get("button").contains(this.clientName).click({ force: true });
         break;
@@ -356,7 +327,6 @@ export default class ProviderPage {
           .get(".pf-c-select__menu-item")
           .first()
           .click();
-
         break;
       default:
         console.log("Invalid mapper type.");
@@ -398,8 +368,7 @@ export default class ProviderPage {
 
   clickExistingCard(cardName: string) {
     cy.findByTestId("keycloak-card-title").contains(cardName).click();
-    // cy.get('[data-testid="keycloak-card-title"]').contains(cardName).click();
-    // cy.wait(1000);
+    cy.wait(1000);
     return this;
   }
 
@@ -411,8 +380,7 @@ export default class ProviderPage {
 
   clickNewCard(providerType: string) {
     cy.findByTestId(`${providerType}-card`).click();
-    // cy.get(`[data-testid=${providerType}-card]`).click();
-    // cy.wait(1000);
+    cy.wait(1000);
     return this;
   }
 
@@ -428,13 +396,21 @@ export default class ProviderPage {
 
   save(providerType: string) {
     cy.findByTestId(`${providerType}-save`).click();
-    // cy.get(`[data-testid=${providerType}-save]`).click();
     return this;
   }
 
   cancel(providerType: string) {
     cy.findByTestId(`${providerType}-cancel`).click();
-    // cy.get(`[data-testid=${providerType}-cancel]`).click();
+    return this;
+  }
+
+  testConnection() {
+    cy.findByTestId(this.testConnectionBtn).click();
+    return this;
+  }
+
+  testAuthorization() {
+    cy.findByTestId(this.testAuthBtn).click();
     return this;
   }
 }

--- a/cypress/support/pages/admin_console/manage/providers/ProviderPage.ts
+++ b/cypress/support/pages/admin_console/manage/providers/ProviderPage.ts
@@ -1,30 +1,33 @@
 export default class ProviderPage {
   // KerberosSettingsRequired required input values
-  private kerberosNameInput = "data-testid=kerberos-name";
-  private kerberosRealmInput = "data-testid=kerberos-realm";
-  private kerberosPrincipalInput = "data-testid=kerberos-principal";
-  private kerberosKeytabInput = "data-testid=kerberos-keytab";
+  private kerberosNameInput = "kerberos-name";
+  private kerberosRealmInput = "kerberos-realm";
+  private kerberosPrincipalInput = "kerberos-principal";
+  private kerberosKeytabInput = "kerberos-keytab";
 
   // LdapSettingsGeneral required input values
-  private ldapNameInput = "data-testid=ldap-name";
+  private ldapNameInput = "ldap-name";
   private ldapVendorInput = "#kc-vendor";
   private ldapVendorList = "#kc-vendor + ul";
 
   // LdapSettingsConnection required input values
-  private ldapConnectionUrlInput = "data-testid=ldap-connection-url";
-  private ldapBindTypeInput = "#kc-bind-type";
-  private ldapBindTypeList = "#kc-bind-type + ul";
-  private ldapBindDnInput = "data-testid=ldap-bind-dn";
-  private ldapBindCredsInput = "data-testid=ldap-bind-credentials";
+  connectionUrlInput = "ldap-connection-url";
+  truststoreSpiInput = "#kc-use-truststore-spi";
+  truststoreSpiList = "#kc-use-truststore-spi + ul";
+  connectionTimeoutInput = "connection-timeout";
+  bindTypeInput = "#kc-bind-type";
+  private bindTypeList = "#kc-bind-type + ul";
+  bindDnInput = "ldap-bind-dn";
+  bindCredsInput = "ldap-bind-credentials";
 
   // LdapSettingsSearching required input values
   private ldapEditModeInput = "#kc-edit-mode";
   private ldapEditModeList = "#kc-edit-mode + ul";
-  private ldapUsersDnInput = "data-testid=ldap-users-dn";
-  private ldapUserLdapAttInput = "data-testid=ldap-username-attribute";
-  private ldapRdnLdapAttInput = "data-testid=ldap-rdn-attribute";
-  private ldapUuidLdapAttInput = "data-testid=ldap-uuid-attribute";
-  private ldapUserObjClassesInput = "data-testid=ldap-user-object-classes";
+  private ldapUsersDnInput = "ldap-users-dn";
+  private ldapUserLdapAttInput = "ldap-username-attribute";
+  private ldapRdnLdapAttInput = "ldap-rdn-attribute";
+  private ldapUuidLdapAttInput = "ldap-uuid-attribute";
+  private ldapUserObjClassesInput = "ldap-user-object-classes";
 
   // SettingsCache input values
   private cacheDayInput = "#kc-eviction-day";
@@ -61,9 +64,13 @@ export default class ProviderPage {
   private roleLdapMapper = "role-ldap-mapper";
   private hcLdapRoleMapper = "hardcoded-ldap-role-mapper";
 
+  private actionDropdown = "action-dropdown";
+  private deleteCmd = "delete-cmd";
+
+  private mappersTab = "ldap-mappers-tab";
   private rolesTab = "rolesTab";
-  private createRoleBtn = "data-testid=no-roles-for-this-client-empty-action";
-  private realmRolesSaveBtn = "data-testid=realm-roles-save-button";
+  private createRoleBtn = "no-roles-for-this-client-empty-action";
+  private realmRolesSaveBtn = "realm-roles-save-button";
   private roleNameField = "#kc-name";
   private clientIdSelect = "#client\\.id-select-typeahead";
 
@@ -76,6 +83,10 @@ export default class ProviderPage {
   debugSwitch = "debug";
   firstLoginSwitch = "update-first-login";
   passwordAuthSwitch = "allow-password-authentication";
+
+  // LDAP switch input values
+  enableStartTls = "enable-start-tls";
+  connectionPooling = "connection-pooling";
 
   changeCacheTime(unit: string, time: string) {
     switch (unit) {
@@ -107,15 +118,19 @@ export default class ProviderPage {
   }
 
   deleteCardFromCard(card: string) {
-    cy.get(`[data-testid=${card}-dropdown]`).click();
-    cy.get('[data-testid="card-delete"]').click();
+    cy.findByTestId(`${card}-dropdown`).click();
+    cy.findByTestId("card-delete").click();
+    // cy.get(`[data-testid=${card}-dropdown]`).click();
+    // cy.get('[data-testid="card-delete"]').click();
     return this;
   }
 
   deleteCardFromMenu(card: string) {
     this.clickExistingCard(card);
-    cy.get('[data-testid="action-dropdown"]').click();
-    cy.get(`[data-testid="delete-cmd"]`).click();
+    cy.findByTestId(this.actionDropdown).click();
+    cy.findByTestId(this.deleteCmd).click();
+    // cy.get('[data-testid="action-dropdown"]').click();
+    // cy.get(`[data-testid="delete-cmd"]`).click();
     return this;
   }
 
@@ -126,16 +141,20 @@ export default class ProviderPage {
     keytab: string
   ) {
     if (name) {
-      cy.get(`[${this.kerberosNameInput}]`).type(name);
+      cy.findByTestId(this.kerberosNameInput).clear().type(name);
+      // cy.get(`[${this.kerberosNameInput}]`).type(name);
     }
     if (realm) {
-      cy.get(`[${this.kerberosRealmInput}]`).type(realm);
+      cy.findByTestId(this.kerberosRealmInput).clear().type(realm);
+      // cy.get(`[${this.kerberosRealmInput}]`).type(realm);
     }
     if (principal) {
-      cy.get(`[${this.kerberosPrincipalInput}]`).type(principal);
+      cy.findByTestId(this.kerberosPrincipalInput).clear().type(principal);
+      // cy.get(`[${this.kerberosPrincipalInput}]`).type(principal);
     }
     if (keytab) {
-      cy.get(`[${this.kerberosKeytabInput}]`).type(keytab);
+      cy.findByTestId(this.kerberosKeytabInput).clear().type(keytab);
+      // cy.get(`[${this.kerberosKeytabInput}]`).type(keytab);
     }
     return this;
   }
@@ -157,9 +176,14 @@ export default class ProviderPage {
     return this;
   }
 
-  fillLdapRequiredGeneralData(name: string, vendor: string) {
+  verifyTextField(fieldName: string, value: string) {
+    cy.findByTestId(fieldName).should("have.value", value);
+  }
+
+  fillLdapRequiredGeneralData(name: string, vendor?: string) {
     if (name) {
-      cy.get(`[${this.ldapNameInput}]`).clear().type(name);
+      cy.findByTestId(this.ldapNameInput).clear().type(name);
+      // cy.get(`[${this.ldapNameInput}]`).clear().type(name);
     }
     if (vendor) {
       cy.get(this.ldapVendorInput).click();
@@ -170,22 +194,41 @@ export default class ProviderPage {
 
   fillLdapRequiredConnectionData(
     connectionUrl: string,
+    truststoreSpi: string,
+    connectionTimeout: string,
     bindType: string,
     bindDn?: string,
     bindCreds?: string
   ) {
     if (connectionUrl) {
-      cy.get(`[${this.ldapConnectionUrlInput}]`).type(connectionUrl);
+      cy.findByTestId(this.connectionUrlInput).clear().type(connectionUrl);
+      // cy.get(`[${this.ldapConnectionUrlInput}]`).type(connectionUrl);
+    }
+
+    if (truststoreSpi) {
+      cy.get(this.truststoreSpiInput).click();
+      cy.get(this.truststoreSpiList).contains(truststoreSpi).click();
+      // cy.findByTestId(this.truststoreSpiInput).type(truststoreSpi);
+      // cy.get(`[${this.ldapConnectionUrlInput}]`).type(connectionUrl);
+    }
+
+    if (connectionTimeout) {
+      cy.findByTestId(this.connectionTimeoutInput)
+        .clear()
+        .type(connectionTimeout);
+      // cy.get(`[${this.ldapConnectionUrlInput}]`).type(connectionUrl);
     }
     if (bindType) {
-      cy.get(this.ldapBindTypeInput).click();
-      cy.get(this.ldapBindTypeList).contains(bindType).click();
+      cy.get(this.bindTypeInput).click();
+      cy.get(this.bindTypeList).contains(bindType).click();
     }
     if (bindDn) {
-      cy.get(`[${this.ldapBindDnInput}]`).type(bindDn);
+      cy.findByTestId(this.bindDnInput).clear().type(bindDn);
+      // cy.get(`[${this.ldapBindDnInput}]`).type(bindDn);
     }
     if (bindCreds) {
-      cy.get(`[${this.ldapBindCredsInput}]`).type(bindCreds);
+      cy.findByTestId(this.bindCredsInput).clear().type(bindCreds);
+      // cy.get(`[${this.ldapBindCredsInput}]`).type(bindCreds);
     }
     return this;
   }
@@ -204,19 +247,26 @@ export default class ProviderPage {
     }
 
     if (usersDn) {
-      cy.get(`[${this.ldapUsersDnInput}]`).type(usersDn);
+      cy.findByTestId(this.ldapUsersDnInput).clear().type(usersDn);
+      // cy.get(`[${this.ldapUsersDnInput}]`).type(usersDn);
     }
     if (userLdapAtt) {
-      cy.get(`[${this.ldapUserLdapAttInput}]`).type(userLdapAtt);
+      cy.findByTestId(this.ldapUserLdapAttInput).clear().type(userLdapAtt);
+      // cy.get(`[${this.ldapUserLdapAttInput}]`).type(userLdapAtt);
     }
     if (rdnLdapAtt) {
-      cy.get(`[${this.ldapRdnLdapAttInput}]`).type(rdnLdapAtt);
+      cy.findByTestId(this.ldapRdnLdapAttInput).clear().type(rdnLdapAtt);
+      // cy.get(`[${this.ldapRdnLdapAttInput}]`).type(rdnLdapAtt);
     }
     if (uuidLdapAtt) {
-      cy.get(`[${this.ldapUuidLdapAttInput}]`).type(uuidLdapAtt);
+      cy.findByTestId(this.ldapUuidLdapAttInput).clear().type(uuidLdapAtt);
+      // cy.get(`[${this.ldapUuidLdapAttInput}]`).type(uuidLdapAtt);
     }
     if (userObjClasses) {
-      cy.get(`[${this.ldapUserObjClassesInput}]`).type(userObjClasses);
+      cy.findByTestId(this.ldapUserObjClassesInput)
+        .clear()
+        .type(userObjClasses);
+      // cy.get(`[${this.ldapUserObjClassesInput}]`).type(userObjClasses);
     }
     return this;
   }
@@ -228,18 +278,21 @@ export default class ProviderPage {
   }
 
   goToMappers() {
-    cy.get(`[data-testid="ldap-mappers-tab"]`).click();
+    // cy.get(`[data-testid="ldap-mappers-tab"]`).click();
+    cy.findByTestId(this.mappersTab).click();
   }
 
   createRole(roleName: string) {
     cy.findByTestId(this.rolesTab).click();
-    cy.wait(1000);
-    cy.get(`[${this.createRoleBtn}]`).click();
-    cy.wait(1000);
-    cy.get(this.roleNameField).type(roleName);
-    cy.wait(1000);
-    cy.get(`[${this.realmRolesSaveBtn}]`).click();
-    cy.wait(1000);
+    // cy.wait(1000);
+    cy.findByTestId(this.createRoleBtn).click();
+    // cy.get(`[${this.createRoleBtn}]`).click();
+    // cy.wait(1000);
+    cy.get(this.roleNameField).clear().type(roleName);
+    // cy.wait(1000);
+    cy.findByTestId(this.realmRolesSaveBtn).click();
+    // cy.get(`[${this.realmRolesSaveBtn}]`).click();
+    // cy.wait(1000);
   }
 
   createNewMapper(mapperType: string) {
@@ -248,12 +301,13 @@ export default class ProviderPage {
     const ldapDnValue = "ou=groups";
 
     cy.contains("Add").click();
-    cy.wait(1000);
+    // cy.wait(1000);
 
     cy.get("#kc-providerId").click();
     cy.get("button").contains(mapperType).click();
 
-    cy.get(`[data-testid="ldap-mapper-name"]`).type(`${mapperType}-test`);
+    cy.findByTestId("ldap-mapper-name").clear().type(`${mapperType}-test`);
+    // cy.get(`[data-testid="ldap-mapper-name"]`).type(`${mapperType}-test`);
 
     switch (mapperType) {
       case this.msadUserAcctMapper:
@@ -261,29 +315,31 @@ export default class ProviderPage {
         break;
       case this.userAttLdapMapper:
       case this.certLdapMapper:
-        cy.findByTestId(this.userModelAttInput).type(userModelAttValue);
-        cy.findByTestId(this.ldapAttInput).type(ldapAttValue);
+        cy.findByTestId(this.userModelAttInput).clear().type(userModelAttValue);
+        cy.findByTestId(this.ldapAttInput).clear().type(ldapAttValue);
         break;
       case this.hcAttMapper:
-        cy.findByTestId(this.userModelAttNameInput).type(userModelAttValue);
-        cy.findByTestId(this.attValueInput).type(ldapAttValue);
+        cy.findByTestId(this.userModelAttNameInput)
+          .clear()
+          .type(userModelAttValue);
+        cy.findByTestId(this.attValueInput).clear().type(ldapAttValue);
         break;
       case this.fullNameLdapMapper:
-        cy.findByTestId(this.ldapFullNameAttInput).type(ldapAttValue);
+        cy.findByTestId(this.ldapFullNameAttInput).clear().type(ldapAttValue);
         break;
       case this.hcLdapAttMapper:
-        cy.findByTestId(this.ldapAttNameInput).type(userModelAttValue);
-        cy.findByTestId(this.ldapAttValueInput).type(ldapAttValue);
+        cy.findByTestId(this.ldapAttNameInput).clear().type(userModelAttValue);
+        cy.findByTestId(this.ldapAttValueInput).clear().type(ldapAttValue);
         break;
       case this.hcLdapGroupMapper:
-        cy.findByTestId(this.groupInput).type(this.groupName);
+        cy.findByTestId(this.groupInput).clear().type(this.groupName);
         break;
       case this.groupLdapMapper:
-        cy.findByTestId(this.ldapGroupsDnInput).type(ldapDnValue);
+        cy.findByTestId(this.ldapGroupsDnInput).clear().type(ldapDnValue);
         break;
 
       case this.roleLdapMapper:
-        cy.findByTestId(this.ldapRolesDnInput).type(ldapDnValue);
+        cy.findByTestId(this.ldapRolesDnInput).clear().type(ldapDnValue);
         // cy select clientID dropdown and choose clientName (var)
         cy.get(this.clientIdSelect).click();
         cy.get("button").contains(this.clientName).click({ force: true });
@@ -341,8 +397,9 @@ export default class ProviderPage {
   }
 
   clickExistingCard(cardName: string) {
-    cy.get('[data-testid="keycloak-card-title"]').contains(cardName).click();
-    cy.wait(1000);
+    cy.findByTestId("keycloak-card-title").contains(cardName).click();
+    // cy.get('[data-testid="keycloak-card-title"]').contains(cardName).click();
+    // cy.wait(1000);
     return this;
   }
 
@@ -353,8 +410,9 @@ export default class ProviderPage {
   }
 
   clickNewCard(providerType: string) {
-    cy.get(`[data-testid=${providerType}-card]`).click();
-    cy.wait(1000);
+    cy.findByTestId(`${providerType}-card`).click();
+    // cy.get(`[data-testid=${providerType}-card]`).click();
+    // cy.wait(1000);
     return this;
   }
 
@@ -369,12 +427,14 @@ export default class ProviderPage {
   }
 
   save(providerType: string) {
-    cy.get(`[data-testid=${providerType}-save]`).click();
+    cy.findByTestId(`${providerType}-save`).click();
+    // cy.get(`[data-testid=${providerType}-save]`).click();
     return this;
   }
 
   cancel(providerType: string) {
-    cy.get(`[data-testid=${providerType}-cancel]`).click();
+    cy.findByTestId(`${providerType}-cancel`).click();
+    // cy.get(`[data-testid=${providerType}-cancel]`).click();
     return this;
   }
 }

--- a/src/user-federation/ldap/LdapSettingsConnection.tsx
+++ b/src/user-federation/ldap/LdapSettingsConnection.tsx
@@ -154,6 +154,7 @@ export const LdapSettingsConnection = ({
             render={({ onChange, value }) => (
               <Switch
                 id={"kc-enable-start-tls"}
+                data-testid="enable-start-tls"
                 isDisabled={false}
                 onChange={(value) => onChange([`${value}`])}
                 isChecked={value[0] === "true"}
@@ -216,6 +217,7 @@ export const LdapSettingsConnection = ({
             render={({ onChange, value }) => (
               <Switch
                 id={"kc-connection-pooling"}
+                data-testid="connection-pooling"
                 isDisabled={false}
                 onChange={(value) => onChange([`${value}`])}
                 isChecked={value[0] === "true"}
@@ -239,6 +241,7 @@ export const LdapSettingsConnection = ({
             type="number"
             min={0}
             id="kc-console-connection-timeout"
+            data-testid="connection-timeout"
             name="config.connectionTimeout[0]"
             ref={form.register}
           />

--- a/src/user-federation/ldap/LdapSettingsConnection.tsx
+++ b/src/user-federation/ldap/LdapSettingsConnection.tsx
@@ -246,10 +246,11 @@ export const LdapSettingsConnection = ({
             ref={form.register}
           />
         </FormGroup>
-        <FormGroup fieldId="kc-test-button">
+        <FormGroup fieldId="kc-test-connection-button">
           <Button
             variant="secondary"
-            id="kc-connection-test-button"
+            id="kc-test-connection-button"
+            data-testid="test-connection-button"
             onClick={() => testLdap("testConnection")}
           >
             {t("common:testConnection")}
@@ -360,10 +361,11 @@ export const LdapSettingsConnection = ({
             </FormGroup>
           </>
         )}
-        <FormGroup fieldId="kc-test-button">
+        <FormGroup fieldId="kc-test-auth-button">
           <Button
             variant="secondary"
-            id="kc-test-button"
+            id="kc-test-auth-button"
+            data-testid="test-auth-button"
             onClick={() => testLdap("testAuthentication")}
           >
             {t("testAuthentication")}


### PR DESCRIPTION
## Motivation
Test coverage dashboard:
https://docs.google.com/spreadsheets/d/1eCngdn3wmMeQ0u5u-eKYJo1XdT2fHvi7ki51mrcu-Ys/edit#gid=1613790516

## Brief Description
Adds several cypress tests for the Connection settings and General settings sections of the user fed LDAP provider UI. Specifically, addresses rows [686-692](https://docs.google.com/spreadsheets/d/1eCngdn3wmMeQ0u5u-eKYJo1XdT2fHvi7ki51mrcu-Ys/edit#gid=1613790516&range=686:692) and [694](https://docs.google.com/spreadsheets/d/1eCngdn3wmMeQ0u5u-eKYJo1XdT2fHvi7ki51mrcu-Ys/edit#gid=1613790516&range=694:694) in the test coverage dashboard.

Also cleaned up and hardened existing user fed tests and made them more consistent.

## Verification Steps
Verify that tests pass.

## Additional Notes
All of the following four tests pass consistently when run locally in the cypress UI and headless:

- user_fed_ldap_test.spec.ts
- user_fed_kerberos_test.spec.ts
- user_fed_ldap_hardcoded_mapper_test.spec.ts
- user_fed_ldap_mapper_test.spec.ts