### PR TITLE
Fix syncMode defult to lower case.

### DIFF
--- a/src/identity-providers/add/AdvancedSettings.tsx
+++ b/src/identity-providers/add/AdvancedSettings.tsx
@@ -152,7 +152,7 @@ export const AdvancedSettings = ({ isOIDC, isSAML }: AdvancedSettingsProps) => {
       >
         <Controller
           name="config.syncMode"
-          defaultValue={syncModes[0]}
+          defaultValue={syncModes[0].toUpperCase()}
           control={control}
           render={({ onChange, value }) => (
             <Select


### PR DESCRIPTION
## Motivation
Fixes https://github.com/keycloak/keycloak-admin-ui/issues/2884

## Brief Description
Default value for sync mode of identity provider needs to be upper case.

## Verification Steps
See https://github.com/keycloak/keycloak-admin-ui/issues/2884

