### PR TITLE
Locale edit shouldn't be disabled

### DIFF
--- a/cypress/integration/realm_settings_events_test.spec.ts
+++ b/cypress/integration/realm_settings_events_test.spec.ts
@@ -250,8 +250,6 @@ describe("Realm settings events tab tests", () => {
 
     cy.findByTestId("localization-tab-save").click();
 
-    cy.findByTestId("add-bundle-button").click({ force: true });
-
     addBundle();
 
     masthead.checkNotificationMessage(

--- a/src/realm-settings/LocalizationTab.tsx
+++ b/src/realm-settings/LocalizationTab.tsx
@@ -506,7 +506,6 @@ export const LocalizationTab = ({
               toolbarItem={
                 <Button
                   data-testid="add-bundle-button"
-                  isDisabled={!formState.isSubmitSuccessful}
                   onClick={() => setAddMessageBundleModalOpen(true)}
                 >
                   {t("addMessageBundle")}
@@ -520,7 +519,7 @@ export const LocalizationTab = ({
                     isOpen={filterDropdownOpen}
                     className="kc-filter-by-locale-select"
                     variant={SelectVariant.single}
-                    isDisabled={!formState.isSubmitSuccessful}
+                    isDisabled={!internationalizationEnabled}
                     onToggle={(isExpanded) => setFilterDropdownOpen(isExpanded)}
                     onSelect={(_, value) => {
                       setSelectMenuLocale(value.toString());


### PR DESCRIPTION
## Motivation
<!-- Add references to relevant tickets, issues, design specs and/or a short description of what motivated you to do it. -->
It seems that locale edit is disabled and enabled only after save, this should not be the case.
Even when internationalization isn't enabled you should be able to change the default (English) one.

## Brief Description
<!-- Add a short answer for: 
What was done in this PR? (e.g Fix to prevent users from accessing feature X.)
Why it was done? (e.g Feature X was deprecated.)
-->

## Verification Steps
<!--
Add the steps required to verify this change. Keep in mind that these steps should be written so groups unfamiliar with the 
new functionality can follow them, such as QE or documentation.

1. Go to `XX >> YY >> SS`.
2. Create a new item `N` with info `X`.
3. Right-click the item and select Delete.
4. Verify that the item is no longer present in the left navigation menu.
-->

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated

## Additional Notes
<!-- 
Add images and/or screen caps to illustrate what was changed if this pull request adds to or modifies existing user-visible appearance/output. 
-->
