### PR TITLE
small fix to make removing alerts fail less

### DIFF
--- a/cypress/support/pages/admin_console/Masthead.ts
+++ b/cypress/support/pages/admin_console/Masthead.ts
@@ -53,14 +53,11 @@ export default class Masthead extends CommonElements {
   }
 
   checkNotificationMessage(message: string, closeNotification?: boolean) {
-    cy.get(this.alertMessage)
-      .should("contain.text", message)
-      .parent()
-      .within(() => {
-        if (closeNotification) {
-          cy.get(".pf-c-alert__action").click({ multiple: true });
-        }
-      });
+    cy.get(this.alertMessage).should("contain.text", message);
+
+    if (closeNotification) {
+      cy.get(`button[title="${message}"]`).click();
+    }
     return this;
   }
 


### PR DESCRIPTION
This might improve some of the tests as it will only click the alert that was needed