### PR TITLE
User events tooltip text fix

### DIFF
--- a/public/resources/en/realm-settings-help.json
+++ b/public/resources/en/realm-settings-help.json
@@ -17,7 +17,7 @@
   "enabled": "Set if the keys are enabled",
   "active": "Set if the keys can be used for signing",
   "AESKeySize": "Size in bytes for the generated AES key. Size 16 is for AES-128, Size 24 for AES-192, and Size 32 for AES-256. WARN: Bigger keys than 128 are not allowed on some JDK implementations.",
-  "save-user-events": "If enabled, login events are saved to the database, which makes events available to the admin and account management consoles.",
+  "save-user-events": "If enabled, user events are saved to the database, which makes events available to the admin and account management consoles.",
   "save-admin-events": "If enabled, admin events are saved to the database, which makes events available to the admin console.",
   "expiration": "Sets the expiration for events. Expired events are periodically deleted from the database.",
   "admin-clearEvents": "Deletes all admin events in the database.",


### PR DESCRIPTION
## Motivation
Small fix for tooltip text.

## Verification Steps

1. Go to Realm settings > Events > User events settings 
2. Verify that tooltip text for "Save events" is reading "If enabled, user events are saved to the database, which makes events available to the admin and account management consoles."

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated
