### PR TITLE
Automatically update Github Actions using Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,3 +25,9 @@ updates:
       interval: weekly
     labels:
       - area/dependencies
+  - package-ecosystem: github-actions
+    directory: /
+    open-pull-requests-limit: 999
+    rebase-strategy: disabled
+    schedule:
+      interval: weekly


### PR DESCRIPTION
This will allow Dependabot to keep our Github Actions up-to-date automatically.