### PR TITLE
Serious accessibility fixes for Home/Provider Info page #2839

### DIFF
--- a/src/dashboard/ProviderInfo.tsx
+++ b/src/dashboard/ProviderInfo.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { Fragment, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ExpandableSection, PageSection } from "@patternfly/react-core";
@@ -59,34 +60,34 @@ export const ProviderInfo = () => {
                       <li key={key}>{key}</li>
                     ))}
                   </ul>
-                  {Object.entries(providers).map(
-                    ([key, { operationalInfo }]) => (
-                      <Fragment key={key}>
-                        {operationalInfo && (
-                          <ExpandableSection
-                            isExpanded={open.includes(key)}
-                            onToggle={() => toggleOpen(key)}
-                            toggleText={
-                              open.includes(key) ? t("showLess") : t("showMore")
-                            }
-                          >
-                            <TableComposable borders={false}>
-                              <Tbody>
-                                {Object.entries(operationalInfo).map(
-                                  ([key, value]) => (
-                                    <Tr key={key}>
-                                      <Td>{key}</Td>
-                                      <Td>{value}</Td>
-                                    </Tr>
-                                  )
-                                )}
-                              </Tbody>
-                            </TableComposable>
-                          </ExpandableSection>
-                        )}
-                      </Fragment>
+                  {Object.entries(providers)
+                    .filter(
+                      ([_, { operationalInfo }]) =>
+                        operationalInfo !== undefined
                     )
-                  )}
+                    .map(([key, { operationalInfo }]) => (
+                      <ExpandableSection
+                        key={key}
+                        isExpanded={open.includes(key)}
+                        onToggle={() => toggleOpen(key)}
+                        toggleText={
+                          open.includes(key) ? t("showLess") : t("showMore")
+                        }
+                      >
+                        <TableComposable borders={false}>
+                          <Tbody>
+                            {Object.entries(operationalInfo).map(
+                              ([key, value]) => (
+                                <Tr key={key}>
+                                  <Td>{key}</Td>
+                                  <Td>{value}</Td>
+                                </Tr>
+                              )
+                            )}
+                          </Tbody>
+                        </TableComposable>
+                      </ExpandableSection>
+                    ))}
                 </Td>
               </Tr>
             ))}

--- a/src/dashboard/ProviderInfo.tsx
+++ b/src/dashboard/ProviderInfo.tsx
@@ -56,9 +56,7 @@ export const ProviderInfo = () => {
                 <Td>
                   <ul>
                     {Object.entries(providers).map(([key]) => (
-                      <Fragment key={key}>
-                        <li>{key}</li>
-                      </Fragment>
+                      <li key={key}>{key}</li>
                     ))}
                   </ul>
                   {Object.entries(providers).map(

--- a/src/dashboard/ProviderInfo.tsx
+++ b/src/dashboard/ProviderInfo.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/jsx-no-useless-fragment */
 import React, { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ExpandableSection, PageSection } from "@patternfly/react-core";
@@ -13,6 +12,7 @@ import {
 
 import { useServerInfo } from "../context/server-info/ServerInfoProvider";
 import { TableToolbar } from "../components/table-toolbar/TableToolbar";
+import { isDefined } from "../utils/isDefined";
 
 export const ProviderInfo = () => {
   const { t } = useTranslation("dashboard");
@@ -60,35 +60,33 @@ export const ProviderInfo = () => {
                       <li key={key}>{key}</li>
                     ))}
                   </ul>
-                  {Object.entries(providers).map(
-                    ([key, { operationalInfo }]) => (
-                      <>
-                        {operationalInfo && (
-                          <ExpandableSection
-                            key={key}
-                            isExpanded={open.includes(key)}
-                            onToggle={() => toggleOpen(key)}
-                            toggleText={
-                              open.includes(key) ? t("showLess") : t("showMore")
-                            }
-                          >
-                            <TableComposable borders={false}>
-                              <Tbody>
-                                {Object.entries(operationalInfo).map(
-                                  ([key, value]) => (
-                                    <Tr key={key}>
-                                      <Td>{key}</Td>
-                                      <Td>{value}</Td>
-                                    </Tr>
-                                  )
-                                )}
-                              </Tbody>
-                            </TableComposable>
-                          </ExpandableSection>
-                        )}
-                      </>
+                  {Object.entries(providers)
+                    .map(([key, { operationalInfo }]) =>
+                      operationalInfo ? (
+                        <ExpandableSection
+                          key={key}
+                          isExpanded={open.includes(key)}
+                          onToggle={() => toggleOpen(key)}
+                          toggleText={
+                            open.includes(key) ? t("showLess") : t("showMore")
+                          }
+                        >
+                          <TableComposable borders={false}>
+                            <Tbody>
+                              {Object.entries(operationalInfo).map(
+                                ([key, value]) => (
+                                  <Tr key={key}>
+                                    <Td>{key}</Td>
+                                    <Td>{value}</Td>
+                                  </Tr>
+                                )
+                              )}
+                            </Tbody>
+                          </TableComposable>
+                        </ExpandableSection>
+                      ) : null
                     )
-                  )}
+                    .filter(isDefined)}
                 </Td>
               </Tr>
             ))}

--- a/src/dashboard/ProviderInfo.tsx
+++ b/src/dashboard/ProviderInfo.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { Fragment, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ExpandableSection, PageSection } from "@patternfly/react-core";
@@ -60,34 +59,34 @@ export const ProviderInfo = () => {
                       <li key={key}>{key}</li>
                     ))}
                   </ul>
-                  {Object.entries(providers)
-                    .filter(
-                      ([_, { operationalInfo }]) =>
-                        operationalInfo !== undefined
+                  {Object.entries(providers).map(
+                    ([key, { operationalInfo }]) => (
+                      <Fragment key={key}>
+                        {operationalInfo && (
+                          <ExpandableSection
+                            isExpanded={open.includes(key)}
+                            onToggle={() => toggleOpen(key)}
+                            toggleText={
+                              open.includes(key) ? t("showLess") : t("showMore")
+                            }
+                          >
+                            <TableComposable borders={false}>
+                              <Tbody>
+                                {Object.entries(operationalInfo).map(
+                                  ([key, value]) => (
+                                    <Tr key={key}>
+                                      <Td>{key}</Td>
+                                      <Td>{value}</Td>
+                                    </Tr>
+                                  )
+                                )}
+                              </Tbody>
+                            </TableComposable>
+                          </ExpandableSection>
+                        )}
+                      </Fragment>
                     )
-                    .map(([key, { operationalInfo }]) => (
-                      <ExpandableSection
-                        key={key}
-                        isExpanded={open.includes(key)}
-                        onToggle={() => toggleOpen(key)}
-                        toggleText={
-                          open.includes(key) ? t("showLess") : t("showMore")
-                        }
-                      >
-                        <TableComposable borders={false}>
-                          <Tbody>
-                            {Object.entries(operationalInfo).map(
-                              ([key, value]) => (
-                                <Tr key={key}>
-                                  <Td>{key}</Td>
-                                  <Td>{value}</Td>
-                                </Tr>
-                              )
-                            )}
-                          </Tbody>
-                        </TableComposable>
-                      </ExpandableSection>
-                    ))}
+                  )}
                 </Td>
               </Tr>
             ))}

--- a/src/dashboard/ProviderInfo.tsx
+++ b/src/dashboard/ProviderInfo.tsx
@@ -55,38 +55,40 @@ export const ProviderInfo = () => {
                 <Td>{name}</Td>
                 <Td>
                   <ul>
-                    {Object.entries(providers).map(
-                      ([key, { operationalInfo }]) => (
-                        <Fragment key={key}>
-                          <li>{key}</li>
-                          {operationalInfo && (
-                            <ExpandableSection
-                              isExpanded={open.includes(key)}
-                              onToggle={() => toggleOpen(key)}
-                              toggleText={
-                                open.includes(key)
-                                  ? t("showLess")
-                                  : t("showMore")
-                              }
-                            >
-                              <TableComposable borders={false}>
-                                <Tbody>
-                                  {Object.entries(operationalInfo).map(
-                                    ([key, value]) => (
-                                      <Tr key={key}>
-                                        <Td>{key}</Td>
-                                        <Td>{value}</Td>
-                                      </Tr>
-                                    )
-                                  )}
-                                </Tbody>
-                              </TableComposable>
-                            </ExpandableSection>
-                          )}
-                        </Fragment>
-                      )
-                    )}
+                    {Object.entries(providers).map(([key]) => (
+                      <Fragment key={key}>
+                        <li>{key}</li>
+                      </Fragment>
+                    ))}
                   </ul>
+                  {Object.entries(providers).map(
+                    ([key, { operationalInfo }]) => (
+                      <Fragment key={key}>
+                        {operationalInfo && (
+                          <ExpandableSection
+                            isExpanded={open.includes(key)}
+                            onToggle={() => toggleOpen(key)}
+                            toggleText={
+                              open.includes(key) ? t("showLess") : t("showMore")
+                            }
+                          >
+                            <TableComposable borders={false}>
+                              <Tbody>
+                                {Object.entries(operationalInfo).map(
+                                  ([key, value]) => (
+                                    <Tr key={key}>
+                                      <Td>{key}</Td>
+                                      <Td>{value}</Td>
+                                    </Tr>
+                                  )
+                                )}
+                              </Tbody>
+                            </TableComposable>
+                          </ExpandableSection>
+                        )}
+                      </Fragment>
+                    )
+                  )}
                 </Td>
               </Tr>
             ))}

--- a/src/dashboard/ProviderInfo.tsx
+++ b/src/dashboard/ProviderInfo.tsx
@@ -1,4 +1,5 @@
-import React, { Fragment, useMemo, useState } from "react";
+/* eslint-disable react/jsx-no-useless-fragment */
+import React, { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ExpandableSection, PageSection } from "@patternfly/react-core";
 import {
@@ -61,9 +62,10 @@ export const ProviderInfo = () => {
                   </ul>
                   {Object.entries(providers).map(
                     ([key, { operationalInfo }]) => (
-                      <Fragment key={key}>
+                      <>
                         {operationalInfo && (
                           <ExpandableSection
+                            key={key}
                             isExpanded={open.includes(key)}
                             onToggle={() => toggleOpen(key)}
                             toggleText={
@@ -84,7 +86,7 @@ export const ProviderInfo = () => {
                             </TableComposable>
                           </ExpandableSection>
                         )}
-                      </Fragment>
+                      </>
                     )
                   )}
                 </Td>


### PR DESCRIPTION
## Motivation
Fixes and closes https://github.com/keycloak/keycloak-admin-ui/issues/2839

Verification: 
![Screenshot 2022-07-01 at 17 08 40](https://user-images.githubusercontent.com/4890675/176931546-8e8e511e-748a-4d7f-8d30-9f2b0e724065.png)

## Verification Steps

1. Run axe scan for the `Provider info` tab on the Home page.

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated
