### PR TITLE
Disable Cypress Dashboard integration

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -59,10 +59,6 @@ jobs:
   test:
     needs: setup
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        containers: [1, 2, 3, 4, 5]
     steps:
       - name: Check out Admin UI
         uses: actions/checkout@v3
@@ -104,15 +100,11 @@ jobs:
         uses: cypress-io/github-action@v2
         with:
           install: false
-          record: true
-          parallel: true
           browser: chrome
           wait-on: http://localhost:8080
         env:
           CYPRESS_BASE_URL: http://localhost:8080/admin/
           CYPRESS_KEYCLOAK_SERVER: http://localhost:8080
-          CYPRESS_RECORD_KEY: b8f1d15e-eab8-4ee7-8e44-c6d7cd8fc0eb
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Add Cypress videos artifacts
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
We are losing access to the Cypress Dashboard so we have to disable it for now.