### PR TITLE
User > identity provider links: Remove the ? in the modal title (Issue 1755)

### DIFF
--- a/public/resources/en/users.json
+++ b/public/resources/en/users.json
@@ -69,7 +69,7 @@
   "unlinkAccountTitle": "Unlink account from {{provider}}?",
   "unlinkAccountConfirm": "Are you sure you want to permanently unlink this account from {{provider}}?",
   "link": "Link",
-  "linkAccountTitle": "Link account to {{provider}}?",
+  "linkAccountTitle": "Link account to {{provider}}",
   "idpLinkSuccess": "Identity provider has been linked",
   "couldNotLinkIdP": "Could not link identity provider {{error}}",
   "verifyEmail": "Verify Email",


### PR DESCRIPTION
## Motivation
See #1755 
Close #1755 
## Brief Description
![image](https://user-images.githubusercontent.com/31955648/180780785-1a1f6bac-bb8b-4a6f-b212-f9d1903c7532.png)

## Verification Steps

user -> choose user -> identity provider links -> link account

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated

## Additional Notes

Instead of doing changing the value of linkAccountTitle , should I create a new key and value without the question mark at the end?