### PR TITLE
Lock React and related dependencies to version 17

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,14 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: react-flow-renderer
         update-types: ["version-update:semver-major"]
+      - dependency-name: react
+        update-types: ["version-update:semver-major"]
+      - dependency-name: react-dom
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/react-dom"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: maven
     directory: keycloak-theme
     open-pull-requests-limit: 999

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "@types/lodash-es": "^4.17.6",
         "@types/node": "^17.0.31",
         "@types/react": "^17.0.45",
-        "@types/react-dom": "^18.0.3",
+        "@types/react-dom": "^17.0.16",
         "@types/react-router-dom": "^5.3.3",
         "@types/snowpack-env": "^2.3.4",
         "@types/tar-fs": "^2.0.1",
@@ -4867,15 +4867,6 @@
         }
       }
     },
-    "node_modules/@testing-library/react/node_modules/@types/react-dom": {
-      "version": "17.0.15",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.15.tgz",
-      "integrity": "sha512-Tr9VU9DvNoHDWlmecmcsE5ZZiUkYx+nKBzum4Oxe1K0yJVyBlfbq7H3eXjxXqJczBKqPGq3EgfTru4MgKb9+Yw==",
-      "dev": true,
-      "dependencies": {
-        "@types/react": "^17"
-      }
-    },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -5175,12 +5166,12 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.0.3",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.3.tgz",
-      "integrity": "sha512-1RRW9kst+67gveJRYPxGmVy8eVJ05O43hg77G2j5m76/RFJtMbcfAs2viQ2UNsvvDg8F7OfQZx8qQcl6ymygaQ==",
+      "version": "17.0.16",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.16.tgz",
+      "integrity": "sha512-DWcXf8EbMrO/gWnQU7Z88Ws/p16qxGpPyjTKTpmBSFKeE+HveVubqGO1CVK7FrwlWD5MuOcvh8gtd0/XO38NdQ==",
       "dev": true,
       "dependencies": {
-        "@types/react": "*"
+        "@types/react": "^17"
       }
     },
     "node_modules/@types/react-redux": {
@@ -26626,17 +26617,6 @@
         "@babel/runtime": "^7.12.5",
         "@testing-library/dom": "^8.0.0",
         "@types/react-dom": "<18.0.0"
-      },
-      "dependencies": {
-        "@types/react-dom": {
-          "version": "17.0.15",
-          "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.15.tgz",
-          "integrity": "sha512-Tr9VU9DvNoHDWlmecmcsE5ZZiUkYx+nKBzum4Oxe1K0yJVyBlfbq7H3eXjxXqJczBKqPGq3EgfTru4MgKb9+Yw==",
-          "dev": true,
-          "requires": {
-            "@types/react": "^17"
-          }
-        }
       }
     },
     "@testing-library/react-hooks": {
@@ -26945,12 +26925,12 @@
       }
     },
     "@types/react-dom": {
-      "version": "18.0.3",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.3.tgz",
-      "integrity": "sha512-1RRW9kst+67gveJRYPxGmVy8eVJ05O43hg77G2j5m76/RFJtMbcfAs2viQ2UNsvvDg8F7OfQZx8qQcl6ymygaQ==",
+      "version": "17.0.16",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.16.tgz",
+      "integrity": "sha512-DWcXf8EbMrO/gWnQU7Z88Ws/p16qxGpPyjTKTpmBSFKeE+HveVubqGO1CVK7FrwlWD5MuOcvh8gtd0/XO38NdQ==",
       "dev": true,
       "requires": {
-        "@types/react": "*"
+        "@types/react": "^17"
       }
     },
     "@types/react-redux": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@types/lodash-es": "^4.17.6",
     "@types/node": "^17.0.31",
     "@types/react": "^17.0.45",
-    "@types/react-dom": "^18.0.3",
+    "@types/react-dom": "^17.0.16",
     "@types/react-router-dom": "^5.3.3",
     "@types/snowpack-env": "^2.3.4",
     "@types/tar-fs": "^2.0.1",


### PR DESCRIPTION
Since we will need to update various components in order to support React 18 it's better to lock the version for now.