### PR TITLE
Fix evaluate screen when user does not have view-users access.

### DIFF
--- a/src/clients/authorization/AuthorizationEvaluate.tsx
+++ b/src/clients/authorization/AuthorizationEvaluate.tsx
@@ -41,6 +41,8 @@ import { AuthorizationEvaluateResource } from "./AuthorizationEvaluateResource";
 import { SearchIcon } from "@patternfly/react-icons";
 import { ListEmptyState } from "../../components/list-empty-state/ListEmptyState";
 import { KeycloakTextInput } from "../../components/keycloak-text-input/KeycloakTextInput";
+import { useAccess } from "../../context/access/Access";
+import { ForbiddenSection } from "../../ForbiddenSection";
 
 interface EvaluateFormInputs
   extends Omit<ResourceEvaluation, "context" | "resources"> {
@@ -142,6 +144,10 @@ export const AuthorizationEvaluate = ({ client }: Props) => {
       ),
     [evaluateResults, filter, searchQuery]
   );
+
+  const { hasAccess } = useAccess();
+  if (!hasAccess("view-users"))
+    return <ForbiddenSection permissionNeeded="view-users" />;
 
   useFetch(
     () =>


### PR DESCRIPTION
## Motivation
The `Client --> Authorization --> Evaluate` screen will crash if the user does not have "query-users" access.  And, evaluate will not function if the user does not have "view-users" access. 

## Brief Description
The solution is to return the `<Forbidden>` tag in this subscreen if the user does not have at least "view-users" access.  (If he has "view-users" then he will also have "query-users")

## Verification Steps
Set up a test user with "view-clients" or "manage-clients" access.  Then go to the screen and see the "Forbidden" message.  

Add "view-users" access and see the screen functions properly.

## Checklist:

- [X] Code has been tested locally by PR requester
- [N/A] User-visible strings are using the react-i18next framework (useTranslation)
- [N/A] Help has been implemented
- [N/A] axe report has been run and resulting a11y issues have been resolved
- [N/A] Unit tests have been created/updated

