### PR TITLE
fixed cannot destructure property error

### DIFF
--- a/src/realm-settings/NewAttributeSettings.tsx
+++ b/src/realm-settings/NewAttributeSettings.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unnecessary-condition */
 import React, { useState } from "react";
 import {
   ActionGroup,
@@ -129,9 +130,10 @@ export default function NewAttributeSettings() {
         selector,
         required,
         ...values
-      } = config.attributes!.find(
-        (attribute) => attribute.name === attributeName
-      )!;
+      } =
+        config.attributes!.find(
+          (attribute) => attribute.name === attributeName
+        )! || {};
       convertToFormValues(values, form.setValue);
       Object.entries(
         flatten({ permissions, selector, required }, { safe: true })

--- a/src/realm-settings/NewAttributeSettings.tsx
+++ b/src/realm-settings/NewAttributeSettings.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unnecessary-condition */
 import React, { useState } from "react";
 import {
   ActionGroup,
@@ -133,7 +132,7 @@ export default function NewAttributeSettings() {
       } =
         config.attributes!.find(
           (attribute) => attribute.name === attributeName
-        )! || {};
+        ) || {};
       convertToFormValues(values, form.setValue);
       Object.entries(
         flatten({ permissions, selector, required }, { safe: true })


### PR DESCRIPTION
## Motivation
Fix "cannot destructure property error" when selecting the "Create Attribute" button on Realm-settings -> User Profile tab

## Verification Steps
1. Navigate to Realm-settings -> User Profile tab and select the "Create Attribute" button.
2. Blank form should display.

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated
