### PR TITLE
Use authServerUrl instead of authUrl to initialize keycloak client (#2703)

### DIFF
--- a/src/context/auth/AdminClient.tsx
+++ b/src/context/auth/AdminClient.tsx
@@ -70,7 +70,7 @@ export async function initAdminClient() {
   await kcAdminClient.init(
     { onLoad: "check-sso", pkceMethod: "S256" },
     {
-      url: environment.authUrl,
+      url: environment.authServerUrl,
       realm: environment.loginRealm,
       clientId: environment.isRunningAsTheme
         ? "security-admin-console"
@@ -79,7 +79,7 @@ export async function initAdminClient() {
   );
 
   kcAdminClient.setConfig({ realmName: environment.loginRealm });
-  kcAdminClient.baseUrl = environment.authUrl;
+  kcAdminClient.baseUrl = environment.authServerUrl;
 
   return kcAdminClient;
 }


### PR DESCRIPTION
Previously, the admin-console did not initialize properly when users configured the admin-hostname different from the frontend-hostname.

E.g:
--hostname: id.acme.test
--hostname-admin: admin.acme.test

produces an `environment` like:
...
- ´authUrl: https://admin.acme.test:8443/auth/...´
- ´authServerUrl: https://id.acme.test:8443/auth/...´

Since `authUrl` was used, the admin-client tried to create an 3p-check-iframe from
`https://admin.acme.test:8443/auth/...` which is not allowed since only `https://id.acme.test:8443/auth/...´ is allowed.

Using the `authServerUrl` ensures that the correct `IdP` url is used.

Fixes #2703

Signed-off-by: Thomas Darimont <thomas.darimont@googlemail.com>

## Motivation
<!-- Add references to relevant tickets, issues, design specs and/or a short description of what motivated you to do it. -->

## Brief Description
<!-- Add a short answer for: 
What was done in this PR? (e.g Fix to prevent users from accessing feature X.)
Why it was done? (e.g Feature X was deprecated.)
-->

## Verification Steps
<!--
Add the steps required to verify this change. Keep in mind that these steps should be written so groups unfamiliar with the 
new functionality can follow them, such as QE or documentation.

1. Go to `XX >> YY >> SS`.
2. Create a new item `N` with info `X`.
3. Right-click the item and select Delete.
4. Verify that the item is no longer present in the left navigation menu.
-->

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated

## Additional Notes
<!-- 
Add images and/or screen caps to illustrate what was changed if this pull request adds to or modifies existing user-visible appearance/output. 
-->
