### PR TITLE
Fix client import form state

### DIFF
--- a/src/clients/import/ImportForm.tsx
+++ b/src/clients/import/ImportForm.tsx
@@ -28,7 +28,7 @@ export default function ImportForm() {
   const history = useHistory();
   const adminClient = useAdminClient();
   const { realm } = useRealm();
-  const form = useForm<ClientRepresentation>();
+  const form = useForm<ClientRepresentation>({ shouldUnregister: false });
   const { register, handleSubmit, setValue } = form;
   const [imported, setImported] = useState<ClientRepresentation>({});
 


### PR DESCRIPTION
Prevents the form data from being reset when component unmounts. Closes #2471.