### PR TITLE
Upgrade to version 18 of Node.js

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,7 +11,7 @@ on:
       - cypress/**
       - mocks/**
 env:
-  NODE_VERSION: 16
+  NODE_VERSION: 18
 jobs:
   analyze:
     runs-on: ubuntu-latest

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
           check-latest: true
           cache: npm
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [main]
 env:
-  NODE_VERSION: 16
+  NODE_VERSION: 18
 jobs:
   setup:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This project is the next generation of the Keycloak Administration UI. It is wri
 
 ### Prerequisites
 
-Make sure that you have Node.js version 16 (or later) installed on your system. If you do not have Node.js installed we recommend using [Node Version Manager](https://github.com/nvm-sh/nvm) to install it.
+Make sure that you have Node.js version 18 (or later) installed on your system. If you do not have Node.js installed we recommend using [Node Version Manager](https://github.com/nvm-sh/nvm) to install it.
 
 You can find out which version of Node.js you are using by running the following command:
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "license": "Apache",
   "engines": {
-    "node": "16"
+    "node": "^18"
   },
   "scripts": {
     "build": "snowpack build",

--- a/scripts/import-client.mjs
+++ b/scripts/import-client.mjs
@@ -12,7 +12,7 @@ await importClient();
 
 async function importClient() {
   const adminClient = new KcAdminClient.default({
-    baseUrl: "http://localhost:8180",
+    baseUrl: "http://127.0.0.1:8180",
     realmName: "master",
   });
 


### PR DESCRIPTION
Version 18 of Node.js has [been released](https://nodejs.org/en/blog/announcements/v18-release-announce/), this brings us up-to-date with the latest.