### PR TITLE
Adds LDAP searching tests

### DIFF
--- a/cypress/integration/user_fed_ldap_test.spec.ts
+++ b/cypress/integration/user_fed_ldap_test.spec.ts
@@ -4,7 +4,6 @@ import ProviderPage from "../support/pages/admin_console/manage/providers/Provid
 import Masthead from "../support/pages/admin_console/Masthead";
 import ModalUtils from "../support/util/ModalUtils";
 import { keycloakBefore } from "../support/util/keycloak_hooks";
-// import { first } from "cypress/types/lodash";
 
 const loginPage = new LoginPage();
 const masthead = new Masthead();
@@ -123,7 +122,7 @@ describe("User Fed LDAP tests", () => {
     sidebarPage.goToUserFederation();
   });
 
-  it.skip("Update an existing LDAP provider and save", () => {
+  it("Update an existing LDAP provider and save", () => {
     providersPage.clickExistingCard(firstLdapName);
     providersPage.selectCacheType(newPolicy);
 
@@ -159,7 +158,6 @@ describe("User Fed LDAP tests", () => {
     // now verify
     sidebarPage.goToUserFederation();
     providersPage.clickExistingCard(firstLdapName);
-
     providersPage.verifyTextField(
       providersPage.connectionUrlInput,
       connectionUrlInvalid
@@ -342,7 +340,7 @@ describe("User Fed LDAP tests", () => {
     expect(cy.contains("Enabled").should("exist"));
   });
 
-  it.skip("Create new LDAP provider using the New Provider dropdown", () => {
+  it("Create new LDAP provider using the New Provider dropdown", () => {
     providersPage.clickMenuCommand(addProviderMenu, allCapProvider);
     providersPage.fillLdapGeneralData(secondLdapName, secondLdapVendor);
     providersPage.fillLdapConnectionData(
@@ -366,14 +364,7 @@ describe("User Fed LDAP tests", () => {
     sidebarPage.goToUserFederation();
   });
 
-  // temp
   it("Delete an LDAP provider from card view using the card's menu", () => {
-    providersPage.deleteCardFromCard(firstLdapName);
-    modalUtils.checkModalTitle(deleteModalTitle).confirmModal();
-    masthead.checkNotificationMessage(deletedSuccessMessage);
-  });
-
-  it.skip("Delete an LDAP provider from card view using the card's menu", () => {
     providersPage.deleteCardFromCard(secondLdapName);
     modalUtils.checkModalTitle(deleteModalTitle).confirmModal();
     masthead.checkNotificationMessage(deletedSuccessMessage);

--- a/cypress/integration/user_fed_ldap_test.spec.ts
+++ b/cypress/integration/user_fed_ldap_test.spec.ts
@@ -4,6 +4,7 @@ import ProviderPage from "../support/pages/admin_console/manage/providers/Provid
 import Masthead from "../support/pages/admin_console/Masthead";
 import ModalUtils from "../support/util/ModalUtils";
 import { keycloakBefore } from "../support/util/keycloak_hooks";
+// import { first } from "cypress/types/lodash";
 
 const loginPage = new LoginPage();
 const masthead = new Masthead();
@@ -122,7 +123,7 @@ describe("User Fed LDAP tests", () => {
     sidebarPage.goToUserFederation();
   });
 
-  it("Update an existing LDAP provider and save", () => {
+  it.skip("Update an existing LDAP provider and save", () => {
     providersPage.clickExistingCard(firstLdapName);
     providersPage.selectCacheType(newPolicy);
 
@@ -158,6 +159,7 @@ describe("User Fed LDAP tests", () => {
     // now verify
     sidebarPage.goToUserFederation();
     providersPage.clickExistingCard(firstLdapName);
+
     providersPage.verifyTextField(
       providersPage.connectionUrlInput,
       connectionUrlInvalid
@@ -340,7 +342,7 @@ describe("User Fed LDAP tests", () => {
     expect(cy.contains("Enabled").should("exist"));
   });
 
-  it("Create new LDAP provider using the New Provider dropdown", () => {
+  it.skip("Create new LDAP provider using the New Provider dropdown", () => {
     providersPage.clickMenuCommand(addProviderMenu, allCapProvider);
     providersPage.fillLdapGeneralData(secondLdapName, secondLdapVendor);
     providersPage.fillLdapConnectionData(
@@ -364,7 +366,14 @@ describe("User Fed LDAP tests", () => {
     sidebarPage.goToUserFederation();
   });
 
+  // temp
   it("Delete an LDAP provider from card view using the card's menu", () => {
+    providersPage.deleteCardFromCard(firstLdapName);
+    modalUtils.checkModalTitle(deleteModalTitle).confirmModal();
+    masthead.checkNotificationMessage(deletedSuccessMessage);
+  });
+
+  it.skip("Delete an LDAP provider from card view using the card's menu", () => {
     providersPage.deleteCardFromCard(secondLdapName);
     modalUtils.checkModalTitle(deleteModalTitle).confirmModal();
     masthead.checkNotificationMessage(deletedSuccessMessage);

--- a/cypress/integration/user_fed_ldap_test.spec.ts
+++ b/cypress/integration/user_fed_ldap_test.spec.ts
@@ -16,6 +16,9 @@ const allCapProvider = provider.toUpperCase();
 
 const firstLdapName = "my-ldap";
 const firstLdapVendor = "Active Directory";
+const secondLdapName = `${firstLdapName}-2`;
+const secondLdapVendor = "Other";
+const updatedLdapName = `${firstLdapName}-updated`;
 
 // connection and authentication settings
 const connectionUrlValid = "ldap://ldap.forumsys.com:389";
@@ -43,24 +46,27 @@ const userSyncPeriod = "86400";
 
 // ldap searching and updating
 const editModeReadOnly = "READ_ONLY";
+const editModeWritable = "WRITABLE";
+const editModeUnsynced = "UNSYNCED";
+
 const firstUsersDn = "user-dn-1";
 const firstUserLdapAtt = "uid";
 const firstRdnLdapAtt = "uid";
 const firstUuidLdapAtt = "entryUUID";
 const firstUserObjClasses = "inetOrgPerson, organizationalPerson";
+const firstUserLdapFilter = "(first-filter)";
+const firstReadTimeout = "5000";
 
-const secondLdapName = `${firstLdapName}-2`;
-const secondLdapVendor = "Other";
-
-const editModeWritable = "WRITABLE";
+const searchScopeOneLevel = "One Level";
+const searchScopeSubtree = "Subtree";
 
 const secondUsersDn = "user-dn-2";
 const secondUserLdapAtt = "cn";
 const secondRdnLdapAtt = "cn";
 const secondUuidLdapAtt = "objectGUID";
 const secondUserObjClasses = "person, organizationalPerson, user";
-
-const updatedLdapName = `${firstLdapName}-updated`;
+const secondUserLdapFilter = "(second-filter)";
+const secondReadTimeout = "5000";
 
 const defaultPolicy = "DEFAULT";
 const newPolicy = "EVICT_WEEKLY";
@@ -115,7 +121,10 @@ describe("User Fed LDAP tests", () => {
       firstUserLdapAtt,
       firstRdnLdapAtt,
       firstUuidLdapAtt,
-      firstUserObjClasses
+      firstUserObjClasses,
+      firstUserLdapFilter,
+      searchScopeOneLevel,
+      firstReadTimeout
     );
     providersPage.save(provider);
     masthead.checkNotificationMessage(createdSuccessMessage);
@@ -288,6 +297,86 @@ describe("User Fed LDAP tests", () => {
     providersPage.verifyToggle(providersPage.periodicUsersSync, "on");
     providersPage.verifyToggle(providersPage.importUsers, "on");
     sidebarPage.goToUserFederation();
+  });
+
+  it("Should update LDAP searching and updating settings and save", () => {
+    providersPage.clickExistingCard(firstLdapName);
+
+    providersPage.fillLdapSearchingData(
+      editModeWritable,
+      secondUsersDn,
+      secondUserLdapAtt,
+      secondRdnLdapAtt,
+      secondUuidLdapAtt,
+      secondUserObjClasses,
+      secondUserLdapFilter,
+      searchScopeSubtree,
+      secondReadTimeout
+    );
+    providersPage.toggleSwitch(providersPage.ldapPagination);
+
+    providersPage.save(provider);
+    masthead.checkNotificationMessage(savedSuccessMessage);
+
+    // now verify
+    sidebarPage.goToUserFederation();
+    providersPage.clickExistingCard(firstLdapName);
+
+    providersPage.verifySelect(
+      providersPage.ldapEditModeInput,
+      editModeWritable
+    );
+    providersPage.verifyTextField(
+      providersPage.ldapUsersDnInput,
+      secondUsersDn
+    );
+    providersPage.verifyTextField(
+      providersPage.ldapUserLdapAttInput,
+      secondUserLdapAtt
+    );
+    providersPage.verifyTextField(
+      providersPage.ldapRdnLdapAttInput,
+      secondRdnLdapAtt
+    );
+    providersPage.verifyTextField(
+      providersPage.ldapUuidLdapAttInput,
+      secondUuidLdapAtt
+    );
+    providersPage.verifyTextField(
+      providersPage.ldapUserObjClassesInput,
+      secondUserObjClasses
+    );
+    providersPage.verifyTextField(
+      providersPage.ldapUserLdapFilter,
+      secondUserLdapFilter
+    );
+    providersPage.verifySelect(
+      providersPage.ldapSearchScopeInput,
+      searchScopeSubtree
+    );
+    providersPage.verifyTextField(
+      providersPage.ldapReadTimeout,
+      secondReadTimeout
+    );
+    providersPage.verifyToggle(providersPage.ldapPagination, "on");
+
+    sidebarPage.goToUserFederation();
+    providersPage.clickExistingCard(firstLdapName);
+
+    providersPage.fillSelect(providersPage.ldapEditModeInput, editModeUnsynced);
+    providersPage.toggleSwitch(providersPage.importUsers);
+
+    providersPage.save(provider);
+    masthead.checkNotificationMessage(savedSuccessMessage);
+
+    // now verify
+    sidebarPage.goToUserFederation();
+    providersPage.clickExistingCard(firstLdapName);
+
+    providersPage.verifySelect(
+      providersPage.ldapEditModeInput,
+      editModeUnsynced
+    );
   });
 
   it("Should update display name", () => {

--- a/cypress/support/pages/admin_console/manage/providers/ProviderPage.ts
+++ b/cypress/support/pages/admin_console/manage/providers/ProviderPage.ts
@@ -211,9 +211,9 @@ export default class ProviderPage {
 
   fillLdapConnectionData(
     connectionUrl: string,
-    truststoreSpi: string,
-    connectionTimeout: string,
     bindType: string,
+    truststoreSpi?: string,
+    connectionTimeout?: string,
     bindDn?: string,
     bindCreds?: string
   ) {
@@ -296,7 +296,7 @@ export default class ProviderPage {
     const ldapDnValue = "ou=groups";
 
     cy.contains("Add").click();
-    // cy.wait(1000);
+    cy.wait(1000);
 
     cy.get("#kc-providerId").click();
     cy.get("button").contains(mapperType).click();

--- a/cypress/support/pages/admin_console/manage/providers/ProviderPage.ts
+++ b/cypress/support/pages/admin_console/manage/providers/ProviderPage.ts
@@ -23,13 +23,18 @@ export default class ProviderPage {
   private testAuthBtn = "test-auth-button";
 
   // LdapSettingsSearching input values
-  private ldapEditModeInput = "#kc-edit-mode";
+  ldapEditModeInput = "#kc-edit-mode";
   private ldapEditModeList = "#kc-edit-mode + ul";
-  private ldapUsersDnInput = "ldap-users-dn";
-  private ldapUserLdapAttInput = "ldap-username-attribute";
-  private ldapRdnLdapAttInput = "ldap-rdn-attribute";
-  private ldapUuidLdapAttInput = "ldap-uuid-attribute";
-  private ldapUserObjClassesInput = "ldap-user-object-classes";
+  ldapSearchScopeInput = "#kc-search-scope";
+  private ldapSearchScopeInputList = "#kc-search-scope + ul";
+  ldapPagination = "console-pagination";
+  ldapUsersDnInput = "ldap-users-dn";
+  ldapUserLdapAttInput = "ldap-username-attribute";
+  ldapRdnLdapAttInput = "ldap-rdn-attribute";
+  ldapUuidLdapAttInput = "ldap-uuid-attribute";
+  ldapUserObjClassesInput = "ldap-user-object-classes";
+  ldapUserLdapFilter = "user-ldap-filter";
+  ldapReadTimeout = "ldap-read-timeout";
 
   // LdapSettingsKerberosIntegration input values
   ldapKerberosRealmInput = "kerberos-realm";
@@ -246,11 +251,13 @@ export default class ProviderPage {
     userLdapAtt?: string,
     rdnLdapAtt?: string,
     uuidLdapAtt?: string,
-    userObjClasses?: string
+    userObjClasses?: string,
+    userLdapFilter?: string,
+    searchScope?: string,
+    readTimeout?: string
   ) {
     cy.get(this.ldapEditModeInput).click();
     cy.get(this.ldapEditModeList).contains(editMode).click();
-
     cy.findByTestId(this.ldapUsersDnInput).clear().type(usersDn);
     if (userLdapAtt) {
       cy.findByTestId(this.ldapUserLdapAttInput).clear().type(userLdapAtt);
@@ -265,6 +272,16 @@ export default class ProviderPage {
       cy.findByTestId(this.ldapUserObjClassesInput)
         .clear()
         .type(userObjClasses);
+    }
+    if (userLdapFilter) {
+      cy.findByTestId(this.ldapUserLdapFilter).clear().type(userLdapFilter);
+    }
+    if (searchScope) {
+      cy.get(this.ldapSearchScopeInput).click();
+      cy.get(this.ldapSearchScopeInputList).contains(searchScope).click();
+    }
+    if (readTimeout) {
+      cy.findByTestId(this.ldapReadTimeout).clear().type(readTimeout);
     }
     return this;
   }

--- a/cypress/support/pages/admin_console/manage/providers/ProviderPage.ts
+++ b/cypress/support/pages/admin_console/manage/providers/ProviderPage.ts
@@ -181,6 +181,11 @@ export default class ProviderPage {
     return this;
   }
 
+  fillSelect(selectField: string, value: string) {
+    cy.get(selectField).click();
+    cy.get(`${selectField} + ul`).contains(value).click();
+  }
+
   fillTextField(textField: string, value: string) {
     cy.findByTestId(textField).type("x");
     cy.findByTestId(textField).clear().type(value).blur();

--- a/cypress/support/pages/admin_console/manage/providers/ProviderPage.ts
+++ b/cypress/support/pages/admin_console/manage/providers/ProviderPage.ts
@@ -211,9 +211,9 @@ export default class ProviderPage {
 
   fillLdapConnectionData(
     connectionUrl: string,
+    truststoreSpi: string,
+    connectionTimeout: string,
     bindType: string,
-    truststoreSpi?: string,
-    connectionTimeout?: string,
     bindDn?: string,
     bindCreds?: string
   ) {
@@ -296,7 +296,7 @@ export default class ProviderPage {
     const ldapDnValue = "ou=groups";
 
     cy.contains("Add").click();
-    cy.wait(1000);
+    // cy.wait(1000);
 
     cy.get("#kc-providerId").click();
     cy.get("button").contains(mapperType).click();

--- a/src/user-federation/ldap/LdapSettingsSearching.tsx
+++ b/src/user-federation/ldap/LdapSettingsSearching.tsx
@@ -274,6 +274,7 @@ export const LdapSettingsSearching = ({
           <TextInput
             type="text"
             id="kc-user-ldap-filter"
+            data-testid="user-ldap-filter"
             name="config.customUserSearchFilter[0]"
             ref={form.register({
               pattern: {
@@ -342,6 +343,7 @@ export const LdapSettingsSearching = ({
             type="number"
             min={0}
             id="kc-read-timeout"
+            data-testid="ldap-read-timeout"
             name="config.readTimeout[0]"
             ref={form.register}
           />
@@ -363,7 +365,8 @@ export const LdapSettingsSearching = ({
             control={form.control}
             render={({ onChange, value }) => (
               <Switch
-                id={"kc-console-pagination"}
+                id="kc-console-pagination"
+                data-testid="console-pagination"
                 isDisabled={false}
                 onChange={(value) => onChange([`${value}`])}
                 isChecked={value[0] === "true"}


### PR DESCRIPTION
## Motivation
Test coverage dashboard:
https://docs.google.com/spreadsheets/d/1eCngdn3wmMeQ0u5u-eKYJo1XdT2fHvi7ki51mrcu-Ys/edit#gid=1613790516

## Brief Description
Adds several cypress tests for the LDAP searching and updating section of the user fed LDAP provider UI. Specifically, addresses rows [701-707](https://docs.google.com/spreadsheets/d/1eCngdn3wmMeQ0u5u-eKYJo1XdT2fHvi7ki51mrcu-Ys/edit#gid=1613790516&range=701:707) in the test coverage dashboard.

## Verification Steps
Verify that tests pass.

## Additional Notes
The user_fed_ldap_test.spec.ts passes consistently locally when run via the cypress UI or headless.
