### PR TITLE
added workaround for overlapping property

### DIFF
--- a/src/clients/ClientDetails.tsx
+++ b/src/clients/ClientDetails.tsx
@@ -234,6 +234,11 @@ export default function ClientDetails() {
         )
       );
     }
+    Object.entries(client.attributes || {})
+      .filter(([key]) => key.startsWith("saml.server.signature"))
+      .map(([key, value]) =>
+        form.setValue("attributes." + key.replaceAll(".", "$"), value)
+      );
   };
 
   useFetch(
@@ -274,6 +279,13 @@ export default function ClientDetails() {
 
       const submittedClient =
         convertFormValuesToObject<ClientRepresentation>(values);
+
+      Object.entries(values.attributes || {})
+        .filter(([key]) => key.includes("$"))
+        .map(
+          ([key, value]) =>
+            (submittedClient.attributes![key.replaceAll("$", ".")] = value)
+        );
 
       if (submittedClient.attributes?.["acr.loa.map"]) {
         submittedClient.attributes["acr.loa.map"] = JSON.stringify(

--- a/src/clients/add/SamlSignature.tsx
+++ b/src/clients/add/SamlSignature.tsx
@@ -25,21 +25,18 @@ const SIGNATURE_ALGORITHMS = [
 const KEYNAME_TRANSFORMER = ["NONE", "KEY_ID", "CERT_SUBJECT"] as const;
 
 const CANONICALIZATION = [
-  {
-    name: "EXCLUSIVE",
-    value: "https://www.w3.org/TR/2002/REC-xml-exc-c14n-20020718/",
-  },
+  { name: "EXCLUSIVE", value: "http://www.w3.org/2001/10/xml-exc-c14n#" },
   {
     name: "EXCLUSIVE_WITH_COMMENTS",
-    value: "https://www.w3.org/TR/2002/REC-xml-exc-c14n-20020718/#WithComments",
+    value: "http://www.w3.org/2001/10/xml-exc-c14n#WithComments",
   },
   {
     name: "INCLUSIVE",
-    value: "https://www.w3.org/TR/2001/REC-xml-c14n-20010315",
+    value: "http://www.w3.org/TR/2001/REC-xml-c14n-20010315",
   },
   {
     name: "INCLUSIVE_WITH_COMMENTS",
-    value: "https://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments",
+    value: "http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments",
   },
 ] as const;
 
@@ -51,7 +48,7 @@ export const SamlSignature = () => {
 
   const { control, watch } = useFormContext<ClientRepresentation>();
 
-  const signDocs = watch("attributes.saml.server.signature");
+  const signDocs = watch("attributes.saml$server$signature");
   const signAssertion = watch("attributes.saml.assertion.signature");
 
   return (
@@ -60,7 +57,7 @@ export const SamlSignature = () => {
       role="manage-clients"
       className="keycloak__capability-config__form"
     >
-      <Toggle name="attributes.saml.server.signature" label="signDocuments" />
+      <Toggle name="attributes.saml$server$signature" label="signDocuments" />
       <Toggle
         name="attributes.saml.assertion.signature"
         label="signAssertions"
@@ -117,7 +114,7 @@ export const SamlSignature = () => {
             }
           >
             <Controller
-              name="attributes.saml.server.signature.keyinfo.xmlSigKeyInfoKeyNameTransformer"
+              name="attributes.saml$server$signature$keyinfo$xmlSigKeyInfoKeyNameTransformer"
               defaultValue={KEYNAME_TRANSFORMER[0]}
               control={control}
               render={({ onChange, value }) => (


### PR DESCRIPTION
saml.server.signature = boolean
saml.server.signature.keyinfo.xmlSigKeyInfoKeyNameTransformer and objec

fixes: #2467

## Motivation
<!-- Add references to relevant tickets, issues, design specs and/or a short description of what motivated you to do it. -->

## Brief Description
<!-- Add a short answer for: 
What was done in this PR? (e.g Fix to prevent users from accessing feature X.)
Why it was done? (e.g Feature X was deprecated.)
-->

## Verification Steps
<!--
Add the steps required to verify this change. Keep in mind that these steps should be written so groups unfamiliar with the 
new functionality can follow them, such as QE or documentation.

1. Go to `XX >> YY >> SS`.
2. Create a new item `N` with info `X`.
3. Right-click the item and select Delete.
4. Verify that the item is no longer present in the left navigation menu.
-->

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated

## Additional Notes
<!-- 
Add images and/or screen caps to illustrate what was changed if this pull request adds to or modifies existing user-visible appearance/output. 
-->
