### PR TITLE
Avoid errors in Groups section.

### DIFF
--- a/src/groups/SearchGroups.tsx
+++ b/src/groups/SearchGroups.tsx
@@ -24,6 +24,7 @@ import { ListEmptyState } from "../components/list-empty-state/ListEmptyState";
 import { GroupPath } from "../components/group/GroupPath";
 import { useSubGroups } from "./SubGroupsContext";
 import { ViewHeader } from "../components/view-header/ViewHeader";
+import { useAccess } from "../context/access/Access";
 
 type SearchGroup = GroupRepresentation & {
   link?: string;
@@ -39,6 +40,9 @@ export default function SearchGroups() {
 
   const [key, setKey] = useState(0);
   const refresh = () => setKey(new Date().getTime());
+
+  const { hasAccess } = useAccess();
+  const isManager = hasAccess("manage-users", "query-clients");
 
   const { setSubGroups } = useSubGroups();
   useEffect(
@@ -61,17 +65,21 @@ export default function SearchGroups() {
     }
   };
 
-  const GroupNameCell = (group: SearchGroup) => (
-    <Link
-      key={group.id}
-      to={`/${realm}/groups/search/${group.link}`}
-      onClick={() =>
-        setSubGroups([{ name: t("searchGroups"), id: "search" }, group])
-      }
-    >
-      {group.name}
-    </Link>
-  );
+  const GroupNameCell = (group: SearchGroup) => {
+    if (!isManager) return <span>{group.name}</span>;
+
+    return (
+      <Link
+        key={group.id}
+        to={`/${realm}/groups/search/${group.link}`}
+        onClick={() =>
+          setSubGroups([{ name: t("searchGroups"), id: "search" }, group])
+        }
+      >
+        {group.name}
+      </Link>
+    );
+  };
 
   const flatten = (
     groups: GroupRepresentation[],


### PR DESCRIPTION
## Motivation
If the user does not have "manage-users" and "query-clients" roles, clicking on a group will result in a 403 error.

## Verification Steps
1. Create a group with an admin user.
2. Create test a user with realm-management roles of "query-groups", "query-users", and "view-realm".
3. Log in with the test user and go to groups section.
4. Click on the group.

## Additional Notes
This change deals with the problem by making so you can view that the group exists, but you can't manage the group.  It also doesn't allow you to attempt to create a group without proper permissions.
