### PR TITLE
Uploading Cypress assets to Github

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -114,6 +114,20 @@ jobs:
           CYPRESS_RECORD_KEY: b8f1d15e-eab8-4ee7-8e44-c6d7cd8fc0eb
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Add Cypress videos artifacts
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: cypress-videos
+          path: assets/videos
+
+      - name: Add Cypress screenshots artifacts
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: cypress-screenshots
+          path: assets/screenshots
+
       - name: Upload server logs
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
Since the Cypress video upload is broken often we want to restore this functionality.