### PR TITLE
Fix #2560 SAML Broker: Add option to validate IdP Entity ID

### DIFF
--- a/public/resources/en/identity-providers-help.json
+++ b/public/resources/en/identity-providers-help.json
@@ -36,6 +36,7 @@
   "postBrokerLoginFlowAlias": "Alias of authentication flow, which is triggered after each login with this identity provider. Useful if you want additional verification of each user authenticated with this identity provider (for example OTP). Leave this to \"None\" if you need no any additional authenticators to be triggered after login with this identity provider. Also note that authenticator implementations must assume that user is already set in ClientSession as identity provider already set it.",
   "syncMode": "Default sync mode for all mappers. The sync mode determines when user data will be synced using the mappers. Possible values are: 'legacy' to keep the behaviour before this option was introduced, 'import' to only import the user once during first login of the user with this identity provider, 'force' to always update the user during every login with this identity provider.",
   "serviceProviderEntityId": "The Entity ID that will be used to uniquely identify this SAML Service Provider.",
+  "identityProviderEntityId": "The Entity ID used to validate the Issuer for received SAML assertions. If empty, no Issuer validation is performed.",
   "useEntityDescriptor": "Import metadata from a remote IDP SAML entity descriptor.",
   "samlEntityDescriptor": "Allows you to load external IDP metadata from a config file or to download it from a URL.",
   "ssoServiceUrl": "The Url that must be used to send authentication requests (SAML AuthnRequest).",

--- a/public/resources/en/identity-providers.json
+++ b/public/resources/en/identity-providers.json
@@ -84,6 +84,7 @@
   "signServiceProviderMetadata": "Sign service provider metadata",
   "passSubject": "Pass subject",
   "serviceProviderEntityId": "Service provider entity ID",
+  "identityProviderEntityId": "Identity provider entity ID",
   "importConfig": "Import config from file",
   "showMetaData": "Show metadata",
   "hideMetaData": "Hide metadata",

--- a/src/identity-providers/add/DescriptorSettings.tsx
+++ b/src/identity-providers/add/DescriptorSettings.tsx
@@ -75,6 +75,24 @@ const Fields = ({ readOnly }: DescriptorSettingsProps) => {
         />
       </FormGroup>
       <FormGroup
+        label={t("identityProviderEntityId")}
+        fieldId="kc-identity-provider-entity-id"
+        labelIcon={
+          <HelpItem
+            helpText="identity-providers-help:identityProviderEntityId"
+            fieldLabelId="identity-providers:identityProviderEntityId"
+          />
+        }
+      >
+        <KeycloakTextInput
+          type="text"
+          name="config.idpEntityId"
+          data-testid="identityProviderEntityId"
+          id="kc-identity-provider-entity-id"
+          ref={register()}
+        />
+      </FormGroup>
+      <FormGroup
         label={t("ssoServiceUrl")}
         labelIcon={
           <HelpItem


### PR DESCRIPTION
## Motivation
Fixes #2560 as requested on https://github.com/keycloak/keycloak/pull/11084 .

## Brief Description
Added an option to enter the expected Identity Provider Entity ID.

## Checklist:

- [X] Code has been tested locally by PR requester
- [X] User-visible strings are using the react-i18next framework (useTranslation)
- [X] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated

## Additional Notes
![immagine](https://user-images.githubusercontent.com/16761934/166332730-6e95a5cb-1bb5-4692-bce4-0abd53697d6a.png)
