### PR TITLE
Fixed subheading in the dialog #2810

### DIFF
--- a/src/client-scopes/add/MapperDialog.tsx
+++ b/src/client-scopes/add/MapperDialog.tsx
@@ -90,7 +90,9 @@ export const AddMapperDialog = (props: AddMapperDialogProps) => {
       variant={ModalVariant.medium}
       header={
         <TextContent>
-          <Text component={TextVariants.h1}>{t("addPredefinedMappers")}</Text>
+          <Text component={TextVariants.h1}>
+            {isBuiltIn ? t("addPredefinedMappers") : t("emptySecondaryAction")}
+          </Text>
           <Text>{t("predefinedMappingDescription")}</Text>
         </TextContent>
       }


### PR DESCRIPTION
## Motivation
Fix for #2810 

## Verification Steps
<!--
Add the steps required to verify this change. Keep in mind that these steps should be written so groups unfamiliar with the 
new functionality can follow them, such as QE or documentation.

1. Go to 'Client scopes', select scope, and go to the "Mappers" tab.
2. Click "Configure a new mapper" and verify that the dialog is showing the "Configure a new mapper" header

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated
