### PR TITLE
Created space between the "Join Group" button and tick for the "Direct membership"

### DIFF
--- a/src/user/UserGroups.tsx
+++ b/src/user/UserGroups.tsx
@@ -4,6 +4,7 @@ import {
   ButtonVariant,
   Checkbox,
   Popover,
+  ToolbarItem,
 } from "@patternfly/react-core";
 import { QuestionCircleIcon } from "@patternfly/react-icons";
 import { cellWidth } from "@patternfly/react-table";
@@ -283,45 +284,52 @@ export const UserGroups = ({ user }: UserGroupsProps) => {
         }
         toolbarItem={
           <>
-            <Button
-              className="kc-join-group-button"
-              onClick={toggleModal}
-              data-testid="add-group-button"
-              isDisabled={!user.access?.manageGroupMembership}
-            >
-              {t("joinGroup")}
-            </Button>
-            <Checkbox
-              label={t("directMembership")}
-              key="direct-membership-check"
-              id="kc-direct-membership-checkbox"
-              onChange={() => setDirectMembership(!isDirectMembership)}
-              isChecked={isDirectMembership}
-              className="direct-membership-check"
-            />
-            <Button
-              onClick={() => leave(selectedGroups)}
-              data-testid="leave-group-button"
-              variant="link"
-              isDisabled={selectedGroups.length === 0}
-            >
-              {t("leave")}
-            </Button>
-
+            <ToolbarItem>
+              <Button
+                className="kc-join-group-button"
+                onClick={toggleModal}
+                data-testid="add-group-button"
+                isDisabled={!user.access?.manageGroupMembership}
+              >
+                {t("joinGroup")}
+              </Button>
+            </ToolbarItem>
+            <ToolbarItem>
+              <Checkbox
+                label={t("directMembership")}
+                key="direct-membership-check"
+                id="kc-direct-membership-checkbox"
+                onChange={() => setDirectMembership(!isDirectMembership)}
+                isChecked={isDirectMembership}
+                className="direct-membership-check"
+              />
+            </ToolbarItem>
+            <ToolbarItem>
+              <Button
+                onClick={() => leave(selectedGroups)}
+                data-testid="leave-group-button"
+                variant="link"
+                isDisabled={selectedGroups.length === 0}
+              >
+                {t("leave")}
+              </Button>
+            </ToolbarItem>
             {enabled && (
               <Popover
                 aria-label="Basic popover"
                 position="bottom"
                 bodyContent={<div>{t("whoWillAppearPopoverText")}</div>}
               >
-                <Button
-                  variant="link"
-                  className="kc-who-will-appear-button"
-                  key="who-will-appear-button"
-                  icon={<QuestionCircleIcon />}
-                >
-                  {t("whoWillAppearLinkText")}
-                </Button>
+                <ToolbarItem>
+                  <Button
+                    variant="link"
+                    className="kc-who-will-appear-button"
+                    key="who-will-appear-button"
+                    icon={<QuestionCircleIcon />}
+                  >
+                    {t("whoWillAppearLinkText")}
+                  </Button>
+                </ToolbarItem>
               </Popover>
             )}
           </>

--- a/src/user/user-section.css
+++ b/src/user/user-section.css
@@ -2,11 +2,6 @@
   color: var(--pf-global--danger-color--100);
 }
 
-button.pf-c-button.pf-m-primary.kc-join-group-button {
-  margin-left: var(--pf-global--spacer--md);
-  margin-right: var(--pf-global--spacer--xl);
-}
-
 .kc-consents-chip-group .pf-c-chip-group,
 kc-consents-chip-group .pf-c-chip-group__list {
   width: 100%;


### PR DESCRIPTION
## Motivation
See issue #2813 
close #2813 
## Brief Description
Added <ToolbarItem> tag around "Join Group" Button and around "Direct Membership" checkbox to create spacing between them.

## Verification Steps
1. Create a new user and assign a previously created group to that user.
2. Selected the created user and navigate to the Groups tab.
3. Observe that there is no space between the "Join Group" button and tick for the "Direct membership".

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated

## Additional Notes
![image](https://user-images.githubusercontent.com/31955648/178002255-bf673612-f0c2-464b-a722-20fdd12b37e6.png)
