### PR TITLE
Check in Cypress Dashboard record key

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -115,7 +115,7 @@ jobs:
         env:
           CYPRESS_BASE_URL: http://localhost:8080/admin/
           CYPRESS_KEYCLOAK_SERVER: http://localhost:8080
-          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+          CYPRESS_RECORD_KEY: b8f1d15e-eab8-4ee7-8e44-c6d7cd8fc0eb
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Add Cypress videos artifacts


### PR DESCRIPTION
Due to limitations in Github Actions we need to check in the record key for the Cypress Dashboard so the tests will run in parallel.