### PR TITLE
Add theme.properties to the build.

### DIFF
--- a/keycloak-theme/src/main/resources/theme/keycloak.v2/admin/theme.properties
+++ b/keycloak-theme/src/main/resources/theme/keycloak.v2/admin/theme.properties
@@ -1,0 +1,1 @@
+parent=base


### PR DESCRIPTION
## Motivation
Fixes https://github.com/keycloak/keycloak-admin-ui/issues/2778

## Brief Description
From my testing, this should fix the problem with User Federation error messages that are not localized.

The problem was that we have not been including a theme.properties.  So unless you run the old admin console first, the message bundles for localization of error messages will never get loaded.

## Verification Steps
See steps in https://github.com/keycloak/keycloak-admin-ui/issues/2778

But note that you wouldn't see the issue if you had already run the old console against the keycloak database.  So for a valid test you need to start with a clean database (or just delete it).
