### PR TITLE
Fixed subheading text for "Configure a new mapper" dialog

### DIFF
--- a/public/resources/en/client-scopes.json
+++ b/public/resources/en/client-scopes.json
@@ -43,6 +43,7 @@
   "chooseAMapperType": "Choose a mapper type",
   "addPredefinedMappers": "Add predefined mappers",
   "predefinedMappingDescription": "Choose any of the predefined mappings from this table",
+  "configureMappingDescription": "Choose any of the mappings from this table",
   "mappingTable": "Table with predefined mapping",
   "scope": "Scope",
   "roleMappingUpdatedSuccess": "Role mapping updated",

--- a/src/client-scopes/add/MapperDialog.tsx
+++ b/src/client-scopes/add/MapperDialog.tsx
@@ -93,7 +93,11 @@ export const AddMapperDialog = (props: AddMapperDialogProps) => {
           <Text component={TextVariants.h1}>
             {isBuiltIn ? t("addPredefinedMappers") : t("emptySecondaryAction")}
           </Text>
-          <Text>{t("predefinedMappingDescription")}</Text>
+          <Text>
+            {isBuiltIn
+              ? t("predefinedMappingDescription")
+              : t("configureMappingDescription")}
+          </Text>
         </TextContent>
       }
       isOpen={props.open}


### PR DESCRIPTION
## Motivation
Fix for https://github.com/keycloak/keycloak-admin-ui/issues/2810

## Verification Steps

1. Go to `Client scopes`, select scope, and go to the 'Mappers' tab.
2. Click 'Configure a new mapper' and verify that the subheading is reading 'Choose any of the mappings from this table'

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated
