### PR TITLE
Adds LDAP kerberos integration and synchronization tests

### DIFF
--- a/cypress/integration/user_fed_ldap_test.spec.ts
+++ b/cypress/integration/user_fed_ldap_test.spec.ts
@@ -31,6 +31,16 @@ const truststoreSpiNever = "Never";
 const bindDnCnOnly = "cn=read-only-admin";
 const bindCredsInvalid = "not-my-password";
 
+// kerberos integration settings
+const kerberosRealm = "FOO.ORG";
+const serverPrincipal = "HTTP/host.foo.org@FOO.ORG";
+const keyTab = "/etc/krb5.keytab";
+
+// ldap synchronization settings
+const batchSize = "100";
+const fullSyncPeriod = "604800";
+const userSyncPeriod = "86400";
+
 // ldap searching and updating
 const editModeReadOnly = "READ_ONLY";
 const firstUsersDn = "user-dn-1";
@@ -200,6 +210,83 @@ describe("User Fed LDAP tests", () => {
     providersPage.testAuthorization();
     masthead.checkNotificationMessage(ldapTestSuccessMsg);
 
+    sidebarPage.goToUserFederation();
+  });
+
+  it("Should update Kerberos integration settings and save", () => {
+    providersPage.clickExistingCard(firstLdapName);
+
+    providersPage.toggleSwitch(providersPage.allowKerberosAuth);
+    providersPage.toggleSwitch(providersPage.debug);
+    providersPage.toggleSwitch(providersPage.useKerberosForPwAuth);
+
+    providersPage.fillTextField(
+      providersPage.ldapKerberosRealmInput,
+      kerberosRealm
+    );
+    providersPage.fillTextField(
+      providersPage.ldapServerPrincipalInput,
+      serverPrincipal
+    );
+    providersPage.fillTextField(providersPage.ldapKeyTabInput, keyTab);
+
+    providersPage.save(provider);
+    masthead.checkNotificationMessage(savedSuccessMessage);
+
+    // now verify
+    sidebarPage.goToUserFederation();
+    providersPage.clickExistingCard(firstLdapName);
+    providersPage.verifyTextField(
+      providersPage.ldapKerberosRealmInput,
+      kerberosRealm
+    );
+    providersPage.verifyTextField(
+      providersPage.ldapServerPrincipalInput,
+      serverPrincipal
+    );
+    providersPage.verifyTextField(providersPage.ldapKeyTabInput, keyTab);
+    providersPage.verifyToggle(providersPage.allowKerberosAuth, "on");
+    providersPage.verifyToggle(providersPage.debug, "on");
+    providersPage.verifyToggle(providersPage.useKerberosForPwAuth, "on");
+
+    sidebarPage.goToUserFederation();
+  });
+
+  it("Should update Synchronization settings and save", () => {
+    providersPage.clickExistingCard(firstLdapName);
+
+    providersPage.toggleSwitch(providersPage.importUsers);
+    providersPage.toggleSwitch(providersPage.periodicFullSync);
+    providersPage.toggleSwitch(providersPage.periodicUsersSync);
+
+    providersPage.fillTextField(providersPage.ldapBatchSizeInput, batchSize);
+    providersPage.fillTextField(
+      providersPage.ldapFullSyncPeriodInput,
+      fullSyncPeriod
+    );
+    providersPage.fillTextField(
+      providersPage.ldapUsersSyncPeriodInput,
+      userSyncPeriod
+    );
+
+    providersPage.save(provider);
+    masthead.checkNotificationMessage(savedSuccessMessage);
+
+    // now verify
+    sidebarPage.goToUserFederation();
+    providersPage.clickExistingCard(firstLdapName);
+    providersPage.verifyTextField(providersPage.ldapBatchSizeInput, batchSize);
+    providersPage.verifyTextField(
+      providersPage.ldapFullSyncPeriodInput,
+      fullSyncPeriod
+    );
+    providersPage.verifyTextField(
+      providersPage.ldapUsersSyncPeriodInput,
+      userSyncPeriod
+    );
+    providersPage.verifyToggle(providersPage.periodicFullSync, "on");
+    providersPage.verifyToggle(providersPage.periodicUsersSync, "on");
+    providersPage.verifyToggle(providersPage.importUsers, "on");
     sidebarPage.goToUserFederation();
   });
 

--- a/cypress/integration/user_fed_ldap_test.spec.ts
+++ b/cypress/integration/user_fed_ldap_test.spec.ts
@@ -4,6 +4,7 @@ import ProviderPage from "../support/pages/admin_console/manage/providers/Provid
 import Masthead from "../support/pages/admin_console/Masthead";
 import ModalUtils from "../support/util/ModalUtils";
 import { keycloakBefore } from "../support/util/keycloak_hooks";
+// import { first } from "cypress/types/lodash";
 
 const loginPage = new LoginPage();
 const masthead = new Masthead();
@@ -112,7 +113,7 @@ describe("User Fed LDAP tests", () => {
     sidebarPage.goToUserFederation();
   });
 
-  it("Update an existing LDAP provider and save", () => {
+  it.skip("Update an existing LDAP provider and save", () => {
     providersPage.clickExistingCard(firstLdapName);
     providersPage.selectCacheType(newPolicy);
 
@@ -253,7 +254,7 @@ describe("User Fed LDAP tests", () => {
     expect(cy.contains("Enabled").should("exist"));
   });
 
-  it("Create new LDAP provider using the New Provider dropdown", () => {
+  it.skip("Create new LDAP provider using the New Provider dropdown", () => {
     providersPage.clickMenuCommand(addProviderMenu, allCapProvider);
     providersPage.fillLdapGeneralData(secondLdapName, secondLdapVendor);
     providersPage.fillLdapConnectionData(
@@ -277,7 +278,14 @@ describe("User Fed LDAP tests", () => {
     sidebarPage.goToUserFederation();
   });
 
+  // temp
   it("Delete an LDAP provider from card view using the card's menu", () => {
+    providersPage.deleteCardFromCard(firstLdapName);
+    modalUtils.checkModalTitle(deleteModalTitle).confirmModal();
+    masthead.checkNotificationMessage(deletedSuccessMessage);
+  });
+
+  it.skip("Delete an LDAP provider from card view using the card's menu", () => {
     providersPage.deleteCardFromCard(secondLdapName);
     modalUtils.checkModalTitle(deleteModalTitle).confirmModal();
     masthead.checkNotificationMessage(deletedSuccessMessage);

--- a/cypress/integration/user_fed_ldap_test.spec.ts
+++ b/cypress/integration/user_fed_ldap_test.spec.ts
@@ -4,7 +4,6 @@ import ProviderPage from "../support/pages/admin_console/manage/providers/Provid
 import Masthead from "../support/pages/admin_console/Masthead";
 import ModalUtils from "../support/util/ModalUtils";
 import { keycloakBefore } from "../support/util/keycloak_hooks";
-// import { first } from "cypress/types/lodash";
 
 const loginPage = new LoginPage();
 const masthead = new Masthead();
@@ -113,7 +112,7 @@ describe("User Fed LDAP tests", () => {
     sidebarPage.goToUserFederation();
   });
 
-  it.skip("Update an existing LDAP provider and save", () => {
+  it("Update an existing LDAP provider and save", () => {
     providersPage.clickExistingCard(firstLdapName);
     providersPage.selectCacheType(newPolicy);
 
@@ -254,7 +253,7 @@ describe("User Fed LDAP tests", () => {
     expect(cy.contains("Enabled").should("exist"));
   });
 
-  it.skip("Create new LDAP provider using the New Provider dropdown", () => {
+  it("Create new LDAP provider using the New Provider dropdown", () => {
     providersPage.clickMenuCommand(addProviderMenu, allCapProvider);
     providersPage.fillLdapGeneralData(secondLdapName, secondLdapVendor);
     providersPage.fillLdapConnectionData(
@@ -278,14 +277,7 @@ describe("User Fed LDAP tests", () => {
     sidebarPage.goToUserFederation();
   });
 
-  // temp
   it("Delete an LDAP provider from card view using the card's menu", () => {
-    providersPage.deleteCardFromCard(firstLdapName);
-    modalUtils.checkModalTitle(deleteModalTitle).confirmModal();
-    masthead.checkNotificationMessage(deletedSuccessMessage);
-  });
-
-  it.skip("Delete an LDAP provider from card view using the card's menu", () => {
     providersPage.deleteCardFromCard(secondLdapName);
     modalUtils.checkModalTitle(deleteModalTitle).confirmModal();
     masthead.checkNotificationMessage(deletedSuccessMessage);

--- a/cypress/support/pages/admin_console/manage/providers/ProviderPage.ts
+++ b/cypress/support/pages/admin_console/manage/providers/ProviderPage.ts
@@ -189,9 +189,9 @@ export default class ProviderPage {
 
   fillLdapConnectionData(
     connectionUrl: string,
+    truststoreSpi: string,
+    connectionTimeout: string,
     bindType: string,
-    truststoreSpi?: string,
-    connectionTimeout?: string,
     bindDn?: string,
     bindCreds?: string
   ) {
@@ -274,7 +274,7 @@ export default class ProviderPage {
     const ldapDnValue = "ou=groups";
 
     cy.contains("Add").click();
-    cy.wait(1000);
+    // cy.wait(1000);
 
     cy.get("#kc-providerId").click();
     cy.get("button").contains(mapperType).click();

--- a/cypress/support/pages/admin_console/manage/providers/ProviderPage.ts
+++ b/cypress/support/pages/admin_console/manage/providers/ProviderPage.ts
@@ -189,9 +189,9 @@ export default class ProviderPage {
 
   fillLdapConnectionData(
     connectionUrl: string,
-    truststoreSpi: string,
-    connectionTimeout: string,
     bindType: string,
+    truststoreSpi?: string,
+    connectionTimeout?: string,
     bindDn?: string,
     bindCreds?: string
   ) {
@@ -274,7 +274,7 @@ export default class ProviderPage {
     const ldapDnValue = "ou=groups";
 
     cy.contains("Add").click();
-    // cy.wait(1000);
+    cy.wait(1000);
 
     cy.get("#kc-providerId").click();
     cy.get("button").contains(mapperType).click();

--- a/cypress/support/pages/admin_console/manage/providers/ProviderPage.ts
+++ b/cypress/support/pages/admin_console/manage/providers/ProviderPage.ts
@@ -31,6 +31,22 @@ export default class ProviderPage {
   private ldapUuidLdapAttInput = "ldap-uuid-attribute";
   private ldapUserObjClassesInput = "ldap-user-object-classes";
 
+  // LdapSettingsKerberosIntegration input values
+  ldapKerberosRealmInput = "kerberos-realm";
+  ldapServerPrincipalInput = "kerberos-principal";
+  ldapKeyTabInput = "kerberos-keytab";
+  allowKerberosAuth = "allow-kerberos-auth";
+  debug = "debug";
+  useKerberosForPwAuth = "use-kerberos-pw-auth";
+
+  // LdapSettingsSynchronization input values
+  ldapBatchSizeInput = "batch-size";
+  ldapFullSyncPeriodInput = "full-sync-period";
+  ldapUsersSyncPeriodInput = "changed-users-sync-period";
+  importUsers = "import-users";
+  periodicFullSync = "periodic-full-sync";
+  periodicUsersSync = "periodic-changed-users-sync";
+
   // SettingsCache input values
   private cacheDayInput = "#kc-eviction-day";
   private cacheDayList = "#kc-eviction-day + ul";
@@ -157,6 +173,12 @@ export default class ProviderPage {
     for (let i = 0; i < lifespan; i++) {
       cy.findByTestId(this.maxLifespan).click();
     }
+    return this;
+  }
+
+  fillTextField(textField: string, value: string) {
+    cy.findByTestId(textField).type("x");
+    cy.findByTestId(textField).clear().type(value).blur();
     return this;
   }
 

--- a/src/user-federation/ldap/LdapSettingsKerberosIntegration.tsx
+++ b/src/user-federation/ldap/LdapSettingsKerberosIntegration.tsx
@@ -54,7 +54,8 @@ export const LdapSettingsKerberosIntegration = ({
             control={form.control}
             render={({ onChange, value }) => (
               <Switch
-                id={"kc-allow-kerberos-authentication"}
+                id="kc-allow-kerberos-authentication"
+                data-testid="allow-kerberos-auth"
                 isDisabled={false}
                 onChange={(value) => onChange([`${value}`])}
                 isChecked={value[0] === "true"}
@@ -184,7 +185,8 @@ export const LdapSettingsKerberosIntegration = ({
                 control={form.control}
                 render={({ onChange, value }) => (
                   <Switch
-                    id={"kc-debug"}
+                    id="kc-debug"
+                    data-testid="debug"
                     isDisabled={false}
                     onChange={(value) => onChange([`${value}`])}
                     isChecked={value[0] === "true"}
@@ -213,7 +215,8 @@ export const LdapSettingsKerberosIntegration = ({
             control={form.control}
             render={({ onChange, value }) => (
               <Switch
-                id={"kc-use-kerberos-password-authentication"}
+                id="kc-use-kerberos-password-authentication"
+                data-testid="use-kerberos-pw-auth"
                 isDisabled={false}
                 onChange={(value) => onChange([`${value}`])}
                 isChecked={value[0] === "true"}

--- a/src/user-federation/ldap/LdapSettingsSynchronization.tsx
+++ b/src/user-federation/ldap/LdapSettingsSynchronization.tsx
@@ -50,7 +50,8 @@ export const LdapSettingsSynchronization = ({
             control={form.control}
             render={({ onChange, value }) => (
               <Switch
-                id={"kc-import-users"}
+                id="kc-import-users"
+                data-testid="import-users"
                 name="importEnabled"
                 label={t("common:on")}
                 labelOff={t("common:off")}
@@ -75,6 +76,7 @@ export const LdapSettingsSynchronization = ({
             type="number"
             min={0}
             id="kc-batch-size"
+            data-testid="batch-size"
             name="config.batchSizeForSync[0]"
             ref={form.register}
           />
@@ -96,7 +98,8 @@ export const LdapSettingsSynchronization = ({
             control={form.control}
             render={({ onChange, value }) => (
               <Switch
-                id={"kc-periodic-full-sync"}
+                id="kc-periodic-full-sync"
+                data-testid="periodic-full-sync"
                 isDisabled={false}
                 onChange={(value) => onChange(value)}
                 isChecked={value === true}
@@ -124,6 +127,7 @@ export const LdapSettingsSynchronization = ({
               min={-1}
               defaultValue={604800}
               id="kc-full-sync-period"
+              data-testid="full-sync-period"
               name="config.fullSyncPeriod[0]"
               ref={form.register}
             />
@@ -146,7 +150,8 @@ export const LdapSettingsSynchronization = ({
             control={form.control}
             render={({ onChange, value }) => (
               <Switch
-                id={"kc-periodic-changed-users-sync"}
+                id="kc-periodic-changed-users-sync"
+                data-testid="periodic-changed-users-sync"
                 isDisabled={false}
                 onChange={(value) => onChange(value)}
                 isChecked={value === true}
@@ -174,6 +179,7 @@ export const LdapSettingsSynchronization = ({
               min={-1}
               defaultValue={86400}
               id="kc-changed-users-sync-period"
+              data-testid="changed-users-sync-period"
               name="config.changedSyncPeriod[0]"
               ref={form.register}
             />


### PR DESCRIPTION
## Motivation
Test coverage dashboard:
https://docs.google.com/spreadsheets/d/1eCngdn3wmMeQ0u5u-eKYJo1XdT2fHvi7ki51mrcu-Ys/edit#gid=1613790516

## Brief Description
Adds several cypress tests for the Kerberos Integration settings and Synchronization settings sections of the user fed LDAP provider UI. Specifically, addresses rows [696-699](https://docs.google.com/spreadsheets/d/1eCngdn3wmMeQ0u5u-eKYJo1XdT2fHvi7ki51mrcu-Ys/edit#gid=1613790516&range=696:699) and rows [709-714](https://docs.google.com/spreadsheets/d/1eCngdn3wmMeQ0u5u-eKYJo1XdT2fHvi7ki51mrcu-Ys/edit#gid=1613790516&range=709:714) in the test coverage dashboard.

## Verification Steps
Verify that tests pass

## Additional Notes
The user_fed_ldap_test.spec.ts passes consistently locally when run via the cypress UI or headless. 