### PR TITLE
Fixed heading for create client policy #2817

### DIFF
--- a/public/resources/en/realm-settings.json
+++ b/public/resources/en/realm-settings.json
@@ -202,7 +202,7 @@
   "clientPolicies": "Client policies",
   "noClientPolicies": "No client policies",
   "noClientPoliciesInstructions": "There are no client policies. Select 'Create client policy' to create a new client policy.",
-  "createPolicy": "Create policy",
+  "createPolicy": "Create client policy",
   "createClientPolicy": "Create client policy",
   "createClientPolicySuccess": "New policy created",
   "updateClientPolicySuccess": "Client policy updated",

--- a/src/client-scopes/add/MapperDialog.tsx
+++ b/src/client-scopes/add/MapperDialog.tsx
@@ -90,7 +90,9 @@ export const AddMapperDialog = (props: AddMapperDialogProps) => {
       variant={ModalVariant.medium}
       header={
         <TextContent>
-          <Text component={TextVariants.h1}>{t("addPredefinedMappers")}</Text>
+          <Text component={TextVariants.h1}>
+            {isBuiltIn ? t("addPredefinedMappers") : t("emptySecondaryAction")}
+          </Text>
           <Text>{t("predefinedMappingDescription")}</Text>
         </TextContent>
       }

--- a/src/client-scopes/add/MapperDialog.tsx
+++ b/src/client-scopes/add/MapperDialog.tsx
@@ -90,9 +90,7 @@ export const AddMapperDialog = (props: AddMapperDialogProps) => {
       variant={ModalVariant.medium}
       header={
         <TextContent>
-          <Text component={TextVariants.h1}>
-            {isBuiltIn ? t("addPredefinedMappers") : t("emptySecondaryAction")}
-          </Text>
+          <Text component={TextVariants.h1}>{t("addPredefinedMappers")}</Text>
           <Text>{t("predefinedMappingDescription")}</Text>
         </TextContent>
       }


### PR DESCRIPTION
## Motivation
Fix for #2817 

## Verification Steps
<!--
Add the steps required to verify this change. Keep in mind that these steps should be written so groups unfamiliar with the 
new functionality can follow them, such as QE or documentation.

1. Go to 'Realm settings', select the 'Client policies' tab, and select the 'Policies' subtab.
2. Click 'Create client policy' and verify that the heading is now reading 'Create client policy.'

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated
