### PR TITLE
Fine-grained permissions for groups

### DIFF
--- a/src/groups/GroupAttributes.tsx
+++ b/src/groups/GroupAttributes.tsx
@@ -64,6 +64,7 @@ export const GroupAttributes = () => {
       <AttributesForm
         form={form}
         save={save}
+        fineGrainedAccess={currentGroup()?.access?.manage}
         reset={() =>
           form.reset({
             attributes: convertAttributes(),

--- a/src/groups/GroupTable.tsx
+++ b/src/groups/GroupTable.tsx
@@ -37,7 +37,7 @@ export const GroupTable = () => {
   const [selectedRows, setSelectedRows] = useState<GroupRepresentation[]>([]);
   const [move, setMove] = useState<GroupRepresentation>();
 
-  const { subGroups, setSubGroups } = useSubGroups();
+  const { subGroups, currentGroup, setSubGroups } = useSubGroups();
 
   const [key, setKey] = useState(0);
   const refresh = () => setKey(new Date().getTime());
@@ -47,7 +47,7 @@ export const GroupTable = () => {
   const id = getLastId(location.pathname);
 
   const { hasAccess } = useAccess();
-  const isManager = hasAccess("manage-users");
+  const isManager = hasAccess("manage-users") || currentGroup()?.access?.manage;
   const canView =
     hasAccess("query-groups", "view-users") ||
     hasAccess("manage-users", "query-groups");
@@ -99,8 +99,11 @@ export const GroupTable = () => {
       <Link
         key={group.id}
         to={`${location.pathname}/${group.id}`}
-        onClick={() => {
-          setSubGroups([...subGroups, group]);
+        onClick={async () => {
+          const loadedGroup = await adminClient.groups.findOne({
+            id: group.id!,
+          });
+          setSubGroups([...subGroups, loadedGroup!]);
         }}
       >
         {group.name}

--- a/src/groups/GroupTable.tsx
+++ b/src/groups/GroupTable.tsx
@@ -47,7 +47,10 @@ export const GroupTable = () => {
   const id = getLastId(location.pathname);
 
   const { hasAccess } = useAccess();
-  const isManager = hasAccess("manage-users", "query-clients");
+  const isManager = hasAccess("manage-users");
+  const canView =
+    hasAccess("query-groups", "view-users") ||
+    hasAccess("manage-users", "query-groups");
 
   const loader = async () => {
     let groupsData = undefined;
@@ -90,7 +93,7 @@ export const GroupTable = () => {
   };
 
   const GroupNameCell = (group: GroupRepresentation) => {
-    if (!isManager) return <span>{group.name}</span>;
+    if (!canView) return <span>{group.name}</span>;
 
     return (
       <Link

--- a/src/groups/GroupsSection.tsx
+++ b/src/groups/GroupsSection.tsx
@@ -48,7 +48,14 @@ export default function GroupsSection() {
   const id = getLastId(location.pathname);
 
   const { hasAccess } = useAccess();
-  const canViewPermissions = hasAccess("manage-authorization", "manage-users");
+  const canViewPermissions = hasAccess(
+    "manage-authorization",
+    "manage-users",
+    "manage-clients"
+  );
+  const canManageGroup =
+    hasAccess("manage-users") || currentGroup()?.access?.manage;
+  const canManageRoles = hasAccess("manage-users");
 
   const deleteGroup = async (group: GroupRepresentation) => {
     try {
@@ -116,7 +123,7 @@ export default function GroupsSection() {
         helpUrl={!id ? helpUrls.groupsUrl : ""}
         divider={!id}
         dropdownItems={
-          id && hasAccess("manage-users")
+          id && canManageGroup
             ? [
                 SearchDropdown,
                 <DropdownItem
@@ -174,13 +181,15 @@ export default function GroupsSection() {
             >
               <GroupAttributes />
             </Tab>
-            <Tab
-              eventKey={3}
-              data-testid="role-mapping-tab"
-              title={<TabTitleText>{t("roleMapping")}</TabTitleText>}
-            >
-              <GroupRoleMapping id={id!} name={currentGroup()?.name!} />
-            </Tab>
+            {canManageRoles && (
+              <Tab
+                eventKey={3}
+                data-testid="role-mapping-tab"
+                title={<TabTitleText>{t("roleMapping")}</TabTitleText>}
+              >
+                <GroupRoleMapping id={id!} name={currentGroup()?.name!} />
+              </Tab>
+            )}
             {canViewPermissions && (
               <Tab
                 eventKey={4}

--- a/src/groups/GroupsSection.tsx
+++ b/src/groups/GroupsSection.tsx
@@ -28,6 +28,7 @@ import { toGroupsSearch } from "./routes/GroupsSearch";
 import { GroupRoleMapping } from "./GroupRoleMapping";
 import helpUrls from "../help-urls";
 import { PermissionsTab } from "../components/permission-tab/PermissionTab";
+import { useAccess } from "../context/access/Access";
 
 import "./GroupsSection.css";
 
@@ -45,6 +46,9 @@ export default function GroupsSection() {
   const history = useHistory();
   const location = useLocation();
   const id = getLastId(location.pathname);
+
+  const { hasAccess } = useAccess();
+  const canViewPermissions = hasAccess("manage-authorization", "manage-users");
 
   const deleteGroup = async (group: GroupRepresentation) => {
     try {
@@ -112,7 +116,7 @@ export default function GroupsSection() {
         helpUrl={!id ? helpUrls.groupsUrl : ""}
         divider={!id}
         dropdownItems={
-          id
+          id && hasAccess("manage-users")
             ? [
                 SearchDropdown,
                 <DropdownItem
@@ -177,13 +181,15 @@ export default function GroupsSection() {
             >
               <GroupRoleMapping id={id!} name={currentGroup()?.name!} />
             </Tab>
-            <Tab
-              eventKey={4}
-              data-testid="permissionsTab"
-              title={<TabTitleText>{t("common:permissions")}</TabTitleText>}
-            >
-              <PermissionsTab id={id} type="groups" />
-            </Tab>
+            {canViewPermissions && (
+              <Tab
+                eventKey={4}
+                data-testid="permissionsTab"
+                title={<TabTitleText>{t("common:permissions")}</TabTitleText>}
+              >
+                <PermissionsTab id={id} type="groups" />
+              </Tab>
+            )}
           </Tabs>
         )}
         {subGroups.length === 0 && <GroupTable />}

--- a/src/groups/Members.tsx
+++ b/src/groups/Members.tsx
@@ -26,6 +26,7 @@ import { MemberModal } from "./MembersModal";
 import { ListEmptyState } from "../components/list-empty-state/ListEmptyState";
 import { GroupPath } from "../components/group/GroupPath";
 import { toUser } from "../user/routes/User";
+import { useAccess } from "../context/access/Access";
 
 type MembersOf = UserRepresentation & {
   membership: GroupRepresentation[];
@@ -43,6 +44,7 @@ export const Members = () => {
   const [addMembers, setAddMembers] = useState(false);
   const [isKebabOpen, setIsKebabOpen] = useState(false);
   const [selectedRows, setSelectedRows] = useState<UserRepresentation[]>([]);
+  const { hasAccess } = useAccess();
 
   const [key, setKey] = useState(0);
   const refresh = () => setKey(new Date().getTime());
@@ -123,86 +125,95 @@ export const Members = () => {
         canSelectAll
         onSelect={(rows) => setSelectedRows([...rows])}
         toolbarItem={
-          <>
-            <ToolbarItem>
-              <Button
-                data-testid="addMember"
-                variant="primary"
-                onClick={() => setAddMembers(true)}
-              >
-                {t("addMember")}
-              </Button>
-            </ToolbarItem>
-            <ToolbarItem>
-              <Checkbox
-                data-testid="includeSubGroupsCheck"
-                label={t("includeSubGroups")}
-                id="kc-include-sub-groups"
-                isChecked={includeSubGroup}
-                onChange={() => setIncludeSubGroup(!includeSubGroup)}
-              />
-            </ToolbarItem>
-            <ToolbarItem>
-              <Dropdown
-                toggle={
-                  <KebabToggle
-                    onToggle={() => setIsKebabOpen(!isKebabOpen)}
-                    isDisabled={selectedRows.length === 0}
-                  />
-                }
-                isOpen={isKebabOpen}
-                isPlain
-                dropdownItems={[
-                  <DropdownItem
-                    key="action"
-                    component="button"
-                    onClick={async () => {
-                      try {
-                        await Promise.all(
-                          selectedRows.map((user) =>
-                            adminClient.users.delFromGroup({
-                              id: user.id!,
-                              groupId: id!,
-                            })
-                          )
-                        );
-                        setIsKebabOpen(false);
-                        addAlert(
-                          t("usersLeft", { count: selectedRows.length }),
-                          AlertVariant.success
-                        );
-                      } catch (error) {
-                        addError("groups:usersLeftError", error);
-                      }
+          hasAccess("manage-users") && (
+            <>
+              <ToolbarItem>
+                <Button
+                  data-testid="addMember"
+                  variant="primary"
+                  onClick={() => setAddMembers(true)}
+                >
+                  {t("addMember")}
+                </Button>
+              </ToolbarItem>
+              <ToolbarItem>
+                <Checkbox
+                  data-testid="includeSubGroupsCheck"
+                  label={t("includeSubGroups")}
+                  id="kc-include-sub-groups"
+                  isChecked={includeSubGroup}
+                  onChange={() => setIncludeSubGroup(!includeSubGroup)}
+                />
+              </ToolbarItem>
+              <ToolbarItem>
+                <Dropdown
+                  toggle={
+                    <KebabToggle
+                      onToggle={() => setIsKebabOpen(!isKebabOpen)}
+                      isDisabled={selectedRows.length === 0}
+                    />
+                  }
+                  isOpen={isKebabOpen}
+                  isPlain
+                  dropdownItems={[
+                    <DropdownItem
+                      key="action"
+                      component="button"
+                      onClick={async () => {
+                        try {
+                          await Promise.all(
+                            selectedRows.map((user) =>
+                              adminClient.users.delFromGroup({
+                                id: user.id!,
+                                groupId: id!,
+                              })
+                            )
+                          );
+                          setIsKebabOpen(false);
+                          addAlert(
+                            t("usersLeft", { count: selectedRows.length }),
+                            AlertVariant.success
+                          );
+                        } catch (error) {
+                          addError("groups:usersLeftError", error);
+                        }
 
-                      refresh();
-                    }}
-                  >
-                    {t("leave")}
-                  </DropdownItem>,
-                ]}
-              />
-            </ToolbarItem>
-          </>
+                        refresh();
+                      }}
+                    >
+                      {t("leave")}
+                    </DropdownItem>,
+                  ]}
+                />
+              </ToolbarItem>
+            </>
+          )
         }
-        actions={[
-          {
-            title: t("leave"),
-            onRowClick: async (user) => {
-              try {
-                await adminClient.users.delFromGroup({
-                  id: user.id!,
-                  groupId: id!,
-                });
-                addAlert(t("usersLeft", { count: 1 }), AlertVariant.success);
-              } catch (error) {
-                addError("groups:usersLeftError", error);
-              }
+        actions={
+          hasAccess("manage-users")
+            ? [
+                {
+                  title: t("leave"),
+                  onRowClick: async (user) => {
+                    try {
+                      await adminClient.users.delFromGroup({
+                        id: user.id!,
+                        groupId: id!,
+                      });
+                      addAlert(
+                        t("usersLeft", { count: 1 }),
+                        AlertVariant.success
+                      );
+                    } catch (error) {
+                      addError("groups:usersLeftError", error);
+                    }
 
-              return true;
-            },
-          },
-        ]}
+                    return true;
+                  },
+                },
+              ]
+            : []
+        }
         columns={[
           {
             name: "username",
@@ -233,8 +244,14 @@ export const Members = () => {
         emptyState={
           <ListEmptyState
             message={t("users:noUsersFound")}
-            instructions={t("users:emptyInstructions")}
-            primaryActionText={t("addMember")}
+            instructions={
+              hasAccess("manage-users")
+                ? t("users:emptyInstructions")
+                : undefined
+            }
+            primaryActionText={
+              hasAccess("manage-users") ? t("addMember") : undefined
+            }
             onPrimaryAction={() => setAddMembers(true)}
           />
         }

--- a/src/groups/Members.tsx
+++ b/src/groups/Members.tsx
@@ -46,6 +46,9 @@ export const Members = () => {
   const [selectedRows, setSelectedRows] = useState<UserRepresentation[]>([]);
   const { hasAccess } = useAccess();
 
+  const isManager =
+    hasAccess("manage-users") || currentGroup()!.access!.manageMembership;
+
   const [key, setKey] = useState(0);
   const refresh = () => setKey(new Date().getTime());
 
@@ -125,7 +128,7 @@ export const Members = () => {
         canSelectAll
         onSelect={(rows) => setSelectedRows([...rows])}
         toolbarItem={
-          hasAccess("manage-users") && (
+          isManager && (
             <>
               <ToolbarItem>
                 <Button
@@ -190,7 +193,7 @@ export const Members = () => {
           )
         }
         actions={
-          hasAccess("manage-users")
+          isManager
             ? [
                 {
                   title: t("leave"),
@@ -244,14 +247,8 @@ export const Members = () => {
         emptyState={
           <ListEmptyState
             message={t("users:noUsersFound")}
-            instructions={
-              hasAccess("manage-users")
-                ? t("users:emptyInstructions")
-                : undefined
-            }
-            primaryActionText={
-              hasAccess("manage-users") ? t("addMember") : undefined
-            }
+            instructions={isManager ? t("users:emptyInstructions") : undefined}
+            primaryActionText={isManager ? t("addMember") : undefined}
             onPrimaryAction={() => setAddMembers(true)}
           />
         }


### PR DESCRIPTION
## Motivation
This implements fine-grained permissions for the group section only.

Implements part of https://github.com/keycloak/keycloak-admin-ui/issues/2403

## Brief Description
This implementation differs somewhat from what we see in the old UI.  I believe that the old UI and back end has some bugs where a user clearly has "manageMembership" authority but is still not allowed to add/remove users from the group.  In this case, the new UI will allow the administrator to add/remove users but will get an error from the back end.

## Verification Steps
You can follow the [examples in the documentation](https://www.keycloak.org/docs/latest/server_admin/#_fine_grain_permissions).

You can also see the access object that is returned in the record when a group is queried. It looks something like this:
"access":{"view":true,"manage":true,"manageMembership":true}

This will give hints as to what the user should be allowed to do in the UI. 

Note that sometimes you also need the proper roles to be set on the realm-management client.

- To view groups, the user needs: "query-groups" and "view-users".
- To add/remove roles, the user needs: "manage-users".
- To add/remove attributes, the user needs: "manage-users".
- To manage permissions, the user needs: "manage-authorization", "manage-clients", and "manage-users".

Lastly, make sure your permissions are set on a test realm. The user restricted by the fine-grained access should log in to the test realm. Using snowpack, you will need to go to that realm like this localhost:8080/?realm=test