### PR TITLE
Run code quality check on a nightly schedule

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,15 +1,7 @@
 name: CodeQL
 on:
-  push:
-    branches: [main]
-    paths-ignore:
-      - cypress/**
-      - mocks/**
-  pull_request:
-    branches: [main]
-    paths-ignore:
-      - cypress/**
-      - mocks/**
+  schedule:
+    - cron: "0 2 * * *"
 env:
   NODE_VERSION: 18
 jobs:


### PR DESCRIPTION
The code quality check running on every commit is causing Github Actions to bog down. Running these tasks on a nightly schedule will alleviate this issue.