### PR TITLE
Use cy.wait() instead of cy.waitFor()

### DIFF
--- a/cypress/integration/clients_saml_test.spec.ts
+++ b/cypress/integration/clients_saml_test.spec.ts
@@ -91,7 +91,6 @@ describe("Clients SAML tests", () => {
         "admin/realms/master/clients/*/certificates/saml.signing"
       ).as("load");
       cy.findByTestId("clientSignature").click({ force: true });
-      cy.wait(["@load"]);
 
       modalUtils
         .checkModalTitle('Disable "Client signature required"')

--- a/cypress/integration/clients_saml_test.spec.ts
+++ b/cypress/integration/clients_saml_test.spec.ts
@@ -91,7 +91,7 @@ describe("Clients SAML tests", () => {
         "admin/realms/master/clients/*/certificates/saml.signing"
       ).as("load");
       cy.findByTestId("clientSignature").click({ force: true });
-      cy.waitFor("@load");
+      cy.wait(["@load"]);
 
       modalUtils
         .checkModalTitle('Disable "Client signature required"')


### PR DESCRIPTION
Due to a bug Cypress accidentally exposed `cy.waitFor()` which has been removed in newer versions (see https://github.com/cypress-io/cypress/issues/20556). In order for the tests to pass on newer versions of Cypress we need to replace instances of `cy.waitFor()` with `cy.wait()`.

Needed to land #2707.