### PR TITLE
Add utilty function to check for defined values

### DIFF
--- a/src/utils/isDefined.test.ts
+++ b/src/utils/isDefined.test.ts
@@ -1,0 +1,14 @@
+import { isDefined } from "./isDefined";
+
+describe("isDefined", () => {
+  it("detects defined values", () => {
+    expect(isDefined(0)).toBe(true);
+    expect(isDefined(false)).toBe(true);
+    expect(isDefined("")).toBe(true);
+  });
+
+  it("detects undefined values", () => {
+    expect(isDefined(undefined)).toBe(false);
+    expect(isDefined(null)).toBe(false);
+  });
+});

--- a/src/utils/isDefined.ts
+++ b/src/utils/isDefined.ts
@@ -1,0 +1,3 @@
+export function isDefined<T>(value: T): value is NonNullable<T> {
+  return value !== undefined && value !== null;
+}

--- a/src/utils/useRequiredContext.ts
+++ b/src/utils/useRequiredContext.ts
@@ -1,5 +1,6 @@
-import { useContext } from "react";
 import type { Context } from "react";
+import { useContext } from "react";
+import { isDefined } from "./isDefined";
 
 /**
  * Passes the call to `useContext` and throw an exception if the resolved value is either `null` or `undefined`.
@@ -13,8 +14,8 @@ export default function useRequiredContext<T>(
 ): NonNullable<T> {
   const resolved = useContext(context);
 
-  if (resolved !== undefined && resolved !== null) {
-    return resolved as NonNullable<T>;
+  if (isDefined(resolved)) {
+    return resolved;
   }
 
   throw new Error(


### PR DESCRIPTION
Adds an easy to use utility function to check for values that are defined (anything not `undefined` or `null`). This allows for filtering collections in a manner that will provide type safety guarantees.