### PR TITLE
now also removes the already added validators after closing the dialog

### DIFF
--- a/src/realm-settings/user-profile/attribute/AddValidatorDialog.tsx
+++ b/src/realm-settings/user-profile/attribute/AddValidatorDialog.tsx
@@ -9,22 +9,30 @@ import {
   Thead,
   Tr,
 } from "@patternfly/react-table";
+
+import type { KeyValueType } from "../../../components/attribute-form/attribute-convert";
 import { AddValidatorRoleDialog } from "./AddValidatorRoleDialog";
 import { Validator, validators as allValidator } from "./Validators";
 import useToggle from "../../../utils/useToggle";
 
 export type AddValidatorDialogProps = {
+  selectedValidators: KeyValueType[];
   toggleDialog: () => void;
   onConfirm: (newValidator: Validator) => void;
 };
 
 export const AddValidatorDialog = ({
+  selectedValidators,
   toggleDialog,
   onConfirm,
 }: AddValidatorDialogProps) => {
   const { t } = useTranslation("realm-settings");
   const [selectedValidator, setSelectedValidator] = useState<Validator>();
-  const [validators, setValidators] = useState(allValidator);
+  const [validators, setValidators] = useState(
+    allValidator.filter(
+      ({ name }) => !selectedValidators.map(({ key }) => key).includes(name)
+    )
+  );
   const [addValidatorRoleModalOpen, toggleModal] = useToggle();
 
   return (

--- a/src/realm-settings/user-profile/attribute/AddValidatorDialog.tsx
+++ b/src/realm-settings/user-profile/attribute/AddValidatorDialog.tsx
@@ -28,7 +28,7 @@ export const AddValidatorDialog = ({
 }: AddValidatorDialogProps) => {
   const { t } = useTranslation("realm-settings");
   const [selectedValidator, setSelectedValidator] = useState<Validator>();
-  const [validators, setValidators] = useState(
+  const [validators, setValidators] = useState(() =>
     allValidator.filter(
       ({ name }) => !selectedValidators.map(({ key }) => key).includes(name)
     )

--- a/src/realm-settings/user-profile/attribute/AttributeValidations.tsx
+++ b/src/realm-settings/user-profile/attribute/AttributeValidations.tsx
@@ -66,6 +66,7 @@ export const AttributeValidations = () => {
     <>
       {addValidatorModalOpen && (
         <AddValidatorDialog
+          selectedValidators={validators}
           onConfirm={(newValidator) => {
             setValue("validations", [
               ...validators,


### PR DESCRIPTION
Used to only remove the validators as long as the dialog stayed open
now also removes the already installed validators when the dialog
is opened again.

fixes: #2397