### PR TITLE
wip: Partial import test fix

### DIFF
--- a/cypress/integration/partial_import_test.spec.ts
+++ b/cypress/integration/partial_import_test.spec.ts
@@ -25,6 +25,7 @@ describe("Partial import test", () => {
     createRealmPage.fillRealmName(TEST_REALM).createRealm();
 
     sidebarPage.goToRealmSettings();
+    sidebarPage.waitForPageLoad();
     realmSettings.clickActionMenu();
   });
 


### PR DESCRIPTION
## Motivation
An attempt to fix "Displays user options after realmless import and does the import" test in partial_import_test suit.

## Verification Steps
1. Run tests in `partial_import_test.spec.ts` locally. All tests in this suit should be greeen.

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated
