### PR TITLE
Fine-grained permissions for user section.

### DIFF
--- a/src/components/key-value-form/AttributeForm.tsx
+++ b/src/components/key-value-form/AttributeForm.tsx
@@ -16,9 +16,15 @@ export type AttributesFormProps = {
   form: UseFormMethods<AttributeForm>;
   save?: (model: AttributeForm) => void;
   reset?: () => void;
+  fineGrainedAccess?: boolean;
 };
 
-export const AttributesForm = ({ form, reset, save }: AttributesFormProps) => {
+export const AttributesForm = ({
+  form,
+  reset,
+  save,
+  fineGrainedAccess,
+}: AttributesFormProps) => {
   const { t } = useTranslation("roles");
   const noSaveCancelButtons = !save && !reset;
   const {
@@ -30,6 +36,7 @@ export const AttributesForm = ({ form, reset, save }: AttributesFormProps) => {
     <FormAccess
       role="manage-realm"
       onSubmit={save ? handleSubmit(save) : undefined}
+      fineGrainedAccess={fineGrainedAccess}
     >
       <FormProvider {...form}>
         <KeyValueInput name="attributes" />

--- a/src/user/UserAttributes.tsx
+++ b/src/user/UserAttributes.tsx
@@ -56,6 +56,7 @@ export const UserAttributes = ({ user: defaultUser }: UserAttributesProps) => {
       <AttributesForm
         form={form}
         save={save}
+        fineGrainedAccess={user.access?.manage}
         reset={() =>
           form.reset({
             attributes: convertAttributes(),

--- a/src/user/UserForm.tsx
+++ b/src/user/UserForm.tsx
@@ -153,6 +153,7 @@ export const UserForm = ({
       isHorizontal
       onSubmit={handleSubmit(save)}
       role="manage-users"
+      fineGrainedAccess={user?.access?.manage}
       className="pf-u-mt-lg"
     >
       {open && (

--- a/src/user/UserGroups.tsx
+++ b/src/user/UserGroups.tsx
@@ -216,6 +216,7 @@ export const UserGroups = ({ user }: UserGroupsProps) => {
           data-testid={`leave-${group.name}`}
           onClick={() => leave([group])}
           variant="link"
+          isDisabled={!user.access?.manageGroupMembership}
         >
           {t("leave")}
         </Button>
@@ -286,6 +287,7 @@ export const UserGroups = ({ user }: UserGroupsProps) => {
               className="kc-join-group-button"
               onClick={toggleModal}
               data-testid="add-group-button"
+              isDisabled={!user.access?.manageGroupMembership}
             >
               {t("joinGroup")}
             </Button>

--- a/src/user/UsersSection.tsx
+++ b/src/user/UsersSection.tsx
@@ -23,6 +23,7 @@ import {
   SearchIcon,
   WarningTriangleIcon,
 } from "@patternfly/react-icons";
+import type { IRowData } from "@patternfly/react-table";
 import type RealmRepresentation from "@keycloak/keycloak-admin-client/lib/defs/realmRepresentation";
 import type ComponentRepresentation from "@keycloak/keycloak-admin-client/lib/defs/componentRepresentation";
 import type UserRepresentation from "@keycloak/keycloak-admin-client/lib/defs/userRepresentation";
@@ -113,7 +114,10 @@ export default function UsersSection() {
     }
 
     try {
-      const users = await adminClient.users.find({ ...params });
+      const users = await adminClient.users.find({
+        briefRepresentation: true,
+        ...params,
+      });
       if (realm?.bruteForceProtected) {
         const brutes = await Promise.all(
           users.map((user: BruteUser) =>
@@ -344,15 +348,20 @@ export default function UsersSection() {
             )
           }
           toolbarItem={toolbar}
-          actions={[
-            {
-              title: t("common:delete"),
-              onRowClick: (user) => {
-                setSelectedRows([user]);
-                toggleDeleteDialog();
+          actionResolver={(rowData: IRowData) => {
+            const user: UserRepresentation = rowData.data;
+            if (!user.access?.manage) return [];
+
+            return [
+              {
+                title: t("common:delete"),
+                onClick: () => {
+                  setSelectedRows([user]);
+                  toggleDeleteDialog();
+                },
               },
-            },
-          ]}
+            ];
+          }}
           columns={[
             {
               name: "username",

--- a/src/user/UsersTabs.tsx
+++ b/src/user/UsersTabs.tsx
@@ -157,11 +157,16 @@ const UsersTabs = () => {
         dropdownItems={[
           <DropdownItem
             key="impersonate"
+            isDisabled={!user?.access?.impersonate}
             onClick={() => toggleImpersonateDialog()}
           >
             {t("impersonate")}
           </DropdownItem>,
-          <DropdownItem key="delete" onClick={() => toggleDeleteDialog()}>
+          <DropdownItem
+            key="delete"
+            isDisabled={!user?.access?.manage}
+            onClick={() => toggleDeleteDialog()}
+          >
             {t("common:delete")}
           </DropdownItem>,
         ]}
@@ -196,6 +201,7 @@ const UsersTabs = () => {
               <Tab
                 eventKey="credentials"
                 data-testid="credentials"
+                isHidden={!user.access?.manage}
                 title={<TabTitleText>{t("common:credentials")}</TabTitleText>}
               >
                 <UserCredentials user={user} />
@@ -203,6 +209,7 @@ const UsersTabs = () => {
               <Tab
                 eventKey="role-mapping"
                 data-testid="role-mapping-tab"
+                isHidden={!user.access?.mapRoles}
                 title={<TabTitleText>{t("roleMapping")}</TabTitleText>}
               >
                 <UserRoleMapping id={id} name={user.username!} />

--- a/src/user/routes/User.ts
+++ b/src/user/routes/User.ts
@@ -15,7 +15,7 @@ export const UserRoute: RouteDef = {
   path: "/:realm/users/:id/:tab",
   component: lazy(() => import("../UsersTabs")),
   breadcrumb: (t) => t("users:userDetails"),
-  access: "manage-users",
+  access: "view-users",
 };
 
 export const toUser = (params: UserParams): LocationDescriptorObject => ({


### PR DESCRIPTION
## Motivation
This implements fine-grained permissions for the user section only.

Implements part of https://github.com/keycloak/keycloak-admin-ui/issues/2403

## Brief Description
This is a fairly simple approach.  In some cases we could do better with how we present a restricted screen to the user.  But overall it's on par with the implementation in the old UI.  So I think this approach is good for a first pass and we can improve it later.  Higher priority is to get all of FGP implemented and then create an FGP test suite.

## Verification Steps
Since the [fine-grained permissions configuration screens](https://github.com/keycloak/keycloak-admin-ui/issues/2402) are not implemented in the new UI yet, verification requires going to the old UI.  You can follow the [examples in the documentation](https://www.keycloak.org/docs/latest/server_admin/#_fine_grain_permissions).

You can also see the access object that is returned in the user record when a user is queried.  It looks something like this:
`"access":{"manageGroupMembership":false,"view":true,"mapRoles":true,"impersonate":true,"manage":false}`

This will give hints as to what the user should be allowed to do in the UI.  Note that sometimes you also need the proper roles to be set on the realm-management client.

Lastly, make sure your permissions are set on a test realm.  The user restricted by the fine-grained access should log in to the test realm.  Using snowpack, you will need to go to that realm like this localhost:8080/?realm=test
