### PR TITLE
Fix role-based authorization in Clients section.

### DIFF
--- a/src/clients/ClientSettings.tsx
+++ b/src/clients/ClientSettings.tsx
@@ -26,6 +26,7 @@ import { SamlConfig } from "./add/SamlConfig";
 import { SamlSignature } from "./add/SamlSignature";
 import environment from "../environment";
 import { useRealm } from "../context/realm-context/RealmContext";
+import { useAccess } from "../context/access/Access";
 
 type ClientSettingsProps = {
   client: ClientRepresentation;
@@ -46,6 +47,9 @@ export const ClientSettings = ({
   } = useFormContext<ClientRepresentation>();
   const { t } = useTranslation("clients");
   const { realm } = useRealm();
+
+  const { hasAccess } = useAccess();
+  const isManager = hasAccess("manage-clients");
 
   const [loginThemeOpen, setLoginThemeOpen] = useState(false);
   const loginThemes = useServerInfo().themes!["login"];
@@ -246,6 +250,7 @@ export const ClientSettings = ({
             name="settings"
             save={save}
             reset={reset}
+            isActive={!isManager}
           />
         )}
       </FormAccess>
@@ -527,6 +532,7 @@ export const ClientSettings = ({
           name="settings"
           save={save}
           reset={reset}
+          isActive={isManager}
         />
       </FormAccess>
     </ScrollForm>

--- a/src/clients/ClientsSection.tsx
+++ b/src/clients/ClientsSection.tsx
@@ -149,7 +149,7 @@ export default function ClientsSection() {
               isPaginated
               ariaLabelKey="clients:clientList"
               searchPlaceholderKey="clients:searchForClient"
-              toolbarItem={ToolbarItems()}
+              toolbarItem={<ToolbarItems />}
               actionResolver={(rowData: IRowData) => {
                 const client: ClientRepresentation = rowData.data;
                 const actions: Action<ClientRepresentation>[] = [

--- a/src/clients/ClientsSection.tsx
+++ b/src/clients/ClientsSection.tsx
@@ -32,6 +32,7 @@ import { toClient } from "./routes/Client";
 import { toImportClient } from "./routes/ImportClient";
 import { isRealmClient, getProtocolName } from "./utils";
 import helpUrls from "../help-urls";
+import { useAccess } from "../context/access/Access";
 
 export default function ClientsSection() {
   const { t } = useTranslation("clients");
@@ -44,6 +45,9 @@ export default function ClientsSection() {
   const [key, setKey] = useState(0);
   const refresh = () => setKey(new Date().getTime());
   const [selectedClient, setSelectedClient] = useState<ClientRepresentation>();
+
+  const { hasAccess } = useAccess();
+  const isManager = hasAccess("manage-clients");
 
   const loader = async (first?: number, max?: number, search?: string) => {
     const params: ClientQuery = {
@@ -95,6 +99,34 @@ export default function ClientsSection() {
     </TableText>
   );
 
+  const ToolbarItems = () => {
+    if (!isManager) return <span />;
+
+    return (
+      <>
+        <ToolbarItem>
+          <Button
+            component={(props) => (
+              <Link {...props} to={toAddClient({ realm })} />
+            )}
+          >
+            {t("createClient")}
+          </Button>
+        </ToolbarItem>
+        <ToolbarItem>
+          <Button
+            component={(props) => (
+              <Link {...props} to={toImportClient({ realm })} />
+            )}
+            variant="link"
+          >
+            {t("importClient")}
+          </Button>
+        </ToolbarItem>
+      </>
+    );
+  };
+
   return (
     <>
       <ViewHeader
@@ -117,29 +149,7 @@ export default function ClientsSection() {
               isPaginated
               ariaLabelKey="clients:clientList"
               searchPlaceholderKey="clients:searchForClient"
-              toolbarItem={
-                <>
-                  <ToolbarItem>
-                    <Button
-                      component={(props) => (
-                        <Link {...props} to={toAddClient({ realm })} />
-                      )}
-                    >
-                      {t("createClient")}
-                    </Button>
-                  </ToolbarItem>
-                  <ToolbarItem>
-                    <Button
-                      component={(props) => (
-                        <Link {...props} to={toImportClient({ realm })} />
-                      )}
-                      variant="link"
-                    >
-                      {t("importClient")}
-                    </Button>
-                  </ToolbarItem>
-                </>
-              }
+              toolbarItem={ToolbarItems()}
               actionResolver={(rowData: IRowData) => {
                 const client: ClientRepresentation = rowData.data;
                 const actions: Action<ClientRepresentation>[] = [
@@ -151,7 +161,7 @@ export default function ClientsSection() {
                   },
                 ];
 
-                if (!isRealmClient(client)) {
+                if (!isRealmClient(client) && isManager) {
                   actions.push({
                     title: t("common:delete"),
                     onClick() {

--- a/src/clients/advanced/SaveReset.tsx
+++ b/src/clients/advanced/SaveReset.tsx
@@ -6,16 +6,29 @@ type SaveResetProps = ActionGroupProps & {
   name: string;
   save: () => void;
   reset: () => void;
+  isActive?: boolean;
 };
 
-export const SaveReset = ({ name, save, reset, ...rest }: SaveResetProps) => {
+export const SaveReset = ({
+  name,
+  save,
+  reset,
+  isActive = true,
+  ...rest
+}: SaveResetProps) => {
+  console.log(isActive);
   const { t } = useTranslation("common");
   return (
     <ActionGroup {...rest}>
-      <Button data-testid={name + "Save"} onClick={save}>
+      <Button isDisabled={!isActive} data-testid={name + "Save"} onClick={save}>
         {t("save")}
       </Button>
-      <Button data-testid={name + "Revert"} variant="link" onClick={reset}>
+      <Button
+        isDisabled={!isActive}
+        data-testid={name + "Revert"}
+        variant="link"
+        onClick={reset}
+      >
         {t("revert")}
       </Button>
     </ActionGroup>

--- a/src/clients/authorization/Settings.tsx
+++ b/src/clients/authorization/Settings.tsx
@@ -166,7 +166,7 @@ export const AuthorizationSettings = ({ clientId }: { clientId: string }) => {
           name="authenticationSettings"
           save={() => handleSubmit(save)()}
           reset={() => reset(resource)}
-          isActive={true}
+          isActive
         />
       </FormAccess>
     </PageSection>

--- a/src/clients/authorization/Settings.tsx
+++ b/src/clients/authorization/Settings.tsx
@@ -82,7 +82,7 @@ export const AuthorizationSettings = ({ clientId }: { clientId: string }) => {
           closeDialog={toggleImportDialog}
         />
       )}
-      <FormAccess role="manage-clients" isHorizontal>
+      <FormAccess role="view-clients" isHorizontal>
         <FormGroup
           label={t("import")}
           fieldId="import"
@@ -166,6 +166,7 @@ export const AuthorizationSettings = ({ clientId }: { clientId: string }) => {
           name="authenticationSettings"
           save={() => handleSubmit(save)()}
           reset={() => reset(resource)}
+          isActive={true}
         />
       </FormAccess>
     </PageSection>

--- a/src/clients/service-account/ServiceAccount.tsx
+++ b/src/clients/service-account/ServiceAccount.tsx
@@ -17,6 +17,7 @@ import {
 import { KeycloakSpinner } from "../../components/keycloak-spinner/KeycloakSpinner";
 import { toUser } from "../../user/routes/User";
 import { useRealm } from "../../context/realm-context/RealmContext";
+import { useAccess } from "../../context/access/Access";
 
 import "./service-account.css";
 
@@ -32,6 +33,9 @@ export const ServiceAccount = ({ client }: ServiceAccountProps) => {
 
   const [hide, setHide] = useState(false);
   const [serviceAccount, setServiceAccount] = useState<UserRepresentation>();
+
+  const { hasAccess } = useAccess();
+  const isManager = hasAccess("manage-clients");
 
   useFetch(
     () =>
@@ -124,6 +128,7 @@ export const ServiceAccount = ({ client }: ServiceAccountProps) => {
         name={client.clientId!}
         id={serviceAccount.id!}
         type="users"
+        isManager={isManager}
         loader={loader}
         save={assignRoles}
         onHideRolesToggle={() => setHide(!hide)}

--- a/src/components/role-mapping/RoleMapping.tsx
+++ b/src/components/role-mapping/RoleMapping.tsx
@@ -79,6 +79,7 @@ type RoleMappingProps = {
   name: string;
   id: string;
   type: ResourcesKey;
+  isManager?: boolean;
   loader: () => Promise<Row[]>;
   save: (rows: Row[]) => Promise<void>;
   onHideRolesToggle: () => void;
@@ -160,6 +161,7 @@ export const RoleMapping = ({
   name,
   id,
   type,
+  isManager = true,
   loader,
   save,
   onHideRolesToggle,
@@ -216,6 +218,30 @@ export const RoleMapping = ({
     },
   });
 
+  const ManagerToolbarItems = () => {
+    if (!isManager) return <span />;
+
+    return (
+      <>
+        <ToolbarItem>
+          <Button data-testid="assignRole" onClick={() => setShowAssign(true)}>
+            {t("common:assignRole")}
+          </Button>
+        </ToolbarItem>
+        <ToolbarItem>
+          <Button
+            variant="link"
+            data-testid="unAssignRole"
+            onClick={toggleDeleteDialog}
+            isDisabled={selected.length === 0}
+          >
+            {t("common:unAssignRole")}
+          </Button>
+        </ToolbarItem>
+      </>
+    );
+  };
+
   return (
     <>
       {showAssign && (
@@ -253,36 +279,23 @@ export const RoleMapping = ({
                 }}
               />
             </ToolbarItem>
-            <ToolbarItem>
-              <Button
-                data-testid="assignRole"
-                onClick={() => setShowAssign(true)}
-              >
-                {t("common:assignRole")}
-              </Button>
-            </ToolbarItem>
-            <ToolbarItem>
-              <Button
-                variant="link"
-                data-testid="unAssignRole"
-                onClick={toggleDeleteDialog}
-                isDisabled={selected.length === 0}
-              >
-                {t("common:unAssignRole")}
-              </Button>
-            </ToolbarItem>
+            <ManagerToolbarItems />
           </>
         }
-        actions={[
-          {
-            title: t("common:unAssignRole"),
-            onRowClick: async (role) => {
-              setSelected([role]);
-              toggleDeleteDialog();
-              return false;
-            },
-          },
-        ]}
+        actions={
+          isManager
+            ? [
+                {
+                  title: t("common:unAssignRole"),
+                  onRowClick: async (role) => {
+                    setSelected([role]);
+                    toggleDeleteDialog();
+                    return false;
+                  },
+                },
+              ]
+            : []
+        }
         columns={[
           {
             name: "role.name",

--- a/src/components/view-header/ViewHeader.tsx
+++ b/src/components/view-header/ViewHeader.tsx
@@ -44,6 +44,7 @@ export type ViewHeaderProps = {
   onToggle?: (value: boolean) => void;
   divider?: boolean;
   helpTextKey?: string;
+  isReadOnly?: boolean;
 };
 
 export type ViewHeaderBadge = {
@@ -68,6 +69,7 @@ export const ViewHeader = ({
   onToggle,
   divider = true,
   helpTextKey,
+  isReadOnly = false,
 }: ViewHeaderProps) => {
   const { t } = useTranslation();
   const { enabled } = useHelp();
@@ -124,6 +126,7 @@ export const ViewHeader = ({
                       label={t("common:enabled")}
                       labelOff={t("common:disabled")}
                       className="pf-u-mr-lg"
+                      isDisabled={isReadOnly}
                       isChecked={isEnabled}
                       onChange={(value) => {
                         onToggle(value);

--- a/src/realm-roles/RolesList.tsx
+++ b/src/realm-roles/RolesList.tsx
@@ -25,6 +25,7 @@ type RolesListProps = {
   paginated?: boolean;
   parentRoleId?: string;
   messageBundle?: string;
+  isReadOnly?: boolean;
   loader?: (
     first?: number,
     max?: number,
@@ -51,6 +52,7 @@ export const RolesList = ({
   paginated = true,
   parentRoleId,
   messageBundle = "roles",
+  isReadOnly = false,
 }: RolesListProps) => {
   const { t } = useTranslation(messageBundle);
   const history = useHistory();
@@ -129,21 +131,30 @@ export const RolesList = ({
         searchPlaceholderKey="roles:searchFor"
         isPaginated={paginated}
         toolbarItem={
-          <Button data-testid="create-role" onClick={goToCreate}>
-            {t("createRole")}
-          </Button>
+          !isReadOnly && (
+            <Button data-testid="create-role" onClick={goToCreate}>
+              {t("createRole")}
+            </Button>
+          )
         }
-        actions={[
-          {
-            title: t("common:delete"),
-            onRowClick: (role) => {
-              setSelectedRole(role);
-              if (role.name === realm!.defaultRole!.name) {
-                addAlert(t("defaultRoleDeleteError"), AlertVariant.danger);
-              } else toggleDeleteDialog();
-            },
-          },
-        ]}
+        actions={
+          isReadOnly
+            ? []
+            : [
+                {
+                  title: t("common:delete"),
+                  onRowClick: (role) => {
+                    setSelectedRole(role);
+                    if (role.name === realm!.defaultRole!.name) {
+                      addAlert(
+                        t("defaultRoleDeleteError"),
+                        AlertVariant.danger
+                      );
+                    } else toggleDeleteDialog();
+                  },
+                },
+              ]
+        }
         columns={[
           {
             name: "name",
@@ -165,8 +176,8 @@ export const RolesList = ({
           <ListEmptyState
             hasIcon={true}
             message={t("noRoles")}
-            instructions={t("noRolesInstructions")}
-            primaryActionText={t("createRole")}
+            instructions={isReadOnly ? "" : t("noRolesInstructions")}
+            primaryActionText={isReadOnly ? "" : t("createRole")}
             onPrimaryAction={goToCreate}
           />
         }


### PR DESCRIPTION
## Motivation
The PR fixes role-based authorization in the Clients section by hiding components or making them read-only as needed.

## Brief Description
This is in preparation for implementing fine-grained authorization, where flags such as `isManager` will also include a check for fine-grained authorization.

## Verification Steps
To verify the PR, it is best to log into a test realm with a test user.  Then set limited client roles for that user on the realm-management client.

To see the Clients section the user should have "view-clients" and "query-clients" roles.
To see the Permissions tab, the user also needs "manage-authorization" role.
To see Keys and Credentials tabs, the client needs to have `Client authentication` enabled.
To see Authorization tab, the client needs to have `Authorization` enabled.
To see Service account roles tab, the client needs to have `Service account roles` enabled.
