### PR TITLE
fine-tuning of layout in Authorization Evaluate page (Issue 2159)

### DIFF
--- a/src/clients/authorization/AuthorizationEvaluate.tsx
+++ b/src/clients/authorization/AuthorizationEvaluate.tsx
@@ -393,6 +393,7 @@ export const AuthorizationEvaluate = ({ client }: Props) => {
             <Button
               data-testid="authorization-eval"
               id="authorization-eval"
+              className="pf-u-mr-md"
               isDisabled={!isValid}
               onClick={() => evaluate()}
             >
@@ -401,6 +402,7 @@ export const AuthorizationEvaluate = ({ client }: Props) => {
             <Button
               data-testid="authorization-revert"
               id="authorization-revert"
+              className="pf-u-mr-md"
               variant="link"
               onClick={() => reset()}
             >

--- a/src/clients/authorization/AuthorizationEvaluate.tsx
+++ b/src/clients/authorization/AuthorizationEvaluate.tsx
@@ -392,6 +392,7 @@ export const AuthorizationEvaluate = ({ client }: Props) => {
           <ActionGroup>
             <Button
               data-testid="authorization-eval"
+              id="authorization-eval"
               isDisabled={!isValid}
               onClick={() => evaluate()}
             >
@@ -399,6 +400,7 @@ export const AuthorizationEvaluate = ({ client }: Props) => {
             </Button>
             <Button
               data-testid="authorization-revert"
+              id="authorization-revert"
               variant="link"
               onClick={() => reset()}
             >

--- a/src/clients/authorization/auth-evaluate.css
+++ b/src/clients/authorization/auth-evaluate.css
@@ -20,16 +20,12 @@ button#reevaluate-btn {
   margin-right: var(--pf-global--spacer--md);
 }
 
-button#authorization-eval, button#authorization-revert {
-  margin-right: 16px;
-}
-
 .kc-identity-information, .kc-permissions {
   border: none !important;
 }
 
 .kc-identity-information > div.pf-c-card__header.kc-form-panel__header {
-  padding-top: 0px;
+  padding-top: 0;
 }
 
 #resourcesAndAuthScopes > .pf-c-form__group-control > .kc-attributes__table > thead #key, 

--- a/src/clients/authorization/auth-evaluate.css
+++ b/src/clients/authorization/auth-evaluate.css
@@ -20,4 +20,19 @@ button#reevaluate-btn {
   margin-right: var(--pf-global--spacer--md);
 }
 
+button#authorization-eval, button#authorization-revert {
+  margin-right: 16px;
+}
 
+.kc-identity-information, .kc-permissions {
+  border: none !important;
+}
+
+.kc-identity-information > div.pf-c-card__header.kc-form-panel__header {
+  padding-top: 0px;
+}
+
+#resourcesAndAuthScopes > .pf-c-form__group-control > .kc-attributes__table > thead #key, 
+#resourcesAndAuthScopes > .pf-c-form__group-control > .kc-attributes__table > thead #value {
+  display:none
+}

--- a/src/clients/authorization/key-based-attribute-input.css
+++ b/src/clients/authorization/key-based-attribute-input.css
@@ -23,13 +23,13 @@
 }
 
 .pf-c-select.kc-attribute-key-selectable {
-  width: 500px;
+  width: 400px;
 }
 
 .pf-c-select.kc-attribute-value-selectable {
-  width: 500px;
+  width: 400px;
 }
 
 .pf-c-form-control.value-input {
-  width: 350px;
+  width: 400px;
 }


### PR DESCRIPTION
## Motivation
Close #2159

![image](https://user-images.githubusercontent.com/31955648/178713543-c3ca5b92-21fb-42ff-9015-2ddc4dd90a2a.png)

## Brief Description
See #2159

## Verification Steps
Clients -> Client details -> Permissions -> Enable permissions -> Scope Name -> Cancel button -> Authorization -> Evaluate


## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated

## Additional Notes
The "Resources and Authentication Scopes" and "Contextual Attributes" stick out on the right side of the page. This was already present. I've changed the width of the input/selectable fields from 500px to 400px to make it less noticeable. 
