### PR TITLE
Replace .hasOwn() with .hasOwnProperty()

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -77,7 +77,10 @@ const isAttributeArray = (value: any) => {
   }
 
   return value.some(
-    (e) => Object.hasOwn(e, "key") && Object.hasOwn(e, "value")
+    (e) =>
+      // TODO: Use Object.hasOwn() when Firefox ESR supports it.
+      Object.prototype.hasOwnProperty.call(e, "key") &&
+      Object.prototype.hasOwnProperty.call(e, "value")
   );
 };
 


### PR DESCRIPTION
Replaces all instances of `.hasOwn()` with external calls to `.hasOwnProperty()` (see [MDN docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty#using_hasownproperty_as_a_property_name)). This is because the current [ESR version](https://support.mozilla.org/en-US/kb/switch-to-firefox-extended-support-release-esr) of Firefox [does not support](https://caniuse.com/mdn-javascript_builtins_object_hasown) this functionality yet.

Closes #2864.