### PR TITLE
Remove Java setup from testing job

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -91,14 +91,6 @@ jobs:
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci
 
-      - name: Set up Java
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 11
-          check-latest: true
-          cache: maven
-
       - name: Restore Keycloak server
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
Removes the Java setup from the testing job as this is not required to run the Quarkus server.