### PR TITLE
with keycloak-js updated logout works again

### DIFF
--- a/cypress/integration/masthead_test.spec.ts
+++ b/cypress/integration/masthead_test.spec.ts
@@ -19,7 +19,7 @@ const logOutTest = () => {
 const goToAcctMgtTest = () => {
   sidebarPage.waitForPageLoad();
   masthead.accountManagement();
-  cy.contains("Welcome to Keycloak Account Management");
+  cy.get("h1").contains("Welcome to Keycloak account management");
   cy.get("#landingReferrerLink").click({ force: true });
   masthead.checkIsAdminConsole();
 };

--- a/cypress/integration/masthead_test.spec.ts
+++ b/cypress/integration/masthead_test.spec.ts
@@ -24,7 +24,7 @@ const goToAcctMgtTest = () => {
   masthead.checkIsAdminConsole();
 };
 
-describe.skip("Masthead tests in desktop mode", () => {
+describe("Masthead tests in desktop mode", () => {
   beforeEach(() => {
     keycloakBefore();
     loginPage.logIn();
@@ -48,7 +48,7 @@ describe.skip("Masthead tests in desktop mode", () => {
   });
 });
 
-describe.skip("Masthead tests with kebab menu", () => {
+describe("Masthead tests with kebab menu", () => {
   beforeEach(() => {
     keycloakBefore();
     loginPage.logIn();

--- a/cypress/integration/sessions_test.spec.ts
+++ b/cypress/integration/sessions_test.spec.ts
@@ -30,7 +30,7 @@ describe("Sessions test", () => {
     sessionsPage.checkNotBeforeCleared();
   });
 
-  it.skip("logout all sessions", () => {
+  it("logout all sessions", () => {
     sessionsPage.logoutAllSessions();
 
     cy.get("#kc-page-title").contains("Sign in to your account");

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "name": "keycloak-admin-ui",
       "license": "Apache",
       "dependencies": {
-        "@keycloak/keycloak-admin-client": "^18.0.0",
+        "@keycloak/keycloak-admin-client": "^18.0.0-dev.22",
         "@patternfly/patternfly": "^4.185.1",
         "@patternfly/react-code-editor": "^4.43.16",
         "@patternfly/react-core": "^4.202.16",
@@ -3448,13 +3448,13 @@
       }
     },
     "node_modules/@keycloak/keycloak-admin-client": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@keycloak/keycloak-admin-client/-/keycloak-admin-client-18.0.0.tgz",
-      "integrity": "sha512-xKmuHAUitXhOZ8Pz3M95m0ZdYsxlZW38E6vBdh4gP8NFfuIl6kdAKvDRqd+QUIGo4TpCP6GOlw7+GTIF0NTwjw==",
+      "version": "18.0.0-dev.22",
+      "resolved": "https://registry.npmjs.org/@keycloak/keycloak-admin-client/-/keycloak-admin-client-18.0.0-dev.22.tgz",
+      "integrity": "sha512-xWiZip5uzVoYkzJA3uJWqIKWy1krd9b9XgNzdhibw1uLbo9HGTzpdn8ViAXQrpgFxx5tgws0cTQrSduHHZsbFg==",
       "dependencies": {
         "axios": "^0.26.1",
         "camelize-ts": "^1.0.8",
-        "keycloak-js": "^17.0.1",
+        "keycloak-js": "^18.0.0",
         "lodash": "^4.17.21",
         "query-string": "^7.0.1",
         "url-join": "^4.0.0",
@@ -14538,9 +14538,9 @@
       "dev": true
     },
     "node_modules/keycloak-js": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-17.0.1.tgz",
-      "integrity": "sha512-mbLBSoogCBX5VYeKCdEz8BaRWVL9twzSqArRU3Mo3Z7vEO1mghGZJ5IzREfiMEi7kTUZtk5i9mu+Yc0koGkK6g==",
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-18.0.0.tgz",
+      "integrity": "sha512-kaD6nrzgYX3NhgwQfVEZiAzaZXua3PSBIBWGWf8fgqPgUdiO8uvYaKV1Ebf43IAB5M8kvubW+2J+eBS+UnWsuw==",
       "dependencies": {
         "base64-js": "^1.5.1",
         "js-sha256": "^0.9.0"
@@ -24770,13 +24770,13 @@
       }
     },
     "@keycloak/keycloak-admin-client": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@keycloak/keycloak-admin-client/-/keycloak-admin-client-18.0.0.tgz",
-      "integrity": "sha512-xKmuHAUitXhOZ8Pz3M95m0ZdYsxlZW38E6vBdh4gP8NFfuIl6kdAKvDRqd+QUIGo4TpCP6GOlw7+GTIF0NTwjw==",
+      "version": "18.0.0-dev.22",
+      "resolved": "https://registry.npmjs.org/@keycloak/keycloak-admin-client/-/keycloak-admin-client-18.0.0-dev.22.tgz",
+      "integrity": "sha512-xWiZip5uzVoYkzJA3uJWqIKWy1krd9b9XgNzdhibw1uLbo9HGTzpdn8ViAXQrpgFxx5tgws0cTQrSduHHZsbFg==",
       "requires": {
         "axios": "^0.26.1",
         "camelize-ts": "^1.0.8",
-        "keycloak-js": "^17.0.1",
+        "keycloak-js": "^18.0.0",
         "lodash": "^4.17.21",
         "query-string": "^7.0.1",
         "url-join": "^4.0.0",
@@ -33449,9 +33449,9 @@
       "dev": true
     },
     "keycloak-js": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-17.0.1.tgz",
-      "integrity": "sha512-mbLBSoogCBX5VYeKCdEz8BaRWVL9twzSqArRU3Mo3Z7vEO1mghGZJ5IzREfiMEi7kTUZtk5i9mu+Yc0koGkK6g==",
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-18.0.0.tgz",
+      "integrity": "sha512-kaD6nrzgYX3NhgwQfVEZiAzaZXua3PSBIBWGWf8fgqPgUdiO8uvYaKV1Ebf43IAB5M8kvubW+2J+eBS+UnWsuw==",
       "requires": {
         "base64-js": "^1.5.1",
         "js-sha256": "^0.9.0"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "server:import-client": "./scripts/import-client.mjs"
   },
   "dependencies": {
-    "@keycloak/keycloak-admin-client": "^18.0.0",
+    "@keycloak/keycloak-admin-client": "^18.0.0-dev.22",
     "@patternfly/patternfly": "^4.185.1",
     "@patternfly/react-code-editor": "^4.43.16",
     "@patternfly/react-core": "^4.202.16",


### PR DESCRIPTION
Updated keycloak-js on the admin client to version 18 so that the redirect url problem is fixed and we can enable the logout tests again.