### PR TITLE
Always Display in Console missing from OIDC clients

### DIFF
--- a/cypress/e2e/realm_settings_tabs_test.spec.ts
+++ b/cypress/e2e/realm_settings_tabs_test.spec.ts
@@ -39,39 +39,35 @@ describe("Realm settings tabs tests", () => {
     cy.findByTestId(realmSettingsPage.userProfileTab).should("exist");
   });
 
+  // Toggles will update the database immediately.
+  // So we need to force realm settings to reload - otherwise you aren't testing anything but patternfly
+  // This also keeps Cypress from getting hung.
+  function reloadRealm() {
+    sidebarPage.goToClientScopes();
+    sidebarPage.goToRealmSettings();
+    cy.findByTestId("rs-login-tab").click();
+  }
+
+  function testToggle(realmSwitch: string, expectedValue: string) {
+    realmSettingsPage.toggleSwitch(realmSwitch);
+    reloadRealm();
+    cy.findByTestId(realmSwitch).should("have.value", expectedValue);
+  }
+
   it("Go to login tab", () => {
     sidebarPage.goToRealmSettings();
     cy.findByTestId("rs-login-tab").click();
-    realmSettingsPage.toggleSwitch(realmSettingsPage.userRegSwitch);
 
-    realmSettingsPage.toggleSwitch(realmSettingsPage.forgotPwdSwitch);
+    testToggle(realmSettingsPage.userRegSwitch, "on");
+    testToggle(realmSettingsPage.forgotPwdSwitch, "on");
+    testToggle(realmSettingsPage.rememberMeSwitch, "on");
+    testToggle(realmSettingsPage.loginWithEmailSwitch, "off");
+    testToggle(realmSettingsPage.duplicateEmailsSwitch, "on");
 
-    realmSettingsPage.toggleSwitch(realmSettingsPage.rememberMeSwitch);
-
-    realmSettingsPage.toggleSwitch(realmSettingsPage.loginWithEmailSwitch);
-
-    // Check values
-    cy.findByTestId(realmSettingsPage.userRegSwitch).should("have.value", "on");
-    cy.findByTestId(realmSettingsPage.forgotPwdSwitch).should(
-      "have.value",
-      "on"
-    );
-    cy.findByTestId(realmSettingsPage.rememberMeSwitch).should(
-      "have.value",
-      "on"
-    );
+    // Check other values
     cy.findByTestId(realmSettingsPage.emailAsUsernameSwitch).should(
       "have.value",
       "off"
-    );
-    cy.findByTestId(realmSettingsPage.loginWithEmailSwitch).should(
-      "have.value",
-      "off"
-    );
-
-    cy.findByTestId(realmSettingsPage.duplicateEmailsSwitch).should(
-      "have.value",
-      "on"
     );
 
     cy.findByTestId(realmSettingsPage.verifyEmailSwitch).should(

--- a/cypress/e2e/realm_settings_tabs_test.spec.ts
+++ b/cypress/e2e/realm_settings_tabs_test.spec.ts
@@ -39,9 +39,10 @@ describe("Realm settings tabs tests", () => {
     cy.findByTestId(realmSettingsPage.userProfileTab).should("exist");
   });
 
-  // Toggles will update the database immediately.
-  // So we need to force realm settings to reload - otherwise you aren't testing anything but patternfly
-  // This also keeps Cypress from getting hung.
+  // Clicking multiple toggles in succession causes quick re-renderings of the screen
+  // and there will be a noticeable flicker during the test.
+  // Sometimes, this will screw up the test and cause Cypress to hang.
+  // Clicking to another section each time fixes the problem.
   function reloadRealm() {
     sidebarPage.goToClientScopes();
     sidebarPage.goToRealmSettings();

--- a/src/clients/ClientDescription.tsx
+++ b/src/clients/ClientDescription.tsx
@@ -15,7 +15,6 @@ type ClientDescriptionProps = {
 };
 
 export const ClientDescription = ({
-  protocol,
   hasConfigureAccess: configure,
 }: ClientDescriptionProps) => {
   const { t } = useTranslation("clients");
@@ -93,62 +92,32 @@ export const ClientDescription = ({
           }
         />
       </FormGroup>
-      {protocol === "saml" && (
-        <>
-          <FormGroup
-            label={t("clients:alwaysDisplayInConsole")}
-            labelIcon={
-              <HelpItem
-                helpText="clients-help:alwaysDisplayInConsole"
-                fieldLabelId="clients:alwaysDisplayInConsole"
-              />
-            }
-            fieldId="kc-always-display-in-console"
-            hasNoPaddingTop
-          >
-            <Controller
-              name="alwaysDisplayInConsole"
-              defaultValue={false}
-              control={control}
-              render={({ onChange, value }) => (
-                <Switch
-                  id="kc-always-display-in-console-switch"
-                  label={t("common:on")}
-                  labelOff={t("common:off")}
-                  isChecked={value}
-                  onChange={onChange}
-                />
-              )}
+      <FormGroup
+        label={t("clients:alwaysDisplayInConsole")}
+        labelIcon={
+          <HelpItem
+            helpText="clients-help:alwaysDisplayInConsole"
+            fieldLabelId="clients:alwaysDisplayInConsole"
+          />
+        }
+        fieldId="kc-always-display-in-console"
+        hasNoPaddingTop
+      >
+        <Controller
+          name="alwaysDisplayInConsole"
+          defaultValue={false}
+          control={control}
+          render={({ onChange, value }) => (
+            <Switch
+              id="kc-always-display-in-console-switch"
+              label={t("common:on")}
+              labelOff={t("common:off")}
+              isChecked={value}
+              onChange={onChange}
             />
-          </FormGroup>
-          <FormGroup
-            label={t("frontchannelLogout")}
-            labelIcon={
-              <HelpItem
-                helpText="clients-help:frontchannelLogout"
-                fieldLabelId="clients:frontchannelLogout"
-              />
-            }
-            fieldId="kc-frontchannelLogout"
-            hasNoPaddingTop
-          >
-            <Controller
-              name="frontchannelLogout"
-              defaultValue={true}
-              control={control}
-              render={({ onChange, value }) => (
-                <Switch
-                  id="kc-frontchannelLogout-switch"
-                  label={t("common:on")}
-                  labelOff={t("common:off")}
-                  isChecked={value.toString() === "true"}
-                  onChange={(value) => onChange(value.toString())}
-                />
-              )}
-            />
-          </FormGroup>
-        </>
-      )}
+          )}
+        />
+      </FormGroup>
     </FormAccess>
   );
 };

--- a/src/clients/add/LogoutPanel.tsx
+++ b/src/clients/add/LogoutPanel.tsx
@@ -37,75 +37,71 @@ export const LogoutPanel = ({
       role="manage-clients"
       className="pf-u-pb-xl"
     >
-      {protocol === "openid-connect" && (
-        <>
+      <FormGroup
+        label={t("frontchannelLogout")}
+        labelIcon={
+          <HelpItem
+            helpText="clients-help:frontchannelLogout"
+            fieldLabelId="clients:frontchannelLogout"
+          />
+        }
+        fieldId="kc-frontchannelLogout"
+        hasNoPaddingTop
+      >
+        <Controller
+          name="frontchannelLogout"
+          defaultValue={true}
+          control={control}
+          render={({ onChange, value }) => (
+            <Switch
+              id="kc-frontchannelLogout-switch"
+              label={t("common:on")}
+              labelOff={t("common:off")}
+              isChecked={value.toString() === "true"}
+              onChange={(value) => onChange(value.toString())}
+            />
+          )}
+        />
+      </FormGroup>
+      {protocol === "openid-connect" &&
+        frontchannelLogout?.toString() === "true" && (
           <FormGroup
-            label={t("frontchannelLogout")}
+            label={t("frontchannelLogoutUrl")}
+            fieldId="frontchannelLogoutUrl"
             labelIcon={
               <HelpItem
-                helpText="clients-help:frontchannelLogout"
-                fieldLabelId="clients:frontchannelLogout"
+                helpText="clients-help:frontchannelLogoutUrl"
+                fieldLabelId="clients:frontchannelLogoutUrl"
               />
             }
-            fieldId="frontchannelLogout"
-            hasNoPaddingTop
+            helperTextInvalid={
+              errors.attributes?.frontchannel?.logout?.url?.message
+            }
+            validated={
+              errors.attributes?.frontchannel?.logout?.url?.message
+                ? ValidatedOptions.error
+                : ValidatedOptions.default
+            }
           >
-            <Controller
-              name="frontchannelLogout"
-              defaultValue={true}
-              control={control}
-              render={({ onChange, value }) => (
-                <Switch
-                  id="frontchannelLogout"
-                  label={t("common:on")}
-                  labelOff={t("common:off")}
-                  isChecked={value.toString() === "true"}
-                  onChange={(value) => onChange(value.toString())}
-                />
-              )}
-            />
-          </FormGroup>
-          {frontchannelLogout?.toString() === "true" && (
-            <FormGroup
-              label={t("frontchannelLogoutUrl")}
-              fieldId="frontchannelLogoutUrl"
-              labelIcon={
-                <HelpItem
-                  helpText="clients-help:frontchannelLogoutUrl"
-                  fieldLabelId="clients:frontchannelLogoutUrl"
-                />
-              }
-              helperTextInvalid={
-                errors.attributes?.frontchannel?.logout?.url?.message
-              }
+            <KeycloakTextInput
+              type="text"
+              id="frontchannelLogoutUrl"
+              name="attributes.frontchannel.logout.url"
+              ref={register({
+                validate: (uri) =>
+                  ((uri.startsWith("https://") || uri.startsWith("http://")) &&
+                    !uri.includes("*")) ||
+                  uri === "" ||
+                  t("frontchannelUrlInvalid").toString(),
+              })}
               validated={
                 errors.attributes?.frontchannel?.logout?.url?.message
                   ? ValidatedOptions.error
                   : ValidatedOptions.default
               }
-            >
-              <KeycloakTextInput
-                type="text"
-                id="frontchannelLogoutUrl"
-                name="attributes.frontchannel.logout.url"
-                ref={register({
-                  validate: (uri) =>
-                    ((uri.startsWith("https://") ||
-                      uri.startsWith("http://")) &&
-                      !uri.includes("*")) ||
-                    uri === "" ||
-                    t("frontchannelUrlInvalid").toString(),
-                })}
-                validated={
-                  errors.attributes?.frontchannel?.logout?.url?.message
-                    ? ValidatedOptions.error
-                    : ValidatedOptions.default
-                }
-              />
-            </FormGroup>
-          )}
-        </>
-      )}
+            />
+          </FormGroup>
+        )}
       <FormGroup
         label={t("backchannelLogoutUrl")}
         fieldId="backchannelLogoutUrl"


### PR DESCRIPTION
## Motivation
In Clients --> Settings, the "Always display in console" field was missing from OIDC clients.

Also, for SAML, Front Channel Logout was in General Settings instead of Logout settings.

## Verification Steps
Verify that "Always display in console" is always visible for both OIDC and SAML clients.
Verify "Front Channel Logout" is in Logout settings for both OIDC and SAML clients.

## Checklist:

- [X] Code has been tested locally by PR requester
- [X] User-visible strings are using the react-i18next framework (useTranslation)
- [X] Help has been implemented
- [N/A] axe report has been run and resulting a11y issues have been resolved
- [N/A] Unit tests have been created/updated

