### PR TITLE
Don't render create header when editing

### DIFF
--- a/src/realm-roles/RealmRoleForm.tsx
+++ b/src/realm-roles/RealmRoleForm.tsx
@@ -35,7 +35,7 @@ export const RealmRoleForm = ({
 
   return (
     <>
-      <ViewHeader titleKey={t("createRole")} />
+      {!editMode && <ViewHeader titleKey={t("createRole")} />}
       <PageSection variant="light">
         <FormAccess
           isHorizontal


### PR DESCRIPTION
## Motivation
<!-- Add references to relevant tickets, issues, design specs and/or a short description of what motivated you to do it. -->
On the edit details screen there are 2 headers rendered
![image](https://user-images.githubusercontent.com/51133/167559841-f79c8d22-59c7-4e83-b3ef-1f70a090d375.png)


## Brief Description
<!-- Add a short answer for: 
What was done in this PR? (e.g Fix to prevent users from accessing feature X.)
Why it was done? (e.g Feature X was deprecated.)
-->

## Verification Steps
<!--
Add the steps required to verify this change. Keep in mind that these steps should be written so groups unfamiliar with the 
new functionality can follow them, such as QE or documentation.

1. Go to `XX >> YY >> SS`.
2. Create a new item `N` with info `X`.
3. Right-click the item and select Delete.
4. Verify that the item is no longer present in the left navigation menu.
-->

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated

## Additional Notes
<!-- 
Add images and/or screen caps to illustrate what was changed if this pull request adds to or modifies existing user-visible appearance/output. 
-->
