### PR TITLE
Replace CI trigger for Cypress

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,5 +1,9 @@
 name: Cypress
-on: push
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 jobs:
   setup:
     runs-on: ubuntu-latest
@@ -111,7 +115,7 @@ jobs:
         env:
           CYPRESS_BASE_URL: http://localhost:8080/admin/
           CYPRESS_KEYCLOAK_SERVER: http://localhost:8080
-          CYPRESS_RECORD_KEY: b8f1d15e-eab8-4ee7-8e44-c6d7cd8fc0eb
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Add Cypress videos artifacts


### PR DESCRIPTION
This will allow us to run the Cypress tests on PRs from 'external' contributors such as @dominikkawka. See #2969 for an example of a PR where these tests are not running as expected.

Also includes a change to replace the hard-coded record key for the Cypress Dashboard with a secret so that it cannot be abused by 3rd parties. A new key was generated for this and the old key should be revoked as soon as this PR has been merged.

Please hold on merging this PR until @ssilvert has added this new key to the secrets to avoid potential isssues running the tests.