### PR TITLE
Fixed serious ay11 issues on Realm-settings/Client policies tab

### DIFF
--- a/src/realm-settings/RealmSettingsTabs.tsx
+++ b/src/realm-settings/RealmSettingsTabs.tsx
@@ -10,6 +10,7 @@ import {
   PageSection,
   Tab,
   TabTitleText,
+  Tooltip,
 } from "@patternfly/react-core";
 
 import type RealmRepresentation from "@keycloak/keycloak-admin-client/lib/defs/realmRepresentation";
@@ -44,7 +45,6 @@ import { PartialImportDialog } from "./PartialImport";
 import { PartialExportDialog } from "./PartialExport";
 import { RealmSettingsTab, toRealmSettings } from "./routes/RealmSettings";
 import { LocalizationTab } from "./LocalizationTab";
-import { HelpItem } from "../components/help-enabler/HelpItem";
 import { UserRegistration } from "./UserRegistration";
 import { toDashboard } from "../dashboard/routes/Dashboard";
 import environment from "../environment";
@@ -363,16 +363,11 @@ export const RealmSettingsTabs = ({
                 id="profiles"
                 data-testid="rs-policies-clientProfiles-tab"
                 aria-label={t("clientProfilesSubTab")}
-                title={
-                  <TabTitleText>
-                    {t("profiles")}
-                    <span className="kc-help-text">
-                      <HelpItem
-                        helpText="realm-settings:clientPoliciesProfilesHelpText"
-                        fieldLabelId="realm-settings:clientPoliciesProfiles"
-                      />
-                    </span>
-                  </TabTitleText>
+                title={<TabTitleText>{t("profiles")}</TabTitleText>}
+                tooltip={
+                  <Tooltip
+                    content={t("realm-settings:clientPoliciesProfilesHelpText")}
+                  />
                 }
                 {...policiesRoute("profiles")}
               >
@@ -383,16 +378,11 @@ export const RealmSettingsTabs = ({
                 data-testid="rs-policies-clientPolicies-tab"
                 aria-label={t("clientPoliciesSubTab")}
                 {...policiesRoute("policies")}
-                title={
-                  <TabTitleText>
-                    {t("policies")}
-                    <span className="kc-help-text">
-                      <HelpItem
-                        helpText="realm-settings:clientPoliciesPoliciesHelpText"
-                        fieldLabelId="realm-settings:clientPoliciesPolicies"
-                      />
-                    </span>
-                  </TabTitleText>
+                title={<TabTitleText>{t("policies")}</TabTitleText>}
+                tooltip={
+                  <Tooltip
+                    content={t("realm-settings:clientPoliciesPoliciesHelpText")}
+                  />
                 }
               >
                 <PoliciesTab />

--- a/src/realm-settings/realm-settings-section.css
+++ b/src/realm-settings/realm-settings-section.css
@@ -180,11 +180,6 @@ article.pf-c-card.pf-m-flat.kc-login-settings-template
   padding: var(--pf-global--spacer--sm);
 }
 
-.kc-help-text {
-  margin: var(--pf-global--spacer--sm);
-  font-size: var(--pf-global--FontSize--sm);
-}
-
 .kc-profiles-config-section {
   align-items: center;
 }


### PR DESCRIPTION
## Motivation
Fix for 3 &4 #2851. Closes #2851

## Verification Steps
1. Go to the `Client policies` tab under `Realm settings` and scan the page using AXE.
2. Verify that all serious ay11 issues have been fixed.

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated

