### PR TITLE
Always close notifications during testing

### DIFF
--- a/cypress/e2e/client_authorization_test.spec.ts
+++ b/cypress/e2e/client_authorization_test.spec.ts
@@ -47,7 +47,7 @@ describe("Client authentication subtab", () => {
 
   it("Should update the resource server settings", () => {
     policiesSubTab.setPolicy("DISABLED").formUtils().save();
-    masthead.checkNotificationMessage("Resource successfully updated", true);
+    masthead.checkNotificationMessage("Resource successfully updated");
   });
 
   it("Should create a resource", () => {
@@ -63,7 +63,7 @@ describe("Client authentication subtab", () => {
       })
       .formUtils()
       .save();
-    masthead.checkNotificationMessage("Resource created successfully", true);
+    masthead.checkNotificationMessage("Resource created successfully");
     sidebarPage.waitForPageLoad();
     authenticationTab.formUtils().cancel();
   });
@@ -81,8 +81,7 @@ describe("Client authentication subtab", () => {
       .save();
 
     masthead.checkNotificationMessage(
-      "Authorization scope created successfully",
-      true
+      "Authorization scope created successfully"
     );
     authenticationTab.goToScopesSubTab();
     listingPage.itemExist("The scope");
@@ -106,7 +105,7 @@ describe("Client authentication subtab", () => {
       .save();
 
     cy.wait(["@get"]);
-    masthead.checkNotificationMessage("Successfully created the policy", true);
+    masthead.checkNotificationMessage("Successfully created the policy");
 
     sidebarPage.waitForPageLoad();
     authenticationTab.formUtils().cancel();
@@ -117,7 +116,7 @@ describe("Client authentication subtab", () => {
     listingPage.deleteItem("Regex policy");
     new ModalUtils().confirmModal();
 
-    masthead.checkNotificationMessage("The Policy successfully deleted", true);
+    masthead.checkNotificationMessage("The Policy successfully deleted");
   });
 
   it("Should create a client policy", () => {
@@ -136,7 +135,7 @@ describe("Client authentication subtab", () => {
       .formUtils()
       .save();
     cy.wait(["@get"]);
-    masthead.checkNotificationMessage("Successfully created the policy", true);
+    masthead.checkNotificationMessage("Successfully created the policy");
 
     sidebarPage.waitForPageLoad();
     authenticationTab.formUtils().cancel();
@@ -153,10 +152,7 @@ describe("Client authentication subtab", () => {
     cy.intercept(
       "/admin/realms/master/clients/*/authz/resource-server/resource?first=0&max=10&permission=false"
     ).as("load");
-    masthead.checkNotificationMessage(
-      "Successfully created the permission",
-      true
-    );
+    masthead.checkNotificationMessage("Successfully created the permission");
     cy.wait(["@load"]);
 
     sidebarPage.waitForPageLoad();
@@ -167,7 +163,7 @@ describe("Client authentication subtab", () => {
     const exportTab = authenticationTab.goToExportSubTab();
     sidebarPage.waitForPageLoad();
     exportTab.copy();
-    masthead.checkNotificationMessage("Authorization details copied.", true);
+    masthead.checkNotificationMessage("Authorization details copied.");
   });
 
   it("Should export auth details", () => {
@@ -176,8 +172,7 @@ describe("Client authentication subtab", () => {
     exportTab.export();
 
     masthead.checkNotificationMessage(
-      "Successfully exported authorization details.",
-      true
+      "Successfully exported authorization details."
     );
   });
 });

--- a/cypress/e2e/clients_test.spec.ts
+++ b/cypress/e2e/clients_test.spec.ts
@@ -448,7 +448,7 @@ describe("Clients test", () => {
         .save();
       commonPage
         .masthead()
-        .checkNotificationMessage("Client created successfully", true);
+        .checkNotificationMessage("Client created successfully");
     });
 
     beforeEach(() => {
@@ -473,7 +473,7 @@ describe("Clients test", () => {
     it("Should create client role", () => {
       rolesTab.goToCreateRoleFromEmptyState();
       createRealmRolePage.fillRealmRoleData(itemId).save();
-      commonPage.masthead().checkNotificationMessage("Role created", true);
+      commonPage.masthead().checkNotificationMessage("Role created");
     });
 
     it("Should update client role description", () => {
@@ -481,9 +481,7 @@ describe("Clients test", () => {
       commonPage.tableToolbarUtils().searchItem(itemId, false);
       commonPage.tableUtils().clickRowItemLink(itemId);
       createRealmRolePage.updateDescription(updateDescription).save();
-      commonPage
-        .masthead()
-        .checkNotificationMessage("The role has been saved", true);
+      commonPage.masthead().checkNotificationMessage("The role has been saved");
       createRealmRolePage.checkDescription(updateDescription);
     });
 
@@ -496,9 +494,7 @@ describe("Clients test", () => {
         .addAttribute("crud_attribute_key", "crud_attribute_value")
         .save();
       attributesTab.asseertRowItemsEqualTo(1);
-      commonPage
-        .masthead()
-        .checkNotificationMessage("The role has been saved", true);
+      commonPage.masthead().checkNotificationMessage("The role has been saved");
     });
 
     it("Should delete attribute from client role", () => {
@@ -507,15 +503,13 @@ describe("Clients test", () => {
       rolesTab.goToAttributesTab();
       cy.wait(["@load", "@load"]);
       attributesTab.deleteAttribute(1);
-      commonPage
-        .masthead()
-        .checkNotificationMessage("The role has been saved", true);
+      commonPage.masthead().checkNotificationMessage("The role has been saved");
     });
 
     it("Should create client role to be deleted", () => {
       rolesTab.goToCreateRoleFromToolbar();
       createRealmRolePage.fillRealmRoleData("client_role_to_be_deleted").save();
-      commonPage.masthead().checkNotificationMessage("Role created", true);
+      commonPage.masthead().checkNotificationMessage("Role created");
     });
 
     it("Should fail to create duplicate client role", () => {
@@ -524,8 +518,7 @@ describe("Clients test", () => {
       commonPage
         .masthead()
         .checkNotificationMessage(
-          `Could not create role: Role with name ${itemId} already exists`,
-          true
+          `Could not create role: Role with name ${itemId} already exists`
         );
     });
 
@@ -552,13 +545,13 @@ describe("Clients test", () => {
       associatedRolesPage.addAssociatedRealmRole("create-realm");
       commonPage
         .masthead()
-        .checkNotificationMessage("Associated roles have been added", true);
+        .checkNotificationMessage("Associated roles have been added");
 
       // Add associated client role
       associatedRolesPage.addAssociatedRoleFromSearchBar("create-client", true);
       commonPage
         .masthead()
-        .checkNotificationMessage("Associated roles have been added", true);
+        .checkNotificationMessage("Associated roles have been added");
 
       rolesTab.goToAssociatedRolesTab();
 
@@ -569,7 +562,7 @@ describe("Clients test", () => {
       );
       commonPage
         .masthead()
-        .checkNotificationMessage("Associated roles have been added", true);
+        .checkNotificationMessage("Associated roles have been added");
     });
 
     it("Should hide inherited roles test", () => {
@@ -592,7 +585,7 @@ describe("Clients test", () => {
 
       commonPage
         .masthead()
-        .checkNotificationMessage("Associated roles have been removed", true);
+        .checkNotificationMessage("Associated roles have been removed");
 
       commonPage.tableUtils().selectRowItemAction("manage-consent", "Remove");
       commonPage.sidebar().waitForPageLoad();
@@ -626,7 +619,7 @@ describe("Clients test", () => {
 
       commonPage
         .masthead()
-        .checkNotificationMessage("Associated roles have been removed", true);
+        .checkNotificationMessage("Associated roles have been removed");
     });
 
     it("Should delete client role test", () => {
@@ -644,7 +637,7 @@ describe("Clients test", () => {
       commonPage.modalUtils().confirmModal();
       commonPage
         .masthead()
-        .checkNotificationMessage("The role has been deleted", true);
+        .checkNotificationMessage("The role has been deleted");
     });
   });
 

--- a/cypress/e2e/identity_providers_oidc_test.spec.ts
+++ b/cypress/e2e/identity_providers_oidc_test.spec.ts
@@ -47,7 +47,7 @@ describe("OIDC identity provider test", () => {
         .shouldBeSuccessful()
         .fill(oidcProviderName, secret)
         .clickAdd();
-      masthead.checkNotificationMessage(createSuccessMsg, true);
+      masthead.checkNotificationMessage(createSuccessMsg);
       createProviderPage.shouldHaveAuthorizationUrl(authorizationUrl);
     });
 
@@ -57,7 +57,7 @@ describe("OIDC identity provider test", () => {
       addMapperPage.goToMappersTab();
       addMapperPage.emptyStateAddMapper();
       addMapperPage.addOIDCAttrImporterMapper("OIDC Attribute Importer");
-      masthead.checkNotificationMessage(createMapperSuccessMsg, true);
+      masthead.checkNotificationMessage(createMapperSuccessMsg);
     });
 
     it("should add OIDC mapper of type Claim To Role", () => {
@@ -66,7 +66,7 @@ describe("OIDC identity provider test", () => {
       addMapperPage.goToMappersTab();
       addMapperPage.addMapper();
       addMapperPage.addOIDCClaimToRoleMapper("OIDC Claim to Role");
-      masthead.checkNotificationMessage(createMapperSuccessMsg, true);
+      masthead.checkNotificationMessage(createMapperSuccessMsg);
     });
 
     it("clean up providers", () => {
@@ -75,7 +75,7 @@ describe("OIDC identity provider test", () => {
       sidebarPage.goToIdentityProviders();
       listingPage.itemExist(oidcProviderName).deleteItem(oidcProviderName);
       modalUtils.checkModalTitle(deletePrompt).confirmModal();
-      masthead.checkNotificationMessage(deleteSuccessMsg, true);
+      masthead.checkNotificationMessage(deleteSuccessMsg);
     });
   });
 });

--- a/cypress/e2e/identity_providers_saml_test.spec.ts
+++ b/cypress/e2e/identity_providers_saml_test.spec.ts
@@ -48,7 +48,7 @@ describe("SAML identity provider test", () => {
         .fillDiscoveryUrl(samlDiscoveryUrl)
         .shouldBeSuccessful()
         .clickAdd();
-      masthead.checkNotificationMessage(createSuccessMsg, true);
+      masthead.checkNotificationMessage(createSuccessMsg);
     });
 
     it("should add auth constraints to existing SAML provider", () => {
@@ -60,7 +60,7 @@ describe("SAML identity provider test", () => {
         .fillAuthnContextDeclRefs(declRefName)
         .clickDeclRefsAdd()
         .clickSave();
-      masthead.checkNotificationMessage(saveSuccessMsg, true);
+      masthead.checkNotificationMessage(saveSuccessMsg);
     });
 
     it("should add SAML mapper of type Advanced Attribute to Role", () => {
@@ -69,7 +69,7 @@ describe("SAML identity provider test", () => {
       addMapperPage.goToMappersTab();
       addMapperPage.emptyStateAddMapper();
       addMapperPage.addAdvancedAttrToRoleMapper("SAML mapper");
-      masthead.checkNotificationMessage(createMapperSuccessMsg, true);
+      masthead.checkNotificationMessage(createMapperSuccessMsg);
     });
 
     it("should add SAML mapper of type Username Template Importer", () => {
@@ -80,7 +80,7 @@ describe("SAML identity provider test", () => {
       addMapperPage.addUsernameTemplateImporterMapper(
         "SAML Username Template Importer Mapper"
       );
-      masthead.checkNotificationMessage(createMapperSuccessMsg, true);
+      masthead.checkNotificationMessage(createMapperSuccessMsg);
     });
 
     it("should add SAML mapper of type Hardcoded User Session Attribute", () => {
@@ -91,7 +91,7 @@ describe("SAML identity provider test", () => {
       addMapperPage.addHardcodedUserSessionAttrMapper(
         "Hardcoded User Session Attribute"
       );
-      masthead.checkNotificationMessage(createMapperSuccessMsg, true);
+      masthead.checkNotificationMessage(createMapperSuccessMsg);
     });
 
     it("should add SAML mapper of type Attribute Importer", () => {
@@ -100,7 +100,7 @@ describe("SAML identity provider test", () => {
       addMapperPage.goToMappersTab();
       addMapperPage.addMapper();
       addMapperPage.addSAMLAttrImporterMapper("Attribute Importer");
-      masthead.checkNotificationMessage(createMapperSuccessMsg, true);
+      masthead.checkNotificationMessage(createMapperSuccessMsg);
     });
 
     it("should add SAML mapper of type Hardcoded Role", () => {
@@ -109,7 +109,7 @@ describe("SAML identity provider test", () => {
       addMapperPage.goToMappersTab();
       addMapperPage.addMapper();
       addMapperPage.addHardcodedRoleMapper("Hardcoded Role");
-      masthead.checkNotificationMessage(createMapperSuccessMsg, true);
+      masthead.checkNotificationMessage(createMapperSuccessMsg);
     });
 
     it("should add SAML mapper of type Hardcoded Attribute", () => {
@@ -118,7 +118,7 @@ describe("SAML identity provider test", () => {
       addMapperPage.goToMappersTab();
       addMapperPage.addMapper();
       addMapperPage.addHardcodedAttrMapper("Hardcoded Attribute");
-      masthead.checkNotificationMessage(createMapperSuccessMsg, true);
+      masthead.checkNotificationMessage(createMapperSuccessMsg);
     });
 
     it("should add SAML mapper of type SAML Attribute To Role", () => {
@@ -127,7 +127,7 @@ describe("SAML identity provider test", () => {
       addMapperPage.goToMappersTab();
       addMapperPage.addMapper();
       addMapperPage.addSAMLAttributeToRoleMapper("SAML Attribute To Role");
-      masthead.checkNotificationMessage(createMapperSuccessMsg, true);
+      masthead.checkNotificationMessage(createMapperSuccessMsg);
     });
 
     it("should edit Username Template Importer mapper", () => {
@@ -136,7 +136,7 @@ describe("SAML identity provider test", () => {
       addMapperPage.goToMappersTab();
       listingPage.goToItemDetails("SAML Username Template Importer Mapper");
       addMapperPage.editUsernameTemplateImporterMapper();
-      masthead.checkNotificationMessage(saveMapperSuccessMsg, true);
+      masthead.checkNotificationMessage(saveMapperSuccessMsg);
     });
 
     it("should edit SAML mapper", () => {
@@ -145,7 +145,7 @@ describe("SAML identity provider test", () => {
       addMapperPage.goToMappersTab();
       listingPage.goToItemDetails("SAML mapper");
       addMapperPage.editSAMLorOIDCMapper();
-      masthead.checkNotificationMessage(saveMapperSuccessMsg, true);
+      masthead.checkNotificationMessage(saveMapperSuccessMsg);
     });
 
     it("clean up providers", () => {
@@ -154,7 +154,7 @@ describe("SAML identity provider test", () => {
       sidebarPage.goToIdentityProviders();
       listingPage.itemExist(samlProviderName).deleteItem(samlProviderName);
       modalUtils.checkModalTitle(deletePrompt).confirmModal();
-      masthead.checkNotificationMessage(deleteSuccessMsg, true);
+      masthead.checkNotificationMessage(deleteSuccessMsg);
     });
   });
 });

--- a/cypress/e2e/identity_providers_test.spec.ts
+++ b/cypress/e2e/identity_providers_test.spec.ts
@@ -43,7 +43,7 @@ describe("Identity provider test", () => {
         .clickAdd()
         .checkClientIdRequiredMessage(true);
       createProviderPage.fill(identityProviderName, "123").clickAdd();
-      masthead.checkNotificationMessage(createSuccessMsg, true);
+      masthead.checkNotificationMessage(createSuccessMsg);
 
       sidebarPage.goToIdentityProviders();
       listingPage.itemExist(identityProviderName);
@@ -55,7 +55,7 @@ describe("Identity provider test", () => {
         .clickItem("facebook")
         .fill("facebook", "123")
         .clickAdd();
-      masthead.checkNotificationMessage(createSuccessMsg, true);
+      masthead.checkNotificationMessage(createSuccessMsg);
     });
 
     it.skip("should change order of providers", () => {
@@ -73,7 +73,7 @@ describe("Identity provider test", () => {
         .clickItem("bitbucket")
         .fill("bitbucket", "123")
         .clickAdd();
-      masthead.checkNotificationMessage(createSuccessMsg, true);
+      masthead.checkNotificationMessage(createSuccessMsg);
 
       cy.wait(2000);
 
@@ -93,7 +93,7 @@ describe("Identity provider test", () => {
       const modalUtils = new ModalUtils();
       listingPage.deleteItem(identityProviderName);
       modalUtils.checkModalTitle(deletePrompt).confirmModal();
-      masthead.checkNotificationMessage(deleteSuccessMsg, true);
+      masthead.checkNotificationMessage(deleteSuccessMsg);
     });
 
     it("should add facebook social mapper", () => {
@@ -103,7 +103,7 @@ describe("Identity provider test", () => {
       addMapperPage.emptyStateAddMapper();
       addMapperPage.fillSocialMapper("facebook mapper");
       // addMapperPage.saveNewMapper();
-      masthead.checkNotificationMessage(createMapperSuccessMsg, true);
+      masthead.checkNotificationMessage(createMapperSuccessMsg);
     });
 
     it("should add Social mapper of type Attribute Importer", () => {
@@ -112,7 +112,7 @@ describe("Identity provider test", () => {
       addMapperPage.goToMappersTab();
       addMapperPage.addMapper();
       addMapperPage.fillSocialMapper("facebook attribute importer");
-      masthead.checkNotificationMessage(createMapperSuccessMsg, true);
+      masthead.checkNotificationMessage(createMapperSuccessMsg);
     });
 
     it("should edit facebook mapper", () => {
@@ -143,7 +143,7 @@ describe("Identity provider test", () => {
       sidebarPage.goToIdentityProviders();
       listingPage.itemExist("facebook").deleteItem("facebook");
       modalUtils.checkModalTitle(deletePrompt).confirmModal();
-      masthead.checkNotificationMessage(deleteSuccessMsg, true);
+      masthead.checkNotificationMessage(deleteSuccessMsg);
     });
   });
 });

--- a/cypress/e2e/realm_roles_test.spec.ts
+++ b/cypress/e2e/realm_roles_test.spec.ts
@@ -36,8 +36,7 @@ describe("Realm roles test", () => {
 
     // The error should inform about duplicated name/id (THIS MESSAGE DOES NOT HAVE QUOTES AS THE OTHERS)
     masthead.checkNotificationMessage(
-      "Could not create role: Role with name admin already exists",
-      true
+      "Could not create role: Role with name admin already exists"
     );
   });
 
@@ -54,7 +53,7 @@ describe("Realm roles test", () => {
     // Create
     listingPage.itemExist(itemId, false).goToCreateItem();
     createRealmRolePage.fillRealmRoleData(itemId).save();
-    masthead.checkNotificationMessage("Role created", true);
+    masthead.checkNotificationMessage("Role created");
     sidebarPage.goToRealmRoles();
 
     const fetchUrl = "/admin/realms/master/roles?first=0&max=11";
@@ -64,7 +63,7 @@ describe("Realm roles test", () => {
 
     cy.wait(["@fetch"]);
     modalUtils.checkModalTitle("Delete role?").confirmModal();
-    masthead.checkNotificationMessage("The role has been deleted", true);
+    masthead.checkNotificationMessage("The role has been deleted");
 
     listingPage.itemExist(itemId, false);
 
@@ -75,20 +74,17 @@ describe("Realm roles test", () => {
     itemId += "_" + (Math.random() + 1).toString(36).substring(7);
     listingPage.goToCreateItem();
     createRealmRolePage.fillRealmRoleData(itemId).save();
-    masthead.checkNotificationMessage("Role created", true);
+    masthead.checkNotificationMessage("Role created");
     createRealmRolePage.clickActionMenu("Delete this role");
     modalUtils.confirmModal();
-    masthead.checkNotificationMessage("The role has been deleted", true);
+    masthead.checkNotificationMessage("The role has been deleted");
     itemId = "realm_role_crud";
   });
 
   it("should not be able to delete default role", () => {
     const defaultRole = "default-roles-master";
     listingPage.itemExist(defaultRole).deleteItem(defaultRole);
-    masthead.checkNotificationMessage(
-      "You cannot delete a default role.",
-      true
-    );
+    masthead.checkNotificationMessage("You cannot delete a default role.");
   });
 
   it("Add associated roles test", () => {
@@ -97,33 +93,33 @@ describe("Realm roles test", () => {
     // Create
     listingPage.itemExist(itemId, false).goToCreateItem();
     createRealmRolePage.fillRealmRoleData(itemId).save();
-    masthead.checkNotificationMessage("Role created", true);
+    masthead.checkNotificationMessage("Role created");
 
     // Add associated realm role from action dropdown
     associatedRolesPage.addAssociatedRealmRole("create-realm");
-    masthead.checkNotificationMessage("Associated roles have been added", true);
+    masthead.checkNotificationMessage("Associated roles have been added");
 
     // Add associated realm role from search bar
     associatedRolesPage.addAssociatedRoleFromSearchBar("offline_access");
-    masthead.checkNotificationMessage("Associated roles have been added", true);
+    masthead.checkNotificationMessage("Associated roles have been added");
 
     rolesTab.goToAssociatedRolesTab();
 
     // Add associated client role from search bar
     associatedRolesPage.addAssociatedRoleFromSearchBar("manage-account", true);
-    masthead.checkNotificationMessage("Associated roles have been added", true);
+    masthead.checkNotificationMessage("Associated roles have been added");
 
     rolesTab.goToAssociatedRolesTab();
 
     // Add associated client role
     associatedRolesPage.addAssociatedRoleFromSearchBar("manage-consent", true);
-    masthead.checkNotificationMessage("Associated roles have been added", true);
+    masthead.checkNotificationMessage("Associated roles have been added");
 
     rolesTab.goToAssociatedRolesTab();
 
     // Add associated client role
     associatedRolesPage.addAssociatedRoleFromSearchBar("manage-clients", true);
-    masthead.checkNotificationMessage("Associated roles have been added", true);
+    masthead.checkNotificationMessage("Associated roles have been added");
   });
 
   it("Should search existing associated role by name", () => {
@@ -156,10 +152,7 @@ describe("Realm roles test", () => {
     modalUtils.checkModalTitle("Remove associated role?").confirmModal();
     sidebarPage.waitForPageLoad();
 
-    masthead.checkNotificationMessage(
-      "Associated roles have been removed",
-      true
-    );
+    masthead.checkNotificationMessage("Associated roles have been removed");
   });
 
   it("Should delete all roles from search bar", () => {
@@ -175,10 +168,7 @@ describe("Realm roles test", () => {
     modalUtils.checkModalTitle("Remove associated roles?").confirmModal();
     sidebarPage.waitForPageLoad();
 
-    masthead.checkNotificationMessage(
-      "Associated roles have been removed",
-      true
-    );
+    masthead.checkNotificationMessage("Associated roles have been removed");
   });
 
   it("Should delete associated roles from list test", () => {
@@ -188,15 +178,15 @@ describe("Realm roles test", () => {
     // Create
     listingPage.itemExist(itemId, false).goToCreateItem();
     createRealmRolePage.fillRealmRoleData(itemId).save();
-    masthead.checkNotificationMessage("Role created", true);
+    masthead.checkNotificationMessage("Role created");
 
     // Add associated realm role from action dropdown
     associatedRolesPage.addAssociatedRealmRole("create-realm");
-    masthead.checkNotificationMessage("Associated roles have been added", true);
+    masthead.checkNotificationMessage("Associated roles have been added");
 
     // Add associated realm role from search bar
     associatedRolesPage.addAssociatedRoleFromSearchBar("offline_access");
-    masthead.checkNotificationMessage("Associated roles have been added", true);
+    masthead.checkNotificationMessage("Associated roles have been added");
 
     rolesTab.goToAssociatedRolesTab();
 
@@ -206,19 +196,13 @@ describe("Realm roles test", () => {
     modalUtils.checkModalTitle("Remove associated role?").confirmModal();
     sidebarPage.waitForPageLoad();
 
-    masthead.checkNotificationMessage(
-      "Associated roles have been removed",
-      true
-    );
+    masthead.checkNotificationMessage("Associated roles have been removed");
     listingPage.removeItem("offline_access");
     sidebarPage.waitForPageLoad();
     modalUtils.checkModalTitle("Remove associated role?").confirmModal();
     sidebarPage.waitForPageLoad();
 
-    masthead.checkNotificationMessage(
-      "Associated roles have been removed",
-      true
-    );
+    masthead.checkNotificationMessage("Associated roles have been removed");
   });
 
   describe("edit role details", () => {
@@ -239,7 +223,7 @@ describe("Realm roles test", () => {
       listingPage.itemExist(editRoleName).goToItemDetails(editRoleName);
       createRealmRolePage.checkNameDisabled().checkDescription(description);
       createRealmRolePage.updateDescription(updateDescription).save();
-      masthead.checkNotificationMessage("The role has been saved", true);
+      masthead.checkNotificationMessage("The role has been saved");
       createRealmRolePage.checkDescription(updateDescription);
     });
 
@@ -257,7 +241,7 @@ describe("Realm roles test", () => {
       createRealmRolePage.goToAttributesTab();
       keyValue.fillKeyValue({ key: "one", value: "1" }).validateRows(2);
       keyValue.save();
-      masthead.checkNotificationMessage("The role has been saved", true);
+      masthead.checkNotificationMessage("The role has been saved");
       keyValue.validateRows(1);
     });
 

--- a/cypress/e2e/realm_settings_client_policies_test.spec.ts
+++ b/cypress/e2e/realm_settings_client_policies_test.spec.ts
@@ -174,7 +174,7 @@ describe("Realm settings client policies tab tests", () => {
       "Test again",
       "Test Again Description"
     );
-    masthead.checkNotificationMessage("New policy created", true);
+    masthead.checkNotificationMessage("New policy created");
     sidebarPage.waitForPageLoad();
     cy.wait("@save");
     masthead.closeAllAlertMessages();

--- a/cypress/e2e/realm_settings_general_tab_test.spec.ts
+++ b/cypress/e2e/realm_settings_general_tab_test.spec.ts
@@ -34,22 +34,22 @@ describe("Realm settings general tab tests", () => {
       false
     );
     realmSettingsPage.save(realmSettingsPage.generalSaveBtn);
-    masthead.checkNotificationMessage("Realm successfully updated", true);
+    masthead.checkNotificationMessage("Realm successfully updated");
     realmSettingsPage.toggleSwitch(
       realmSettingsPage.managedAccessSwitch,
       false
     );
     realmSettingsPage.save(realmSettingsPage.generalSaveBtn);
-    masthead.checkNotificationMessage("Realm successfully updated", true);
+    masthead.checkNotificationMessage("Realm successfully updated");
 
     // Enable realm
     realmSettingsPage.toggleSwitch(`${realmName}-switch`);
-    masthead.checkNotificationMessage("Realm successfully updated", true);
+    masthead.checkNotificationMessage("Realm successfully updated");
 
     // Disable realm
     realmSettingsPage.toggleSwitch(`${realmName}-switch`);
     realmSettingsPage.disableRealm();
-    masthead.checkNotificationMessage("Realm successfully updated", true);
+    masthead.checkNotificationMessage("Realm successfully updated");
 
     // Re-enable realm
     realmSettingsPage.toggleSwitch(`${realmName}-switch`);
@@ -60,7 +60,7 @@ describe("Realm settings general tab tests", () => {
     sidebarPage.goToRealmSettings();
     realmSettingsPage.fillDisplayName("display_name");
     realmSettingsPage.save(realmSettingsPage.generalSaveBtn);
-    masthead.checkNotificationMessage("Realm successfully updated", true);
+    masthead.checkNotificationMessage("Realm successfully updated");
   });
 
   it("Check Display name value", () => {
@@ -84,7 +84,7 @@ describe("Realm settings general tab tests", () => {
     sidebarPage.goToRealmSettings();
     realmSettingsPage.fillRequireSSL("All requests");
     realmSettingsPage.save(realmSettingsPage.generalSaveBtn);
-    masthead.checkNotificationMessage("Realm successfully updated", true);
+    masthead.checkNotificationMessage("Realm successfully updated");
   });
 
   it("Verify SSL all requests displays", () => {
@@ -96,7 +96,7 @@ describe("Realm settings general tab tests", () => {
     sidebarPage.goToRealmSettings();
     realmSettingsPage.fillRequireSSL("External requests");
     realmSettingsPage.save(realmSettingsPage.generalSaveBtn);
-    masthead.checkNotificationMessage("Realm successfully updated", true);
+    masthead.checkNotificationMessage("Realm successfully updated");
   });
 
   it("Verify SSL external requests displays", () => {
@@ -108,7 +108,7 @@ describe("Realm settings general tab tests", () => {
     sidebarPage.goToRealmSettings();
     realmSettingsPage.fillRequireSSL("None");
     realmSettingsPage.save(realmSettingsPage.generalSaveBtn);
-    masthead.checkNotificationMessage("Realm successfully updated", true);
+    masthead.checkNotificationMessage("Realm successfully updated");
   });
 
   it("Verify SSL None displays", () => {

--- a/cypress/e2e/realm_settings_tabs_test.spec.ts
+++ b/cypress/e2e/realm_settings_tabs_test.spec.ts
@@ -93,7 +93,7 @@ describe("Realm settings tabs tests", () => {
       "example" + (Math.random() + 1).toString(36).substring(7) + "@example.com"
     );
     cy.findByTestId(realmSettingsPage.modalTestConnectionButton).click();
-    masthead.checkNotificationMessage(msg, true);
+    masthead.checkNotificationMessage(msg);
   });
 
   it("Go to themes tab", () => {

--- a/cypress/e2e/user_fed_kerberos_test.spec.ts
+++ b/cypress/e2e/user_fed_kerberos_test.spec.ts
@@ -236,7 +236,7 @@ describe("User Fed Kerberos tests", () => {
     sidebarPage.goToUserFederation();
     priorityDialog.openDialog().checkOrder(providers);
     priorityDialog.clickSave();
-    masthead.checkNotificationMessage(changeSuccessMsg, true);
+    masthead.checkNotificationMessage(changeSuccessMsg);
   });
 
   it("Should delete a Kerberos provider from card view using the card's menu", () => {

--- a/cypress/e2e/user_fed_ldap_hardcoded_mapper_test.spec.ts
+++ b/cypress/e2e/user_fed_ldap_hardcoded_mapper_test.spec.ts
@@ -148,22 +148,22 @@ describe("User Fed LDAP mapper tests", () => {
 
     listingPage.itemExist(creationDateMapper).deleteItem(creationDateMapper);
     modalUtils.checkModalTitle(mapperDeleteTitle).confirmModal();
-    masthead.checkNotificationMessage(mapperDeletedSuccess, true);
+    masthead.checkNotificationMessage(mapperDeletedSuccess);
     listingPage.itemExist(creationDateMapper, false);
 
     listingPage.itemExist(emailMapper).deleteItem(emailMapper);
     modalUtils.checkModalTitle(mapperDeleteTitle).confirmModal();
-    masthead.checkNotificationMessage(mapperDeletedSuccess, true);
+    masthead.checkNotificationMessage(mapperDeletedSuccess);
     listingPage.itemExist(emailMapper, false);
 
     listingPage.itemExist(lastNameMapper).deleteItem(lastNameMapper);
     modalUtils.checkModalTitle(mapperDeleteTitle).confirmModal();
-    masthead.checkNotificationMessage(mapperDeletedSuccess, true);
+    masthead.checkNotificationMessage(mapperDeletedSuccess);
     listingPage.itemExist(lastNameMapper, false);
 
     listingPage.itemExist(modifyDateMapper).deleteItem(modifyDateMapper);
     modalUtils.checkModalTitle(mapperDeleteTitle).confirmModal();
-    masthead.checkNotificationMessage(mapperDeletedSuccess, true);
+    masthead.checkNotificationMessage(mapperDeletedSuccess);
     listingPage.itemExist(modifyDateMapper, false);
   });
 

--- a/cypress/e2e/user_fed_ldap_mapper_test.spec.ts
+++ b/cypress/e2e/user_fed_ldap_mapper_test.spec.ts
@@ -124,39 +124,39 @@ describe("User Fed LDAP mapper tests", () => {
 
     listingPage.itemExist(creationDateMapper).deleteItem(creationDateMapper);
     modalUtils.checkModalTitle(mapperDeleteTitle).confirmModal();
-    masthead.checkNotificationMessage(mapperDeletedSuccess, true);
+    masthead.checkNotificationMessage(mapperDeletedSuccess);
     listingPage.itemExist(creationDateMapper, false);
 
     listingPage.itemExist(emailMapper).deleteItem(emailMapper);
     modalUtils.checkModalTitle(mapperDeleteTitle).confirmModal();
-    masthead.checkNotificationMessage(mapperDeletedSuccess, true);
+    masthead.checkNotificationMessage(mapperDeletedSuccess);
     listingPage.itemExist(emailMapper, false);
 
     listingPage.itemExist(lastNameMapper).deleteItem(lastNameMapper);
     modalUtils.checkModalTitle(mapperDeleteTitle).confirmModal();
-    masthead.checkNotificationMessage(mapperDeletedSuccess, true);
+    masthead.checkNotificationMessage(mapperDeletedSuccess);
     listingPage.itemExist(lastNameMapper, false);
 
     listingPage.itemExist(modifyDateMapper).deleteItem(modifyDateMapper);
     modalUtils.checkModalTitle(mapperDeleteTitle).confirmModal();
-    masthead.checkNotificationMessage(mapperDeletedSuccess, true);
+    masthead.checkNotificationMessage(mapperDeletedSuccess);
     listingPage.itemExist(modifyDateMapper, false);
 
     listingPage.itemExist(usernameMapper).deleteItem(usernameMapper);
     modalUtils.checkModalTitle(mapperDeleteTitle).confirmModal();
-    masthead.checkNotificationMessage(mapperDeletedSuccess, true);
+    masthead.checkNotificationMessage(mapperDeletedSuccess);
     listingPage.itemExist(usernameMapper, false);
 
     listingPage.itemExist(firstNameMapper).deleteItem(firstNameMapper);
     modalUtils.checkModalTitle(mapperDeleteTitle).confirmModal();
-    masthead.checkNotificationMessage(mapperDeletedSuccess, true);
+    masthead.checkNotificationMessage(mapperDeletedSuccess);
     listingPage.itemExist(firstNameMapper, false);
 
     listingPage
       .itemExist(MsadAccountControlsMapper)
       .deleteItem(MsadAccountControlsMapper);
     modalUtils.checkModalTitle(mapperDeleteTitle).confirmModal();
-    masthead.checkNotificationMessage(mapperDeletedSuccess, true);
+    masthead.checkNotificationMessage(mapperDeletedSuccess);
   });
 
   // mapper CRUD tests

--- a/cypress/support/pages/admin_console/Masthead.ts
+++ b/cypress/support/pages/admin_console/Masthead.ts
@@ -52,12 +52,9 @@ export default class Masthead extends CommonElements {
     cy.get("#manage-account").click();
   }
 
-  checkNotificationMessage(message: string, closeNotification?: boolean) {
+  checkNotificationMessage(message: string) {
     cy.get(this.alertMessage).should("contain.text", message);
-
-    if (closeNotification) {
-      cy.get(`button[title="${message}"]`).last().click({ force: true });
-    }
+    cy.get(`button[title="${message}"]`).last().click({ force: true });
     return this;
   }
 


### PR DESCRIPTION
Many test failures are caused by to many notifications on the screen, closing them every time they are checked reduce the chance they cause issues.