### PR TITLE
add expiration to admin events config

### DIFF
--- a/src/realm-settings/event-config/EventConfigForm.tsx
+++ b/src/realm-settings/event-config/EventConfigForm.tsx
@@ -113,7 +113,7 @@ export const EventConfigForm = ({
               />
             </FormGroup>
           )}
-          {type === "user" && (
+          {
             <FormGroup
               label={t("expiration")}
               fieldId="expiration"
@@ -125,7 +125,11 @@ export const EventConfigForm = ({
               }
             >
               <Controller
-                name="eventsExpiration"
+                name={
+                  type === "admin"
+                    ? "adminEventsExpiration"
+                    : "eventsExpiration"
+                }
                 defaultValue=""
                 control={control}
                 render={({ onChange, value }) => (
@@ -137,7 +141,7 @@ export const EventConfigForm = ({
                 )}
               />
             </FormGroup>
-          )}
+          }
         </>
       )}
       <ActionGroup>


### PR DESCRIPTION
## Motivation
Allow admin events to be configured with an expiration time.
#https://github.com/keycloak/keycloak/issues/12476

## Brief Description
Enable the option to set an expiration time on admin events using the event configuration tab. Needs #https://github.com/keycloak/keycloak/pull/12501 to be merged.

## Verification Steps
On the admin event configuration tab an expiration time can now be set and seen (if already set).

## Checklist:

- [x] Code has been tested locally by PR requester
- [x] User-visible strings are using the react-i18next framework (useTranslation) (re-use from events)
- [x] Help has been implemented (re-use from events)

