### PR TITLE
Use new JSX transformation for React

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,6 +13,7 @@ module.exports = {
   extends: [
     "eslint:recommended",
     "plugin:react/recommended",
+    "plugin:react/jsx-runtime",
     "plugin:@typescript-eslint/base",
     "plugin:@typescript-eslint/eslint-recommended",
     "plugin:prettier/recommended",
@@ -42,6 +43,18 @@ module.exports = {
       "error",
       {
         endOfLine: "auto",
+      },
+    ],
+    // Prevent default imports from React, named imports should be used instead.
+    "no-restricted-imports": [
+      "error",
+      {
+        paths: [
+          {
+            name: "react",
+            importNames: ["default"],
+          },
+        ],
       },
     ],
   },

--- a/CODING_GUIDELINES.md
+++ b/CODING_GUIDELINES.md
@@ -40,7 +40,7 @@ A good tutorial on this approach is found in [Kent Dodds’ blog](https://kentcd
 This project uses function components and hooks over class components. When coding function components in typescript, a developer should include any specific props that they need.
 
 ```javascript
-import React, { FunctionComponent } from "react";
+import { FunctionComponent } from "react";
 
 ...
 
@@ -55,7 +55,7 @@ export const ExampleComponent: FunctionComponent<ExampleComponentProps> = ({ mes
 For components that do not have any additional props an empty object should be used instead:
 
 ```javascript
-import React, { FunctionComponent } from "react";
+import { FunctionComponent } from "react";
 
 ...
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, Suspense } from "react";
+import { FunctionComponent, Suspense } from "react";
 import { Page } from "@patternfly/react-core";
 import { HashRouter as Router, Route, Switch } from "react-router-dom";
 import { ErrorBoundary } from "react-error-boundary";

--- a/src/ForbiddenSection.tsx
+++ b/src/ForbiddenSection.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { PageSection } from "@patternfly/react-core";
 

--- a/src/PageHeader.tsx
+++ b/src/PageHeader.tsx
@@ -12,7 +12,7 @@ import {
   PageHeaderToolsItem,
 } from "@patternfly/react-core";
 import { HelpIcon } from "@patternfly/react-icons";
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 import { HelpHeader, useHelp } from "./components/help-enabler/HelpHeader";

--- a/src/PageNav.tsx
+++ b/src/PageNav.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { FormEvent, FunctionComponent } from "react";
 import { NavLink, useHistory, useRouteMatch } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import {
@@ -16,7 +16,7 @@ import { useAccess } from "./context/access/Access";
 import { routes } from "./route-config";
 import { AddRealmRoute } from "./realm/routes/AddRealm";
 
-export const PageNav: React.FunctionComponent = () => {
+export const PageNav: FunctionComponent = () => {
   const { t } = useTranslation("common");
   const { hasAccess, hasSomeAccess } = useAccess();
   const { realm } = useRealm();
@@ -27,7 +27,7 @@ export const PageNav: React.FunctionComponent = () => {
     groupId: number | string;
     itemId: number | string;
     to: string;
-    event: React.FormEvent<HTMLInputElement>;
+    event: FormEvent<HTMLInputElement>;
   };
 
   const onSelect = (item: SelectedItem) => {

--- a/src/PageNotFoundSection.tsx
+++ b/src/PageNotFoundSection.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 export const PageNotFoundSection = () => {
   return <>Page Not Found</>;
 };

--- a/src/authentication/AuthenticationSection.tsx
+++ b/src/authentication/AuthenticationSection.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { Link, useHistory } from "react-router-dom";
 import { Trans, useTranslation } from "react-i18next";
 import { sortBy } from "lodash-es";

--- a/src/authentication/BindFlowDialog.tsx
+++ b/src/authentication/BindFlowDialog.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { Controller, useForm } from "react-hook-form";
 import {

--- a/src/authentication/DuplicateFlowModal.tsx
+++ b/src/authentication/DuplicateFlowModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { FormProvider, useForm } from "react-hook-form";
 import {

--- a/src/authentication/EditFlowModal.tsx
+++ b/src/authentication/EditFlowModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { FormProvider, useForm } from "react-hook-form";
 import {

--- a/src/authentication/EmptyExecutionState.tsx
+++ b/src/authentication/EmptyExecutionState.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Button,

--- a/src/authentication/FlowDetails.tsx
+++ b/src/authentication/FlowDetails.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useHistory, useParams } from "react-router-dom";
 import { Trans, useTranslation } from "react-i18next";
 import {

--- a/src/authentication/RequiredActions.tsx
+++ b/src/authentication/RequiredActions.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { AlertVariant, Switch } from "@patternfly/react-core";
 

--- a/src/authentication/components/AddFlowDropdown.tsx
+++ b/src/authentication/components/AddFlowDropdown.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Dropdown,

--- a/src/authentication/components/DraggableTable.tsx
+++ b/src/authentication/components/DraggableTable.tsx
@@ -1,4 +1,10 @@
-import React, { ReactNode, useMemo, useRef, useState } from "react";
+import {
+  DragEvent as ReactDragEvent,
+  ReactNode,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useTranslation } from "react-i18next";
 import { get } from "lodash-es";
 import {
@@ -53,7 +59,7 @@ export function DraggableTable<T>({
     [data]
   );
 
-  const onDragStart = (evt: React.DragEvent) => {
+  const onDragStart = (evt: ReactDragEvent) => {
     evt.dataTransfer.effectAllowed = "move";
     evt.dataTransfer.setData("text/plain", evt.currentTarget.id);
     const draggedItemId = evt.currentTarget.id;
@@ -103,14 +109,14 @@ export function DraggableTable<T>({
     });
   };
 
-  const onDragLeave = (evt: React.DragEvent) => {
+  const onDragLeave = (evt: ReactDragEvent) => {
     if (!isValidDrop(evt)) {
       move(itemOrder);
       setState({ ...state, draggingToItemIndex: -1 });
     }
   };
 
-  const isValidDrop = (evt: React.DragEvent) => {
+  const isValidDrop = (evt: ReactDragEvent) => {
     const ulRect = bodyRef.current!.getBoundingClientRect();
     return (
       evt.clientX > ulRect.x &&
@@ -120,7 +126,7 @@ export function DraggableTable<T>({
     );
   };
 
-  const onDrop = (evt: React.DragEvent) => {
+  const onDrop = (evt: ReactDragEvent) => {
     if (isValidDrop(evt)) {
       onDragFinish(state.draggedItemId, state.tempItemOrder);
     } else {
@@ -128,7 +134,7 @@ export function DraggableTable<T>({
     }
   };
 
-  const onDragOver = (evt: React.DragEvent) => {
+  const onDragOver = (evt: ReactDragEvent) => {
     evt.preventDefault();
 
     const td = evt.target as HTMLTableCellElement;
@@ -161,7 +167,7 @@ export function DraggableTable<T>({
     }
   };
 
-  const onDragEnd = (evt: React.DragEvent) => {
+  const onDragEnd = (evt: ReactDragEvent) => {
     const tr = evt.target as HTMLTableRowElement;
     tr.classList.remove(styles.modifiers.ghostRow);
     tr.setAttribute("aria-pressed", "false");

--- a/src/authentication/components/EditFlow.tsx
+++ b/src/authentication/components/EditFlow.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { useForm } from "react-hook-form";
 import {

--- a/src/authentication/components/ExecutionConfigModal.tsx
+++ b/src/authentication/components/ExecutionConfigModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { FormProvider, useForm } from "react-hook-form";
 import {

--- a/src/authentication/components/FlowDiagram.tsx
+++ b/src/authentication/components/FlowDiagram.tsx
@@ -1,4 +1,4 @@
-import React, { useState, MouseEvent } from "react";
+import { useState, MouseEvent as ReactMouseEvent } from "react";
 import {
   Drawer,
   DrawerActions,
@@ -41,7 +41,7 @@ const createEdge = (fromNode: string, toNode: string) => ({
   target: toNode,
   data: {
     onEdgeClick: (
-      evt: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+      evt: ReactMouseEvent<HTMLButtonElement, MouseEvent>,
       id: string
     ) => {
       evt.stopPropagation();
@@ -217,7 +217,7 @@ export const FlowDiagram = ({
   );
   const [expandDrawer, setExpandDrawer] = useState(false);
 
-  const onElementClick = (_event: MouseEvent, element: Node | Edge) => {
+  const onElementClick = (_event: ReactMouseEvent, element: Node | Edge) => {
     if (isNode(element)) setExpandDrawer(!expandDrawer);
   };
 

--- a/src/authentication/components/FlowHeader.tsx
+++ b/src/authentication/components/FlowHeader.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import {
   DataListItem,

--- a/src/authentication/components/FlowRequirementDropdown.tsx
+++ b/src/authentication/components/FlowRequirementDropdown.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Select, SelectOption, SelectVariant } from "@patternfly/react-core";
 

--- a/src/authentication/components/FlowRow.tsx
+++ b/src/authentication/components/FlowRow.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import {
   DataListItemRow,

--- a/src/authentication/components/FlowTitle.tsx
+++ b/src/authentication/components/FlowTitle.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Card, CardBody } from "@patternfly/react-core";
 
 import "./flow-title.css";

--- a/src/authentication/components/UsedBy.tsx
+++ b/src/authentication/components/UsedBy.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import {
   Button,

--- a/src/authentication/components/diagram/ButtonEdge.tsx
+++ b/src/authentication/components/diagram/ButtonEdge.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties } from "react";
+import { CSSProperties, MouseEvent as ReactMouseEvent } from "react";
 import { PlusIcon } from "@patternfly/react-icons";
 import {
   ArrowHeadType,
@@ -22,7 +22,7 @@ type ButtonEdgeProps = {
   selected: boolean;
   data: {
     onEdgeClick: (
-      evt: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+      evt: ReactMouseEvent<HTMLButtonElement, MouseEvent>,
       id: string
     ) => void;
   };

--- a/src/authentication/components/diagram/ConditionalNode.tsx
+++ b/src/authentication/components/diagram/ConditionalNode.tsx
@@ -1,4 +1,4 @@
-import React, { memo } from "react";
+import { memo } from "react";
 import { Handle, Position } from "react-flow-renderer";
 
 type ConditionalNodeProps = {

--- a/src/authentication/components/diagram/SubFlowNode.tsx
+++ b/src/authentication/components/diagram/SubFlowNode.tsx
@@ -1,4 +1,4 @@
-import React, { memo } from "react";
+import { memo } from "react";
 import { Handle, Position } from "react-flow-renderer";
 
 type NodeProps = {

--- a/src/authentication/components/modals/AddStepModal.tsx
+++ b/src/authentication/components/modals/AddStepModal.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Button,

--- a/src/authentication/components/modals/AddSubFlowModal.tsx
+++ b/src/authentication/components/modals/AddSubFlowModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Controller, useForm } from "react-hook-form";
 import {

--- a/src/authentication/form/CreateFlow.tsx
+++ b/src/authentication/form/CreateFlow.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Link, useHistory } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { FormProvider, useForm } from "react-hook-form";

--- a/src/authentication/form/FlowType.tsx
+++ b/src/authentication/form/FlowType.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Controller, useFormContext } from "react-hook-form";
 import {

--- a/src/authentication/form/NameDescription.tsx
+++ b/src/authentication/form/NameDescription.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { useFormContext } from "react-hook-form";
 import { FormGroup, ValidatedOptions } from "@patternfly/react-core";

--- a/src/authentication/policies/OtpPolicy.tsx
+++ b/src/authentication/policies/OtpPolicy.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { Controller, useForm, useWatch } from "react-hook-form";
 import {

--- a/src/authentication/policies/PasswordPolicy.tsx
+++ b/src/authentication/policies/PasswordPolicy.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import {

--- a/src/authentication/policies/Policies.tsx
+++ b/src/authentication/policies/Policies.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Tab, Tabs, TabTitleText } from "@patternfly/react-core";
 

--- a/src/authentication/policies/PolicyRow.tsx
+++ b/src/authentication/policies/PolicyRow.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { Controller, useFormContext } from "react-hook-form";
 import {

--- a/src/authentication/policies/WebauthnPolicy.tsx
+++ b/src/authentication/policies/WebauthnPolicy.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import {
   Controller,
   FormProvider,

--- a/src/client-scopes/ChangeTypeDropdown.tsx
+++ b/src/client-scopes/ChangeTypeDropdown.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { AlertVariant, Select } from "@patternfly/react-core";
 

--- a/src/client-scopes/ClientScopesSection.tsx
+++ b/src/client-scopes/ClientScopesSection.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 import {

--- a/src/client-scopes/add/MapperDialog.tsx
+++ b/src/client-scopes/add/MapperDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Button,

--- a/src/client-scopes/details/MapperList.tsx
+++ b/src/client-scopes/details/MapperList.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { LocationDescriptorObject } from "history";
 import { Link } from "react-router-dom";

--- a/src/client-scopes/details/MappingDetails.tsx
+++ b/src/client-scopes/details/MappingDetails.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { Link, useHistory, useParams, useRouteMatch } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { FormProvider, useForm } from "react-hook-form";

--- a/src/client-scopes/details/ScopeForm.tsx
+++ b/src/client-scopes/details/ScopeForm.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { Controller, useForm, useWatch } from "react-hook-form";

--- a/src/client-scopes/details/SearchFilter.tsx
+++ b/src/client-scopes/details/SearchFilter.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Dropdown,

--- a/src/client-scopes/form/ClientScopeForm.tsx
+++ b/src/client-scopes/form/ClientScopeForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useHistory, useParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import {

--- a/src/clients/AdvancedTab.tsx
+++ b/src/clients/AdvancedTab.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { useFormContext } from "react-hook-form";
 import { AlertVariant, PageSection, Text } from "@patternfly/react-core";

--- a/src/clients/ClientDescription.tsx
+++ b/src/clients/ClientDescription.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Controller, useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { FormGroup, Switch, ValidatedOptions } from "@patternfly/react-core";

--- a/src/clients/ClientDetails.tsx
+++ b/src/clients/ClientDetails.tsx
@@ -13,7 +13,7 @@ import {
 import { InfoCircleIcon } from "@patternfly/react-icons";
 import type ClientRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientRepresentation";
 import { cloneDeep, sortBy } from "lodash-es";
-import React, { useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { Controller, FormProvider, useForm, useWatch } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useHistory, useParams } from "react-router-dom";

--- a/src/clients/ClientSessions.tsx
+++ b/src/clients/ClientSessions.tsx
@@ -1,7 +1,7 @@
 import type ClientRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientRepresentation";
 import type UserSessionRepresentation from "@keycloak/keycloak-admin-client/lib/defs/userSessionRepresentation";
 import { PageSection } from "@patternfly/react-core";
-import React from "react";
+
 import { useTranslation } from "react-i18next";
 
 import type { LoaderFunction } from "../components/table-toolbar/KeycloakDataTable";

--- a/src/clients/ClientSettings.tsx
+++ b/src/clients/ClientSettings.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { useFormContext } from "react-hook-form";
 import { Form } from "@patternfly/react-core";

--- a/src/clients/ClientsSection.tsx
+++ b/src/clients/ClientsSection.tsx
@@ -11,7 +11,7 @@ import {
 import { cellWidth, IRowData, TableText } from "@patternfly/react-table";
 import type ClientRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientRepresentation";
 import type { ClientQuery } from "@keycloak/keycloak-admin-client/lib/resources/clients";
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Link, useHistory } from "react-router-dom";
 import { useAlerts } from "../components/alert/Alerts";

--- a/src/clients/add/AccessSettings.tsx
+++ b/src/clients/add/AccessSettings.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { useFormContext } from "react-hook-form";
 import { FormGroup } from "@patternfly/react-core";

--- a/src/clients/add/CapabilityConfig.tsx
+++ b/src/clients/add/CapabilityConfig.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { Controller, useFormContext } from "react-hook-form";
 import {

--- a/src/clients/add/GeneralSettings.tsx
+++ b/src/clients/add/GeneralSettings.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import {
   FormGroup,
   Select,

--- a/src/clients/add/LoginSettingsPanel.tsx
+++ b/src/clients/add/LoginSettingsPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Controller, useFormContext } from "react-hook-form";
 import {

--- a/src/clients/add/LogoutPanel.tsx
+++ b/src/clients/add/LogoutPanel.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { Controller, useFormContext } from "react-hook-form";
 import { FormGroup, Switch, ValidatedOptions } from "@patternfly/react-core";

--- a/src/clients/add/NewClientForm.tsx
+++ b/src/clients/add/NewClientForm.tsx
@@ -7,7 +7,7 @@ import {
   WizardFooter,
 } from "@patternfly/react-core";
 import type ClientRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientRepresentation";
-import React, { useState } from "react";
+import { useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useHistory } from "react-router-dom";

--- a/src/clients/add/SamlConfig.tsx
+++ b/src/clients/add/SamlConfig.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { Controller, useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import {

--- a/src/clients/add/SamlSignature.tsx
+++ b/src/clients/add/SamlSignature.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Controller, useFormContext } from "react-hook-form";
 import {

--- a/src/clients/advanced/AddHostDialog.tsx
+++ b/src/clients/advanced/AddHostDialog.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import {

--- a/src/clients/advanced/AdvancedSettings.tsx
+++ b/src/clients/advanced/AdvancedSettings.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Control, Controller } from "react-hook-form";
 import {

--- a/src/clients/advanced/AuthenticationOverrides.tsx
+++ b/src/clients/advanced/AuthenticationOverrides.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { Control, Controller } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { sortBy } from "lodash-es";

--- a/src/clients/advanced/ClusteringPanel.tsx
+++ b/src/clients/advanced/ClusteringPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Controller, useFormContext } from "react-hook-form";
 import {

--- a/src/clients/advanced/FineGrainOpenIdConnect.tsx
+++ b/src/clients/advanced/FineGrainOpenIdConnect.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Controller, useFormContext } from "react-hook-form";
 import {

--- a/src/clients/advanced/FineGrainSamlEndpointConfig.tsx
+++ b/src/clients/advanced/FineGrainSamlEndpointConfig.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import type { Control } from "react-hook-form";
 import { ActionGroup, Button, FormGroup } from "@patternfly/react-core";

--- a/src/clients/advanced/OpenIdConnectCompatibilityModes.tsx
+++ b/src/clients/advanced/OpenIdConnectCompatibilityModes.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { Control, Controller } from "react-hook-form";
 import { ActionGroup, Button, FormGroup, Switch } from "@patternfly/react-core";

--- a/src/clients/advanced/RevocationPanel.tsx
+++ b/src/clients/advanced/RevocationPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import { useEffect, useRef } from "react";
 import { Link } from "react-router-dom";
 import { Trans, useTranslation } from "react-i18next";
 import { useFormContext } from "react-hook-form";

--- a/src/clients/advanced/SaveReset.tsx
+++ b/src/clients/advanced/SaveReset.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { ActionGroup, ActionGroupProps, Button } from "@patternfly/react-core";
 

--- a/src/clients/advanced/TokenLifespan.tsx
+++ b/src/clients/advanced/TokenLifespan.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { Control, Controller, FieldValues } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import {

--- a/src/clients/authorization/AuthorizationDataModal.tsx
+++ b/src/clients/authorization/AuthorizationDataModal.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import {
   Button,

--- a/src/clients/authorization/AuthorizationEvaluate.tsx
+++ b/src/clients/authorization/AuthorizationEvaluate.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import {

--- a/src/clients/authorization/AuthorizationEvaluateResource.tsx
+++ b/src/clients/authorization/AuthorizationEvaluateResource.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import {
   ExpandableRowContent,
   TableComposable,

--- a/src/clients/authorization/AuthorizationEvaluateResourcePolicies.tsx
+++ b/src/clients/authorization/AuthorizationEvaluateResourcePolicies.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import {
   DescriptionList,
   TextContent,

--- a/src/clients/authorization/AuthorizationExport.tsx
+++ b/src/clients/authorization/AuthorizationExport.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   FormGroup,

--- a/src/clients/authorization/DecisionStragegySelect.tsx
+++ b/src/clients/authorization/DecisionStragegySelect.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { Controller, useFormContext } from "react-hook-form";
 import { FormGroup, Radio } from "@patternfly/react-core";

--- a/src/clients/authorization/DeleteScopeDialog.tsx
+++ b/src/clients/authorization/DeleteScopeDialog.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { Alert, AlertVariant } from "@patternfly/react-core";
 

--- a/src/clients/authorization/DetailCell.tsx
+++ b/src/clients/authorization/DetailCell.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { DescriptionList } from "@patternfly/react-core";
 
 import type ResourceServerRepresentation from "@keycloak/keycloak-admin-client/lib/defs/resourceServerRepresentation";

--- a/src/clients/authorization/DetailDescription.tsx
+++ b/src/clients/authorization/DetailDescription.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Link } from "react-router-dom";
 import type { LocationDescriptor } from "history";
 import { useTranslation } from "react-i18next";

--- a/src/clients/authorization/EmptyPermissionsState.tsx
+++ b/src/clients/authorization/EmptyPermissionsState.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useHistory } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import {

--- a/src/clients/authorization/ImportDialog.tsx
+++ b/src/clients/authorization/ImportDialog.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useState } from "react";
+import { Fragment, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Alert,

--- a/src/clients/authorization/KeyBasedAttributeInput.tsx
+++ b/src/clients/authorization/KeyBasedAttributeInput.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Controller, useFieldArray, useFormContext } from "react-hook-form";
 import {

--- a/src/clients/authorization/MoreLabel.tsx
+++ b/src/clients/authorization/MoreLabel.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { Label } from "@patternfly/react-core";
 

--- a/src/clients/authorization/NewPolicyDialog.tsx
+++ b/src/clients/authorization/NewPolicyDialog.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import {
   Modal,

--- a/src/clients/authorization/PermissionDetails.tsx
+++ b/src/clients/authorization/PermissionDetails.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { Link, useHistory, useParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { Controller, FormProvider, useForm, useWatch } from "react-hook-form";

--- a/src/clients/authorization/Permissions.tsx
+++ b/src/clients/authorization/Permissions.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { Link, useHistory } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import {

--- a/src/clients/authorization/Policies.tsx
+++ b/src/clients/authorization/Policies.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { Link, useHistory } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import {

--- a/src/clients/authorization/ResourceDetails.tsx
+++ b/src/clients/authorization/ResourceDetails.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { Link, useHistory, useParams } from "react-router-dom";
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";

--- a/src/clients/authorization/Resources.tsx
+++ b/src/clients/authorization/Resources.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import {

--- a/src/clients/authorization/ResourcesPolicySelect.tsx
+++ b/src/clients/authorization/ResourcesPolicySelect.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Controller, useFormContext } from "react-hook-form";
 import { Select, SelectOption, SelectVariant } from "@patternfly/react-core";

--- a/src/clients/authorization/ScopeDetails.tsx
+++ b/src/clients/authorization/ScopeDetails.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { Link, useHistory, useParams } from "react-router-dom";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";

--- a/src/clients/authorization/ScopePicker.tsx
+++ b/src/clients/authorization/ScopePicker.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Controller, useFormContext } from "react-hook-form";
 import {

--- a/src/clients/authorization/ScopeSelect.tsx
+++ b/src/clients/authorization/ScopeSelect.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Controller, useFormContext } from "react-hook-form";
 import { Select, SelectOption, SelectVariant } from "@patternfly/react-core";

--- a/src/clients/authorization/Scopes.tsx
+++ b/src/clients/authorization/Scopes.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { Link, useHistory } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import {

--- a/src/clients/authorization/SearchDropdown.tsx
+++ b/src/clients/authorization/SearchDropdown.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { Controller, useForm } from "react-hook-form";
 import {

--- a/src/clients/authorization/Settings.tsx
+++ b/src/clients/authorization/Settings.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import {

--- a/src/clients/authorization/evaluate/Results.tsx
+++ b/src/clients/authorization/evaluate/Results.tsx
@@ -1,4 +1,4 @@
-import React, { KeyboardEvent, useMemo, useState } from "react";
+import { KeyboardEvent, useMemo, useState } from "react";
 import {
   Select,
   SelectVariant,

--- a/src/clients/authorization/policy/Aggregate.tsx
+++ b/src/clients/authorization/policy/Aggregate.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { useParams } from "react-router-dom";
 import { FormGroup } from "@patternfly/react-core";

--- a/src/clients/authorization/policy/Client.tsx
+++ b/src/clients/authorization/policy/Client.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { Controller, useFormContext } from "react-hook-form";
 import {
   SelectOption,

--- a/src/clients/authorization/policy/ClientScope.tsx
+++ b/src/clients/authorization/policy/ClientScope.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useFormContext, Controller } from "react-hook-form";
 import { FormGroup, Button, Checkbox } from "@patternfly/react-core";

--- a/src/clients/authorization/policy/Group.tsx
+++ b/src/clients/authorization/policy/Group.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useFormContext, Controller } from "react-hook-form";
 import { MinusCircleIcon } from "@patternfly/react-icons";

--- a/src/clients/authorization/policy/JavaScript.tsx
+++ b/src/clients/authorization/policy/JavaScript.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { Controller, useFormContext } from "react-hook-form";
 import { FormGroup } from "@patternfly/react-core";

--- a/src/clients/authorization/policy/LogicSelector.tsx
+++ b/src/clients/authorization/policy/LogicSelector.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { Controller, useFormContext } from "react-hook-form";
 import { FormGroup, Radio } from "@patternfly/react-core";

--- a/src/clients/authorization/policy/NameDescription.tsx
+++ b/src/clients/authorization/policy/NameDescription.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { useFormContext } from "react-hook-form";
 import { FormGroup, ValidatedOptions } from "@patternfly/react-core";

--- a/src/clients/authorization/policy/PolicyDetails.tsx
+++ b/src/clients/authorization/policy/PolicyDetails.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useState } from "react";
+import { FunctionComponent, useState } from "react";
 import { Link, useHistory, useParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { FormProvider, useForm } from "react-hook-form";

--- a/src/clients/authorization/policy/Regex.tsx
+++ b/src/clients/authorization/policy/Regex.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { useFormContext } from "react-hook-form";
 import { FormGroup } from "@patternfly/react-core";

--- a/src/clients/authorization/policy/Role.tsx
+++ b/src/clients/authorization/policy/Role.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useFormContext, Controller } from "react-hook-form";
 import { FormGroup, Button, Checkbox } from "@patternfly/react-core";

--- a/src/clients/authorization/policy/Time.tsx
+++ b/src/clients/authorization/policy/Time.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Controller, useFormContext } from "react-hook-form";
 import {

--- a/src/clients/authorization/policy/User.tsx
+++ b/src/clients/authorization/policy/User.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { UserSelect } from "../../../components/users/UserSelect";
 
 export const User = () => (

--- a/src/clients/credentials/ClientSecret.tsx
+++ b/src/clients/credentials/ClientSecret.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useFormContext } from "react-hook-form";
 import {

--- a/src/clients/credentials/Credentials.tsx
+++ b/src/clients/credentials/Credentials.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { Controller, useFormContext, useWatch } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import {

--- a/src/clients/credentials/SignedJWT.tsx
+++ b/src/clients/credentials/SignedJWT.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Controller, useFormContext } from "react-hook-form";
 import {

--- a/src/clients/credentials/X509.tsx
+++ b/src/clients/credentials/X509.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { Controller, useFormContext } from "react-hook-form";
 import { FormGroup, Switch, ValidatedOptions } from "@patternfly/react-core";

--- a/src/clients/import/ImportForm.tsx
+++ b/src/clients/import/ImportForm.tsx
@@ -6,7 +6,7 @@ import {
   PageSection,
 } from "@patternfly/react-core";
 import type ClientRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientRepresentation";
-import React, { useState } from "react";
+import { useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { Link, useHistory } from "react-router-dom";

--- a/src/clients/initial-access/AccessTokenDialog.tsx
+++ b/src/clients/initial-access/AccessTokenDialog.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import {
   Alert,

--- a/src/clients/initial-access/CreateInitialAccessToken.tsx
+++ b/src/clients/initial-access/CreateInitialAccessToken.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Controller, useForm } from "react-hook-form";
 import {

--- a/src/clients/initial-access/InitialAccessTokenList.tsx
+++ b/src/clients/initial-access/InitialAccessTokenList.tsx
@@ -1,7 +1,7 @@
 import { AlertVariant, Button, ButtonVariant } from "@patternfly/react-core";
 import { wrappable } from "@patternfly/react-table";
 import type ClientInitialAccessPresentation from "@keycloak/keycloak-admin-client/lib/defs/clientInitialAccessPresentation";
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Link, useHistory } from "react-router-dom";
 import { useAlerts } from "../../components/alert/Alerts";

--- a/src/clients/keys/Certificate.tsx
+++ b/src/clients/keys/Certificate.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { FormGroup, GenerateId } from "@patternfly/react-core";
 

--- a/src/clients/keys/GenerateKeyDialog.tsx
+++ b/src/clients/keys/GenerateKeyDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Controller,

--- a/src/clients/keys/ImportKeyDialog.tsx
+++ b/src/clients/keys/ImportKeyDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Controller, FormProvider, useForm, useWatch } from "react-hook-form";
 import {

--- a/src/clients/keys/Keys.tsx
+++ b/src/clients/keys/Keys.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import FileSaver from "file-saver";
 import {

--- a/src/clients/keys/SamlImportKeyDialog.tsx
+++ b/src/clients/keys/SamlImportKeyDialog.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { FormProvider, useFormContext } from "react-hook-form";
 import { AlertVariant } from "@patternfly/react-core";

--- a/src/clients/keys/SamlKeys.tsx
+++ b/src/clients/keys/SamlKeys.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useState } from "react";
+import { Fragment, useState } from "react";
 import FileSaver from "file-saver";
 import { useTranslation } from "react-i18next";
 import { Controller, useFormContext } from "react-hook-form";

--- a/src/clients/keys/SamlKeysDialog.tsx
+++ b/src/clients/keys/SamlKeysDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import FileSaver from "file-saver";
 import { useTranslation } from "react-i18next";
 import { FormProvider, useForm } from "react-hook-form";

--- a/src/clients/keys/StoreSettings.tsx
+++ b/src/clients/keys/StoreSettings.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { useFormContext } from "react-hook-form";
 import { FormGroup } from "@patternfly/react-core";

--- a/src/clients/scopes/AddScopeDialog.tsx
+++ b/src/clients/scopes/AddScopeDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Button,

--- a/src/clients/scopes/ClientScopes.tsx
+++ b/src/clients/scopes/ClientScopes.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import {

--- a/src/clients/scopes/CopyToClipboardButton.tsx
+++ b/src/clients/scopes/CopyToClipboardButton.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   ClipboardCopyButton,

--- a/src/clients/scopes/DecicatedScope.tsx
+++ b/src/clients/scopes/DecicatedScope.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   AlertVariant,

--- a/src/clients/scopes/DedicatedScopes.tsx
+++ b/src/clients/scopes/DedicatedScopes.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useHistory, useParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import {

--- a/src/clients/scopes/EvaluateScopes.tsx
+++ b/src/clients/scopes/EvaluateScopes.tsx
@@ -23,7 +23,7 @@ import type ProtocolMapperRepresentation from "@keycloak/keycloak-admin-client/l
 import type RoleRepresentation from "@keycloak/keycloak-admin-client/lib/defs/roleRepresentation";
 import type { ProtocolMapperTypeRepresentation } from "@keycloak/keycloak-admin-client/lib/defs/serverInfoRepesentation";
 import type UserRepresentation from "@keycloak/keycloak-admin-client/lib/defs/userRepresentation";
-import React, { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useHelp } from "../../components/help-enabler/HelpHeader";
 import { HelpItem } from "../../components/help-enabler/HelpItem";

--- a/src/clients/scopes/GeneratedCodeTab.tsx
+++ b/src/clients/scopes/GeneratedCodeTab.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import {
   CodeBlock,

--- a/src/clients/service-account/ServiceAccount.tsx
+++ b/src/clients/service-account/ServiceAccount.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { Link } from "react-router-dom";
 import { Trans, useTranslation } from "react-i18next";
 import { AlertVariant, PageSection } from "@patternfly/react-core";

--- a/src/components/alert/AlertPanel.tsx
+++ b/src/components/alert/AlertPanel.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import {
   AlertGroup,
   Alert,

--- a/src/components/alert/Alerts.tsx
+++ b/src/components/alert/Alerts.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, FunctionComponent, useState } from "react";
+import { createContext, FunctionComponent, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { AlertVariant } from "@patternfly/react-core";
 import axios from "axios";

--- a/src/components/bread-crumb/GroupBreadCrumbs.tsx
+++ b/src/components/bread-crumb/GroupBreadCrumbs.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import { Link, useHistory, useLocation } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { Breadcrumb, BreadcrumbItem } from "@patternfly/react-core";

--- a/src/components/bread-crumb/PageBreadCrumbs.tsx
+++ b/src/components/bread-crumb/PageBreadCrumbs.tsx
@@ -1,4 +1,4 @@
-import React, { isValidElement } from "react";
+import { isValidElement } from "react";
 import { Link } from "react-router-dom";
 import useBreadcrumbs, {
   BreadcrumbData,

--- a/src/components/client-scope/ClientScopeTypes.tsx
+++ b/src/components/client-scope/ClientScopeTypes.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 
 import type { TFunction } from "i18next";
 import { useTranslation } from "react-i18next";

--- a/src/components/client/ClientSelect.tsx
+++ b/src/components/client/ClientSelect.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Controller, useFormContext } from "react-hook-form";
 import {

--- a/src/components/confirm-dialog/ConfirmDialog.test.tsx
+++ b/src/components/confirm-dialog/ConfirmDialog.test.tsx
@@ -1,7 +1,6 @@
 /**
  * @vitest-environment jsdom
  */
-import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { useConfirmDialog } from "./ConfirmDialog";

--- a/src/components/confirm-dialog/ConfirmDialog.tsx
+++ b/src/components/confirm-dialog/ConfirmDialog.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, ReactNode, useState } from "react";
+import { ReactElement, ReactNode, useState } from "react";
 import {
   Button,
   ButtonVariant,

--- a/src/components/data-loader/DataLoader.test.tsx
+++ b/src/components/data-loader/DataLoader.test.tsx
@@ -5,7 +5,7 @@ import type KeycloakAdminClient from "@keycloak/keycloak-admin-client";
 import type { ServerInfoRepresentation } from "@keycloak/keycloak-admin-client/lib/defs/serverInfoRepesentation";
 import { render, waitFor } from "@testing-library/react";
 import type Keycloak from "keycloak-js";
-import React, { FunctionComponent } from "react";
+import { FunctionComponent } from "react";
 import { HashRouter } from "react-router-dom";
 import { describe, expect, it } from "vitest";
 import { AccessContextProvider } from "../../context/access/Access";

--- a/src/components/data-loader/DataLoader.tsx
+++ b/src/components/data-loader/DataLoader.tsx
@@ -1,4 +1,4 @@
-import React, { DependencyList, useState } from "react";
+import { DependencyList, ReactNode, useState } from "react";
 
 import { useFetch } from "../../context/auth/AdminClient";
 import { KeycloakSpinner } from "../keycloak-spinner/KeycloakSpinner";
@@ -6,7 +6,7 @@ import { KeycloakSpinner } from "../keycloak-spinner/KeycloakSpinner";
 type DataLoaderProps<T> = {
   loader: () => Promise<T>;
   deps?: DependencyList;
-  children: ((arg: T) => any) | React.ReactNode;
+  children: ((arg: T) => any) | ReactNode;
 };
 
 export function DataLoader<T>(props: DataLoaderProps<T>) {

--- a/src/components/download-dialog/DownloadDialog.tsx
+++ b/src/components/download-dialog/DownloadDialog.tsx
@@ -11,7 +11,7 @@ import {
   StackItem,
 } from "@patternfly/react-core";
 import FileSaver from "file-saver";
-import React, { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useAdminClient, useFetch } from "../../context/auth/AdminClient";
 import { useServerInfo } from "../../context/server-info/ServerInfoProvider";

--- a/src/components/dynamic/BooleanComponent.tsx
+++ b/src/components/dynamic/BooleanComponent.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Controller, useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { FormGroup, Switch } from "@patternfly/react-core";

--- a/src/components/dynamic/ClientSelectComponent.tsx
+++ b/src/components/dynamic/ClientSelectComponent.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import type { ComponentProps } from "./components";
 import { ClientSelect } from "../client/ClientSelect";
 

--- a/src/components/dynamic/DynamicComponents.tsx
+++ b/src/components/dynamic/DynamicComponents.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import type { ConfigPropertyRepresentation } from "@keycloak/keycloak-admin-client/lib/defs/authenticatorConfigInfoRepresentation";
 
 import { COMPONENTS, isValidComponentType } from "./components";

--- a/src/components/dynamic/FileComponent.tsx
+++ b/src/components/dynamic/FileComponent.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Controller, useFormContext } from "react-hook-form";
 import { FileUpload, FormGroup } from "@patternfly/react-core";

--- a/src/components/dynamic/GroupComponent.tsx
+++ b/src/components/dynamic/GroupComponent.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Controller, useFormContext } from "react-hook-form";
 import {

--- a/src/components/dynamic/ListComponent.tsx
+++ b/src/components/dynamic/ListComponent.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Controller, useFormContext } from "react-hook-form";
 import {

--- a/src/components/dynamic/MapComponent.tsx
+++ b/src/components/dynamic/MapComponent.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { FormGroup } from "@patternfly/react-core";
 

--- a/src/components/dynamic/MultivaluedListComponent.tsx
+++ b/src/components/dynamic/MultivaluedListComponent.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Controller, useFormContext } from "react-hook-form";
 import {

--- a/src/components/dynamic/MultivaluedScopesComponent.tsx
+++ b/src/components/dynamic/MultivaluedScopesComponent.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Controller, useFormContext } from "react-hook-form";
 import { Button, Chip, ChipGroup, FormGroup } from "@patternfly/react-core";

--- a/src/components/dynamic/MultivaluedStringComponent.tsx
+++ b/src/components/dynamic/MultivaluedStringComponent.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { FormGroup } from "@patternfly/react-core";
 

--- a/src/components/dynamic/RoleComponent.tsx
+++ b/src/components/dynamic/RoleComponent.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { Controller, useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import {

--- a/src/components/dynamic/ScriptComponent.tsx
+++ b/src/components/dynamic/ScriptComponent.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Controller, useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { FormGroup } from "@patternfly/react-core";

--- a/src/components/dynamic/StringComponent.tsx
+++ b/src/components/dynamic/StringComponent.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { useFormContext } from "react-hook-form";
 import { FormGroup } from "@patternfly/react-core";

--- a/src/components/error/ErrorRenderer.tsx
+++ b/src/components/error/ErrorRenderer.tsx
@@ -5,7 +5,7 @@ import {
   AlertVariant,
   PageSection,
 } from "@patternfly/react-core";
-import React from "react";
+
 import type { FallbackProps } from "react-error-boundary";
 import { useTranslation } from "react-i18next";
 

--- a/src/components/external-link/FormattedLink.tsx
+++ b/src/components/external-link/FormattedLink.tsx
@@ -1,4 +1,4 @@
-import React, { AnchorHTMLAttributes } from "react";
+import { AnchorHTMLAttributes } from "react";
 import { ExternalLinkAltIcon } from "@patternfly/react-icons";
 import type { IFormatter, IFormatterValueType } from "@patternfly/react-table";
 

--- a/src/components/form-access/FormAccess.test.tsx
+++ b/src/components/form-access/FormAccess.test.tsx
@@ -1,7 +1,6 @@
 /**
  * @vitest-environment jsdom
  */
-import React from "react";
 import type WhoAmIRepresentation from "@keycloak/keycloak-admin-client/lib/defs/whoAmIRepresentation";
 import { FormGroup, Switch } from "@patternfly/react-core";
 import { render, screen } from "@testing-library/react";

--- a/src/components/form-access/FormAccess.tsx
+++ b/src/components/form-access/FormAccess.tsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   Children,
   cloneElement,
   FunctionComponent,

--- a/src/components/group/GroupPath.tsx
+++ b/src/components/group/GroupPath.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { useState } from "react";
 import { Tooltip } from "@patternfly/react-core";
 import type { TableTextProps } from "@patternfly/react-table";
 
@@ -27,7 +27,7 @@ export const GroupPath = ({
   onMouseEnter: onMouseEnterProp,
   ...props
 }: GroupPathProps) => {
-  const [tooltip, setTooltip] = React.useState("");
+  const [tooltip, setTooltip] = useState("");
   const onMouseEnter = (event: any) => {
     setTooltip(path!);
     onMouseEnterProp?.(event);

--- a/src/components/group/GroupPickerDialog.tsx
+++ b/src/components/group/GroupPickerDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Breadcrumb,

--- a/src/components/help-enabler/HelpHeader.tsx
+++ b/src/components/help-enabler/HelpHeader.tsx
@@ -9,7 +9,7 @@ import {
   TextContent,
 } from "@patternfly/react-core";
 import { ExternalLinkAltIcon, HelpIcon } from "@patternfly/react-icons";
-import React, { createContext, FunctionComponent, useState } from "react";
+import { createContext, FunctionComponent, useState } from "react";
 import { useTranslation } from "react-i18next";
 import useRequiredContext from "../../utils/useRequiredContext";
 import helpUrls from "../../help-urls";

--- a/src/components/help-enabler/HelpItem.tsx
+++ b/src/components/help-enabler/HelpItem.tsx
@@ -1,6 +1,6 @@
 import { Popover } from "@patternfly/react-core";
 import { HelpIcon } from "@patternfly/react-icons";
-import React, { isValidElement, ReactNode } from "react";
+import { isValidElement, ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { useHelp } from "./HelpHeader";
 

--- a/src/components/json-file-upload/FileUploadForm.tsx
+++ b/src/components/json-file-upload/FileUploadForm.tsx
@@ -1,4 +1,9 @@
-import React, { useState } from "react";
+import {
+  ChangeEvent,
+  DragEvent as ReactDragEvent,
+  MouseEvent as ReactMouseEvent,
+  useState,
+} from "react";
 import {
   FormGroup,
   FileUpload,
@@ -18,9 +23,9 @@ type FileUploadType = {
 };
 
 export type FileUploadEvent =
-  | React.DragEvent<HTMLElement> // User dragged/dropped a file
-  | React.ChangeEvent<HTMLTextAreaElement> // User typed in the TextArea
-  | React.MouseEvent<HTMLButtonElement, MouseEvent>; // User clicked Clear button
+  | ReactDragEvent<HTMLElement> // User dragged/dropped a file
+  | ChangeEvent<HTMLTextAreaElement> // User typed in the TextArea
+  | ReactMouseEvent<HTMLButtonElement, MouseEvent>; // User clicked Clear button
 
 export type FileUploadFormProps = Omit<FileUploadProps, "onChange"> & {
   id: string;

--- a/src/components/json-file-upload/JsonFileUpload.tsx
+++ b/src/components/json-file-upload/JsonFileUpload.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Language } from "@patternfly/react-code-editor";
 
 import { FileUploadForm, FileUploadFormProps } from "./FileUploadForm";

--- a/src/components/key-value-form/AttributeForm.tsx
+++ b/src/components/key-value-form/AttributeForm.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { FormProvider, UseFormMethods } from "react-hook-form";
 import { ActionGroup, Button } from "@patternfly/react-core";

--- a/src/components/key-value-form/KeyValueInput.tsx
+++ b/src/components/key-value-form/KeyValueInput.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { useFieldArray, useFormContext, useWatch } from "react-hook-form";
 import {

--- a/src/components/keycloak-card/KeycloakCard.tsx
+++ b/src/components/keycloak-card/KeycloakCard.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useState } from "react";
+import { ReactElement, useState } from "react";
 import {
   Card,
   CardHeader,

--- a/src/components/keycloak-spinner/KeycloakSpinner.tsx
+++ b/src/components/keycloak-spinner/KeycloakSpinner.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Spinner } from "@patternfly/react-core";
 
 export const KeycloakSpinner = () => (

--- a/src/components/keycloak-tabs/KeycloakTabs.tsx
+++ b/src/components/keycloak-tabs/KeycloakTabs.tsx
@@ -1,4 +1,4 @@
-import React, { Children, isValidElement, useState } from "react";
+import { Children, isValidElement, useState } from "react";
 import { useHistory, useRouteMatch } from "react-router-dom";
 import { TabProps, Tabs, TabsProps } from "@patternfly/react-core";
 import { useFormContext } from "react-hook-form";
@@ -30,7 +30,9 @@ export const KeycloakTabs = ({
   const match = useRouteMatch();
   const params = match.params as { [index: string]: string };
   const history = useHistory();
-  const form = useFormContext();
+  const form = useFormContext() as
+    | ReturnType<typeof useFormContext>
+    | undefined;
   const [key, setKey] = useState("");
 
   const firstTab = Children.toArray(children)[0];
@@ -47,7 +49,7 @@ export const KeycloakTabs = ({
     messageKey: "common:leaveDirtyConfirm",
     continueButtonLabel: "common:leave",
     onConfirm: () => {
-      form.reset();
+      form?.reset();
       history.push(createUrl(path, { ...params, [paramName]: key as string }));
     },
   });

--- a/src/components/keycloak-text-area/KeycloakTextArea.tsx
+++ b/src/components/keycloak-text-area/KeycloakTextArea.tsx
@@ -1,5 +1,5 @@
 import { TextArea, TextAreaProps } from "@patternfly/react-core";
-import React, { ComponentProps, forwardRef, HTMLProps } from "react";
+import { ComponentProps, forwardRef, HTMLProps } from "react";
 
 // PatternFly changes the signature of the 'onChange' handler for textarea elements.
 // This causes issues with React Hook Form as it expects the default signature for a textarea element.

--- a/src/components/keycloak-text-input/KeycloakTextInput.tsx
+++ b/src/components/keycloak-text-input/KeycloakTextInput.tsx
@@ -1,5 +1,5 @@
 import { TextInput, TextInputProps } from "@patternfly/react-core";
-import React, { ComponentProps, forwardRef, HTMLProps } from "react";
+import { ComponentProps, forwardRef, HTMLProps } from "react";
 
 // PatternFly changes the signature of the 'onChange' handler for input elements.
 // This causes issues with React Hook Form as it expects the default signature for an input element.

--- a/src/components/list-empty-state/ListEmptyState.tsx
+++ b/src/components/list-empty-state/ListEmptyState.tsx
@@ -1,4 +1,4 @@
-import React, { MouseEventHandler } from "react";
+import { ComponentClass, MouseEventHandler, ReactNode } from "react";
 import {
   EmptyState,
   EmptyStateIcon,
@@ -20,11 +20,11 @@ export type Action = {
 
 export type ListEmptyStateProps = {
   message: string;
-  instructions: React.ReactNode;
+  instructions: ReactNode;
   primaryActionText?: string;
   onPrimaryAction?: MouseEventHandler<HTMLButtonElement>;
   hasIcon?: boolean;
-  icon?: React.ComponentClass<SVGIconProps>;
+  icon?: ComponentClass<SVGIconProps>;
   isSearchVariant?: boolean;
   secondaryActions?: Action[];
 };

--- a/src/components/multi-line-input/MultiLineInput.tsx
+++ b/src/components/multi-line-input/MultiLineInput.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useEffect } from "react";
+import { Fragment, useEffect } from "react";
 import { useFormContext } from "react-hook-form";
 import {
   TextInput,

--- a/src/components/password-input/PasswordInput.tsx
+++ b/src/components/password-input/PasswordInput.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { forwardRef, MutableRefObject, Ref, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Button, InputGroup } from "@patternfly/react-core";
 import { EyeIcon, EyeSlashIcon } from "@patternfly/react-icons";
@@ -39,12 +39,9 @@ const PasswordInputBase = ({
   );
 };
 
-export const PasswordInput = React.forwardRef(
-  (props: PasswordInputProps, ref: React.Ref<HTMLInputElement>) => (
-    <PasswordInputBase
-      {...props}
-      innerRef={ref as React.MutableRefObject<any>}
-    />
+export const PasswordInput = forwardRef(
+  (props: PasswordInputProps, ref: Ref<HTMLInputElement>) => (
+    <PasswordInputBase {...props} innerRef={ref as MutableRefObject<any>} />
   )
 );
 PasswordInput.displayName = "PasswordInput";

--- a/src/components/permission-tab/PermissionTab.tsx
+++ b/src/components/permission-tab/PermissionTab.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { Link, useHistory } from "react-router-dom";
 import { Trans, useTranslation } from "react-i18next";
 import {

--- a/src/components/realm-selector/RealmSelector.tsx
+++ b/src/components/realm-selector/RealmSelector.tsx
@@ -11,7 +11,7 @@ import {
   SplitItem,
 } from "@patternfly/react-core";
 import { CheckIcon } from "@patternfly/react-icons";
-import React, { ReactElement, useMemo, useState } from "react";
+import { Fragment, ReactElement, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useHistory } from "react-router-dom";
 
@@ -95,7 +95,7 @@ export const RealmSelector = () => {
   ));
 
   const addRealmComponent = (
-    <React.Fragment key="Add Realm">
+    <Fragment key="Add Realm">
       {whoAmI.canCreateRealm() && (
         <>
           <Divider key="divider" />
@@ -104,7 +104,7 @@ export const RealmSelector = () => {
           </DropdownItem>
         </>
       )}
-    </React.Fragment>
+    </Fragment>
   );
 
   return (

--- a/src/components/role-mapping/AddRoleMappingModal.tsx
+++ b/src/components/role-mapping/AddRoleMappingModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Badge,

--- a/src/components/role-mapping/RoleMapping.tsx
+++ b/src/components/role-mapping/RoleMapping.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   AlertVariant,

--- a/src/components/routable-tabs/RoutableTabs.tsx
+++ b/src/components/routable-tabs/RoutableTabs.tsx
@@ -5,7 +5,7 @@ import {
   TabsProps,
 } from "@patternfly/react-core";
 import type { History, LocationDescriptorObject } from "history";
-import React, {
+import {
   Children,
   isValidElement,
   JSXElementConstructor,

--- a/src/components/scroll-form/FormPanel.tsx
+++ b/src/components/scroll-form/FormPanel.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from "react";
+import { FunctionComponent } from "react";
 import {
   Card,
   CardBody,

--- a/src/components/scroll-form/ScrollForm.tsx
+++ b/src/components/scroll-form/ScrollForm.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, FunctionComponent, ReactNode, useMemo } from "react";
+import { Fragment, FunctionComponent, ReactNode, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Grid,

--- a/src/components/scroll-form/ScrollPanel.tsx
+++ b/src/components/scroll-form/ScrollPanel.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, HTMLProps } from "react";
+import { FunctionComponent, HTMLProps } from "react";
 import { Title } from "@patternfly/react-core";
 
 import "./form-panel.css";

--- a/src/components/table-toolbar/KeycloakDataTable.tsx
+++ b/src/components/table-toolbar/KeycloakDataTable.tsx
@@ -1,4 +1,5 @@
-import React, {
+import {
+  ComponentClass,
   isValidElement,
   ReactNode,
   useEffect,
@@ -146,7 +147,7 @@ export type DataListProps<T> = Omit<
   toolbarItem?: ReactNode;
   subToolbar?: ReactNode;
   emptyState?: ReactNode;
-  icon?: React.ComponentClass<SVGIconProps>;
+  icon?: ComponentClass<SVGIconProps>;
   isNotCompact?: boolean;
   isRadio?: boolean;
   isSearching?: boolean;

--- a/src/components/table-toolbar/PaginatingTableToolbar.tsx
+++ b/src/components/table-toolbar/PaginatingTableToolbar.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, ReactNode } from "react";
+import { FunctionComponent, ReactNode } from "react";
 import {
   Pagination,
   ToggleTemplateProps,

--- a/src/components/table-toolbar/TableToolbar.tsx
+++ b/src/components/table-toolbar/TableToolbar.tsx
@@ -1,9 +1,4 @@
-import React, {
-  FunctionComponent,
-  ReactNode,
-  useState,
-  KeyboardEvent,
-} from "react";
+import { FunctionComponent, ReactNode, useState, KeyboardEvent } from "react";
 import {
   Toolbar,
   ToolbarContent,

--- a/src/components/time-selector/TimeSelector.tsx
+++ b/src/components/time-selector/TimeSelector.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   DropdownProps,

--- a/src/components/users/UserSelect.tsx
+++ b/src/components/users/UserSelect.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Controller, useFormContext } from "react-hook-form";
 import {

--- a/src/components/view-header/ViewHeader.tsx
+++ b/src/components/view-header/ViewHeader.tsx
@@ -15,7 +15,7 @@ import {
   ToolbarContent,
   ToolbarItem,
 } from "@patternfly/react-core";
-import React, {
+import {
   ReactElement,
   ReactNode,
   useState,
@@ -168,7 +168,7 @@ export const ViewHeader = ({
         {enabled && (
           <TextContent id="view-header-subkey">
             <Text>
-              {React.isValidElement(subKey)
+              {isValidElement(subKey)
                 ? subKey
                 : subKey
                 ? t(subKey as string)

--- a/src/components/wizard-section-header/WizardSectionHeader.tsx
+++ b/src/components/wizard-section-header/WizardSectionHeader.tsx
@@ -1,5 +1,5 @@
 import { Text, TextContent, Title } from "@patternfly/react-core";
-import React from "react";
+
 import "./wizard-section-header.css";
 
 export type WizardSectionHeaderProps = {

--- a/src/context/RealmsContext.tsx
+++ b/src/context/RealmsContext.tsx
@@ -1,6 +1,6 @@
 import type RealmRepresentation from "@keycloak/keycloak-admin-client/lib/defs/realmRepresentation";
 import { sortBy } from "lodash-es";
-import React, {
+import {
   createContext,
   FunctionComponent,
   useCallback,

--- a/src/context/access/Access.tsx
+++ b/src/context/access/Access.tsx
@@ -1,10 +1,5 @@
 import type { AccessType } from "@keycloak/keycloak-admin-client/lib/defs/whoAmIRepresentation";
-import React, {
-  createContext,
-  FunctionComponent,
-  useEffect,
-  useState,
-} from "react";
+import { createContext, FunctionComponent, useEffect, useState } from "react";
 import { useRealm } from "../../context/realm-context/RealmContext";
 import { useWhoAmI } from "../../context/whoami/WhoAmI";
 import useRequiredContext from "../../utils/useRequiredContext";

--- a/src/context/realm-context/RealmContext.tsx
+++ b/src/context/realm-context/RealmContext.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useEffect, useMemo } from "react";
+import { createContext, FunctionComponent, useEffect, useMemo } from "react";
 import { useRouteMatch } from "react-router-dom";
 import { RecentUsed } from "../../components/realm-selector/recent-used";
 import {
@@ -13,7 +13,7 @@ type RealmContextType = {
   realm: string;
 };
 
-export const RealmContext = React.createContext<RealmContextType | undefined>(
+export const RealmContext = createContext<RealmContextType | undefined>(
   undefined
 );
 

--- a/src/context/server-info/ServerInfoProvider.tsx
+++ b/src/context/server-info/ServerInfoProvider.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, FunctionComponent, useState } from "react";
+import { createContext, FunctionComponent, useState } from "react";
 
 import type { ServerInfoRepresentation } from "@keycloak/keycloak-admin-client/lib/defs/serverInfoRepesentation";
 import { sortProviders } from "../../util";

--- a/src/context/whoami/WhoAmI.tsx
+++ b/src/context/whoami/WhoAmI.tsx
@@ -1,6 +1,6 @@
 import type WhoAmIRepresentation from "@keycloak/keycloak-admin-client/lib/defs/whoAmIRepresentation";
 import type { AccessType } from "@keycloak/keycloak-admin-client/lib/defs/whoAmIRepresentation";
-import React, { FunctionComponent, useState } from "react";
+import { createContext, FunctionComponent, useState } from "react";
 import environment from "../../environment";
 import i18n, { DEFAULT_LOCALE } from "../../i18n";
 import useRequiredContext from "../../utils/useRequiredContext";
@@ -53,9 +53,7 @@ type WhoAmIProps = {
   whoAmI: WhoAmI;
 };
 
-export const WhoAmIContext = React.createContext<WhoAmIProps | undefined>(
-  undefined
-);
+export const WhoAmIContext = createContext<WhoAmIProps | undefined>(undefined);
 
 export const useWhoAmI = () => useRequiredContext(WhoAmIContext);
 

--- a/src/dashboard/Dashboard.tsx
+++ b/src/dashboard/Dashboard.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import { useMemo } from "react";
 import { useHistory } from "react-router-dom";
 import { Trans, useTranslation } from "react-i18next";
 import { xor } from "lodash-es";

--- a/src/dashboard/ProviderInfo.tsx
+++ b/src/dashboard/ProviderInfo.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ExpandableSection, PageSection } from "@patternfly/react-core";
 import {

--- a/src/events/AdminEvents.tsx
+++ b/src/events/AdminEvents.tsx
@@ -24,7 +24,7 @@ import {
 } from "@patternfly/react-table";
 import { CodeEditor, Language } from "@patternfly/react-code-editor";
 import type AdminEventRepresentation from "@keycloak/keycloak-admin-client/lib/defs/adminEventRepresentation";
-import React, { FunctionComponent, useMemo, useState } from "react";
+import { FunctionComponent, useMemo, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { pickBy } from "lodash-es";

--- a/src/events/EventsSection.tsx
+++ b/src/events/EventsSection.tsx
@@ -27,7 +27,7 @@ import type EventRepresentation from "@keycloak/keycloak-admin-client/lib/defs/e
 import type EventType from "@keycloak/keycloak-admin-client/lib/defs/eventTypes";
 import type { RealmEventsConfigRepresentation } from "@keycloak/keycloak-admin-client/lib/defs/realmEventsConfigRepresentation";
 import { pickBy } from "lodash-es";
-import React, { useState } from "react";
+import { useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { Trans, useTranslation } from "react-i18next";
 import { Link, useHistory } from "react-router-dom";

--- a/src/events/ResourceLinks.tsx
+++ b/src/events/ResourceLinks.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from "react";
+import { ReactElement } from "react";
 import { Link } from "react-router-dom";
 import { Tooltip } from "@patternfly/react-core";
 

--- a/src/groups/GroupAttributes.tsx
+++ b/src/groups/GroupAttributes.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { useForm } from "react-hook-form";
 import {

--- a/src/groups/GroupRoleMapping.tsx
+++ b/src/groups/GroupRoleMapping.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { AlertVariant } from "@patternfly/react-core";
 

--- a/src/groups/GroupTable.tsx
+++ b/src/groups/GroupTable.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { Link, useHistory, useLocation } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import {

--- a/src/groups/GroupsModal.tsx
+++ b/src/groups/GroupsModal.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import {
   AlertVariant,
   Button,

--- a/src/groups/GroupsSection.tsx
+++ b/src/groups/GroupsSection.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { Link, useHistory, useLocation } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import {

--- a/src/groups/Members.tsx
+++ b/src/groups/Members.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { uniqBy } from "lodash-es";

--- a/src/groups/MembersModal.tsx
+++ b/src/groups/MembersModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   AlertVariant,

--- a/src/groups/SearchGroups.tsx
+++ b/src/groups/SearchGroups.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import {

--- a/src/groups/SubGroupsContext.tsx
+++ b/src/groups/SubGroupsContext.tsx
@@ -1,5 +1,5 @@
 import type GroupRepresentation from "@keycloak/keycloak-admin-client/lib/defs/groupRepresentation";
-import React, { createContext, FunctionComponent, useState } from "react";
+import { createContext, FunctionComponent, useState } from "react";
 import useRequiredContext from "../utils/useRequiredContext";
 
 type SubGroupsProps = {

--- a/src/identity-providers/IdentityProvidersSection.tsx
+++ b/src/identity-providers/IdentityProvidersSection.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useState } from "react";
+import { Fragment, useState } from "react";
 import { Link, useHistory } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { sortBy, groupBy } from "lodash-es";

--- a/src/identity-providers/ManageOrderDialog.tsx
+++ b/src/identity-providers/ManageOrderDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { sortBy } from "lodash-es";
 import {

--- a/src/identity-providers/ProviderIconMapper.tsx
+++ b/src/identity-providers/ProviderIconMapper.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import {
   CubeIcon,
   FacebookSquareIcon,

--- a/src/identity-providers/add/AddIdentityProvider.tsx
+++ b/src/identity-providers/add/AddIdentityProvider.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Link, useHistory, useParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { FormProvider, useForm } from "react-hook-form";

--- a/src/identity-providers/add/AddMapper.tsx
+++ b/src/identity-providers/add/AddMapper.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { Link, useHistory, useParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { FormProvider, useForm } from "react-hook-form";

--- a/src/identity-providers/add/AddMapperForm.tsx
+++ b/src/identity-providers/add/AddMapperForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Controller, UseFormMethods } from "react-hook-form";
 import {

--- a/src/identity-providers/add/AddOpenIdConnect.tsx
+++ b/src/identity-providers/add/AddOpenIdConnect.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Link, useHistory, useRouteMatch } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { FormProvider, useForm } from "react-hook-form";

--- a/src/identity-providers/add/AddSamlConnect.tsx
+++ b/src/identity-providers/add/AddSamlConnect.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Link, useHistory } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { FormProvider, useForm } from "react-hook-form";

--- a/src/identity-providers/add/AdvancedSettings.tsx
+++ b/src/identity-providers/add/AdvancedSettings.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Controller, useFormContext } from "react-hook-form";
 import {

--- a/src/identity-providers/add/DescriptorSettings.tsx
+++ b/src/identity-providers/add/DescriptorSettings.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Controller, useFormContext, useWatch } from "react-hook-form";
 import {

--- a/src/identity-providers/add/DetailSettings.tsx
+++ b/src/identity-providers/add/DetailSettings.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { Link, useHistory, useParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import {

--- a/src/identity-providers/add/DiscoverySettings.tsx
+++ b/src/identity-providers/add/DiscoverySettings.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useFormContext, useWatch } from "react-hook-form";
 import {

--- a/src/identity-providers/add/ExtendedNonDiscoverySettings.tsx
+++ b/src/identity-providers/add/ExtendedNonDiscoverySettings.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Controller, useFormContext } from "react-hook-form";
 import {

--- a/src/identity-providers/add/GeneralSettings.tsx
+++ b/src/identity-providers/add/GeneralSettings.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { RedirectUrl } from "../component/RedirectUrl";
 import { ClientIdSecret } from "../component/ClientIdSecret";
 import { DisplayOrder } from "../component/DisplayOrder";

--- a/src/identity-providers/add/OIDCAuthentication.tsx
+++ b/src/identity-providers/add/OIDCAuthentication.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Controller, useFormContext, useWatch } from "react-hook-form";
 import {

--- a/src/identity-providers/add/OIDCGeneralSettings.tsx
+++ b/src/identity-providers/add/OIDCGeneralSettings.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { useFormContext } from "react-hook-form";
 import { FormGroup, ValidatedOptions } from "@patternfly/react-core";

--- a/src/identity-providers/add/OpenIdConnectSettings.tsx
+++ b/src/identity-providers/add/OpenIdConnectSettings.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useFormContext } from "react-hook-form";
 import { FormGroup, Title } from "@patternfly/react-core";
 

--- a/src/identity-providers/add/ReqAuthnConstraintsSettings.tsx
+++ b/src/identity-providers/add/ReqAuthnConstraintsSettings.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Controller, useFormContext } from "react-hook-form";
 import {

--- a/src/identity-providers/add/SamlConnectSettings.tsx
+++ b/src/identity-providers/add/SamlConnectSettings.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useFormContext } from "react-hook-form";
 import { FormGroup, Title } from "@patternfly/react-core";
 

--- a/src/identity-providers/add/SamlGeneralSettings.tsx
+++ b/src/identity-providers/add/SamlGeneralSettings.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { useFormContext } from "react-hook-form";
 import { FormGroup, ValidatedOptions } from "@patternfly/react-core";

--- a/src/identity-providers/component/ClientIdSecret.tsx
+++ b/src/identity-providers/component/ClientIdSecret.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { useFormContext } from "react-hook-form";
 import { FormGroup, ValidatedOptions } from "@patternfly/react-core";

--- a/src/identity-providers/component/DiscoveryEndpointField.tsx
+++ b/src/identity-providers/component/DiscoveryEndpointField.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useEffect, useState } from "react";
+import { ReactNode, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useFormContext } from "react-hook-form";
 import { FormGroup, Switch } from "@patternfly/react-core";

--- a/src/identity-providers/component/DisplayOrder.tsx
+++ b/src/identity-providers/component/DisplayOrder.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { Controller, useFormContext } from "react-hook-form";
 import { FormGroup, TextInput } from "@patternfly/react-core";

--- a/src/identity-providers/component/FormGroupField.tsx
+++ b/src/identity-providers/component/FormGroupField.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from "react";
+import { FunctionComponent } from "react";
 import { useTranslation } from "react-i18next";
 import { FormGroup } from "@patternfly/react-core";
 

--- a/src/identity-providers/component/RedirectUrl.tsx
+++ b/src/identity-providers/component/RedirectUrl.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { ClipboardCopy, FormGroup } from "@patternfly/react-core";
 

--- a/src/identity-providers/component/SwitchField.tsx
+++ b/src/identity-providers/component/SwitchField.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { Controller, useFormContext } from "react-hook-form";
 import { Switch } from "@patternfly/react-core";

--- a/src/identity-providers/component/TextField.tsx
+++ b/src/identity-providers/component/TextField.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useFormContext } from "react-hook-form";
 
 import { FieldProps, FormGroupField } from "./FormGroupField";

--- a/src/identity-providers/icons/FontAwesomeIcon.tsx
+++ b/src/identity-providers/icons/FontAwesomeIcon.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import environment from "../../environment";
 
 type FontAwesomeIconProps = {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,7 @@
 import "@patternfly/patternfly/patternfly-addons.css";
 import "@patternfly/react-core/dist/styles/base.css";
 
-import React, { StrictMode } from "react";
+import { StrictMode } from "react";
 import ReactDOM from "react-dom";
 
 import { App } from "./App";

--- a/src/realm-roles/AssociatedRolesModal.tsx
+++ b/src/realm-roles/AssociatedRolesModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { omit, sortBy } from "lodash-es";
 import {

--- a/src/realm-roles/AssociatedRolesTab.tsx
+++ b/src/realm-roles/AssociatedRolesTab.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useHistory, useParams, useRouteMatch } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import {

--- a/src/realm-roles/RealmRoleForm.tsx
+++ b/src/realm-roles/RealmRoleForm.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import {
   ActionGroup,
   Button,

--- a/src/realm-roles/RealmRoleTabs.tsx
+++ b/src/realm-roles/RealmRoleTabs.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useHistory, useParams, useRouteMatch } from "react-router-dom";
 import {
   AlertVariant,

--- a/src/realm-roles/RealmRolesSection.tsx
+++ b/src/realm-roles/RealmRolesSection.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { PageSection } from "@patternfly/react-core";
 import { ViewHeader } from "../components/view-header/ViewHeader";
 import { useAdminClient } from "../context/auth/AdminClient";

--- a/src/realm-roles/RolesList.tsx
+++ b/src/realm-roles/RolesList.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useState } from "react";
+import { FunctionComponent, useState } from "react";
 import { Link, useHistory, useRouteMatch } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { AlertVariant, Button, ButtonVariant } from "@patternfly/react-core";

--- a/src/realm-roles/UsersInRoleTab.tsx
+++ b/src/realm-roles/UsersInRoleTab.tsx
@@ -1,6 +1,6 @@
 import { Button, PageSection, Popover } from "@patternfly/react-core";
 import { QuestionCircleIcon } from "@patternfly/react-icons";
-import React from "react";
+
 import { useTranslation } from "react-i18next";
 import { useHistory, useParams } from "react-router-dom";
 import { useHelp } from "../components/help-enabler/HelpHeader";

--- a/src/realm-settings/AddClientProfileModal.tsx
+++ b/src/realm-settings/AddClientProfileModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { Button, Label, Modal, ModalVariant } from "@patternfly/react-core";
 import { useTranslation } from "react-i18next";
 import { useFetch, useAdminClient } from "../context/auth/AdminClient";

--- a/src/realm-settings/AddMessageBundleModal.tsx
+++ b/src/realm-settings/AddMessageBundleModal.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import {
   Button,
   ButtonVariant,

--- a/src/realm-settings/AddUserEmailModal.tsx
+++ b/src/realm-settings/AddUserEmailModal.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import {
   Button,
   ButtonVariant,

--- a/src/realm-settings/ClientProfileForm.tsx
+++ b/src/realm-settings/ClientProfileForm.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useEffect, useMemo, useState } from "react";
+import { Fragment, useEffect, useMemo, useState } from "react";
 import {
   ActionGroup,
   AlertVariant,

--- a/src/realm-settings/DefaultGroupsTab.tsx
+++ b/src/realm-settings/DefaultGroupsTab.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { Link } from "react-router-dom";
 import { Trans, useTranslation } from "react-i18next";
 import {

--- a/src/realm-settings/EmailTab.tsx
+++ b/src/realm-settings/EmailTab.tsx
@@ -8,7 +8,7 @@ import {
   Switch,
 } from "@patternfly/react-core";
 import type RealmRepresentation from "@keycloak/keycloak-admin-client/lib/defs/realmRepresentation";
-import React, { useState } from "react";
+import { useState } from "react";
 import { Controller, useForm, useWatch } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useAlerts } from "../components/alert/Alerts";

--- a/src/realm-settings/ExecutorForm.tsx
+++ b/src/realm-settings/ExecutorForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import {
   ActionGroup,
   AlertVariant,

--- a/src/realm-settings/GeneralTab.tsx
+++ b/src/realm-settings/GeneralTab.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import {

--- a/src/realm-settings/LocalizationTab.tsx
+++ b/src/realm-settings/LocalizationTab.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { cloneDeep, isEqual, uniqWith } from "lodash-es";
 import { Controller, useForm, useWatch } from "react-hook-form";

--- a/src/realm-settings/LoginTab.tsx
+++ b/src/realm-settings/LoginTab.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { FormGroup, PageSection, Switch } from "@patternfly/react-core";
 import { FormAccess } from "../components/form-access/FormAccess";

--- a/src/realm-settings/NewAttributeSettings.tsx
+++ b/src/realm-settings/NewAttributeSettings.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import {
   ActionGroup,
   AlertVariant,

--- a/src/realm-settings/NewClientPolicyCondition.tsx
+++ b/src/realm-settings/NewClientPolicyCondition.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import {

--- a/src/realm-settings/NewClientPolicyForm.tsx
+++ b/src/realm-settings/NewClientPolicyForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import {
   ActionGroup,
   AlertVariant,

--- a/src/realm-settings/PartialExport.tsx
+++ b/src/realm-settings/PartialExport.tsx
@@ -12,7 +12,7 @@ import {
   TextContent,
 } from "@patternfly/react-core";
 import FileSaver from "file-saver";
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useAlerts } from "../components/alert/Alerts";
 import { useAdminClient } from "../context/auth/AdminClient";

--- a/src/realm-settings/PartialImport.tsx
+++ b/src/realm-settings/PartialImport.tsx
@@ -1,4 +1,10 @@
-import React, { useState, useEffect } from "react";
+import {
+  useState,
+  useEffect,
+  FormEvent,
+  ChangeEvent,
+  MouseEvent as ReactMouseEvent,
+} from "react";
 import { useTranslation } from "react-i18next";
 import {
   Alert,
@@ -122,7 +128,7 @@ export const PartialImportDialog = (props: PartialImportProps) => {
 
   const handleResourceCheckBox = (
     checked: boolean,
-    event: React.FormEvent<HTMLInputElement>
+    event: FormEvent<HTMLInputElement>
   ) => {
     const resource = event.currentTarget.name as Resource;
 
@@ -144,7 +150,7 @@ export const PartialImportDialog = (props: PartialImportProps) => {
     ));
 
   const handleCollisionSelect = (
-    event: React.ChangeEvent<Element> | React.MouseEvent<Element, MouseEvent>,
+    event: ChangeEvent<Element> | ReactMouseEvent<Element, MouseEvent>,
     option: string | SelectOptionObject
   ) => {
     setCollisionOption(option as CollisionOption);

--- a/src/realm-settings/PoliciesTab.tsx
+++ b/src/realm-settings/PoliciesTab.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import {
   AlertVariant,
   Button,

--- a/src/realm-settings/ProfilesTab.tsx
+++ b/src/realm-settings/ProfilesTab.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { omit } from "lodash-es";
 import {
   ActionGroup,

--- a/src/realm-settings/RealmSettingsSection.tsx
+++ b/src/realm-settings/RealmSettingsSection.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 
 import type RealmRepresentation from "@keycloak/keycloak-admin-client/lib/defs/realmRepresentation";
 import type { RealmSettingsParams } from "./routes/RealmSettings";

--- a/src/realm-settings/RealmSettingsTabs.tsx
+++ b/src/realm-settings/RealmSettingsTabs.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { useHistory } from "react-router-dom";
 import { Controller, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";

--- a/src/realm-settings/SessionsTab.tsx
+++ b/src/realm-settings/SessionsTab.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { Controller, useForm, useWatch } from "react-hook-form";
 import {

--- a/src/realm-settings/ThemesTab.tsx
+++ b/src/realm-settings/ThemesTab.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Controller, useForm } from "react-hook-form";
 import {

--- a/src/realm-settings/TokensTab.tsx
+++ b/src/realm-settings/TokensTab.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Controller, useForm, useWatch } from "react-hook-form";
 import {

--- a/src/realm-settings/UserRegistration.tsx
+++ b/src/realm-settings/UserRegistration.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Tab, Tabs, TabTitleText } from "@patternfly/react-core";
 

--- a/src/realm-settings/event-config/AddEventTypesDialog.tsx
+++ b/src/realm-settings/event-config/AddEventTypesDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Button, Modal, ModalVariant } from "@patternfly/react-core";
 

--- a/src/realm-settings/event-config/EventConfigForm.tsx
+++ b/src/realm-settings/event-config/EventConfigForm.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { Controller, UseFormMethods } from "react-hook-form";
 import {

--- a/src/realm-settings/event-config/EventListenersForm.tsx
+++ b/src/realm-settings/event-config/EventListenersForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Controller, UseFormMethods } from "react-hook-form";
 import {

--- a/src/realm-settings/event-config/EventsTab.tsx
+++ b/src/realm-settings/event-config/EventsTab.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useForm } from "react-hook-form";
 import {

--- a/src/realm-settings/event-config/EventsTypeTable.tsx
+++ b/src/realm-settings/event-config/EventsTypeTable.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from "react";
+import { Fragment } from "react";
 import { useTranslation } from "react-i18next";
 import { Button, ToolbarItem } from "@patternfly/react-core";
 import type { IFormatterValueType } from "@patternfly/react-table";

--- a/src/realm-settings/keys/KeysListTab.tsx
+++ b/src/realm-settings/keys/KeysListTab.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useHistory } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import {

--- a/src/realm-settings/keys/KeysProvidersTab.tsx
+++ b/src/realm-settings/keys/KeysProvidersTab.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState, KeyboardEvent } from "react";
+import { useMemo, useState, KeyboardEvent } from "react";
 import { useTranslation } from "react-i18next";
 import {
   AlertVariant,

--- a/src/realm-settings/keys/KeysTab.tsx
+++ b/src/realm-settings/keys/KeysTab.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useHistory } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { Tab, TabTitleText } from "@patternfly/react-core";

--- a/src/realm-settings/keys/key-providers/KeyProviderForm.tsx
+++ b/src/realm-settings/keys/key-providers/KeyProviderForm.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { Controller, FormProvider, useForm } from "react-hook-form";

--- a/src/realm-settings/keys/key-providers/KeyProviderModal.tsx
+++ b/src/realm-settings/keys/key-providers/KeyProviderModal.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Modal, ModalVariant } from "@patternfly/react-core";
 import { useTranslation } from "react-i18next";
 import { KeyProviderForm } from "./KeyProviderForm";

--- a/src/realm-settings/security-defences/BruteForceDetection.tsx
+++ b/src/realm-settings/security-defences/BruteForceDetection.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { Controller, FormProvider, useForm, useWatch } from "react-hook-form";
 import {

--- a/src/realm-settings/security-defences/HeadersForm.tsx
+++ b/src/realm-settings/security-defences/HeadersForm.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { FormProvider, useForm } from "react-hook-form";
 import { ActionGroup, Button } from "@patternfly/react-core";

--- a/src/realm-settings/security-defences/HelpLinkTextInput.tsx
+++ b/src/realm-settings/security-defences/HelpLinkTextInput.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { FormGroup } from "@patternfly/react-core";
 

--- a/src/realm-settings/security-defences/SecurityDefenses.tsx
+++ b/src/realm-settings/security-defences/SecurityDefenses.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { PageSection, Tab, Tabs, TabTitleText } from "@patternfly/react-core";
 

--- a/src/realm-settings/security-defences/Time.tsx
+++ b/src/realm-settings/security-defences/Time.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties } from "react";
+import { CSSProperties } from "react";
 import { useTranslation } from "react-i18next";
 import { Controller, useFormContext } from "react-hook-form";
 import { FormGroup, ValidatedOptions } from "@patternfly/react-core";

--- a/src/realm-settings/user-profile/AttributesGroupDetails.tsx
+++ b/src/realm-settings/user-profile/AttributesGroupDetails.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import AttributesGroupForm from "./AttributesGroupForm";
 import { UserProfileProvider } from "./UserProfileContext";
 

--- a/src/realm-settings/user-profile/AttributesGroupForm.tsx
+++ b/src/realm-settings/user-profile/AttributesGroupForm.tsx
@@ -7,7 +7,7 @@ import {
   Text,
   TextContent,
 } from "@patternfly/react-core";
-import React, { useEffect, useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { Link, useHistory, useParams } from "react-router-dom";

--- a/src/realm-settings/user-profile/AttributesGroupTab.tsx
+++ b/src/realm-settings/user-profile/AttributesGroupTab.tsx
@@ -5,7 +5,7 @@ import {
   PageSection,
   ToolbarItem,
 } from "@patternfly/react-core";
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { Link, useHistory } from "react-router-dom";
 import { useConfirmDialog } from "../../components/confirm-dialog/ConfirmDialog";

--- a/src/realm-settings/user-profile/AttributesTab.tsx
+++ b/src/realm-settings/user-profile/AttributesTab.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Button,

--- a/src/realm-settings/user-profile/JsonEditorTab.tsx
+++ b/src/realm-settings/user-profile/JsonEditorTab.tsx
@@ -1,7 +1,7 @@
 import { CodeEditor, Language } from "@patternfly/react-code-editor";
 import { ActionGroup, Button, Form, PageSection } from "@patternfly/react-core";
 import type { editor } from "monaco-editor";
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useAlerts } from "../../components/alert/Alerts";
 import { prettyPrintJSON } from "../../util";

--- a/src/realm-settings/user-profile/UserProfileContext.tsx
+++ b/src/realm-settings/user-profile/UserProfileContext.tsx
@@ -1,6 +1,6 @@
 import type UserProfileConfig from "@keycloak/keycloak-admin-client/lib/defs/userProfileConfig";
 import { AlertVariant } from "@patternfly/react-core";
-import React, { createContext, FunctionComponent, useState } from "react";
+import { createContext, FunctionComponent, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useAlerts } from "../../components/alert/Alerts";
 import { useAdminClient, useFetch } from "../../context/auth/AdminClient";

--- a/src/realm-settings/user-profile/UserProfileTab.tsx
+++ b/src/realm-settings/user-profile/UserProfileTab.tsx
@@ -1,5 +1,5 @@
 import { Tab, TabTitleText } from "@patternfly/react-core";
-import React from "react";
+
 import { useTranslation } from "react-i18next";
 import { useHistory } from "react-router-dom";
 import {

--- a/src/realm-settings/user-profile/attribute/AddValidatorDialog.tsx
+++ b/src/realm-settings/user-profile/attribute/AddValidatorDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Modal, ModalVariant } from "@patternfly/react-core";
 import {

--- a/src/realm-settings/user-profile/attribute/AddValidatorRoleDialog.tsx
+++ b/src/realm-settings/user-profile/attribute/AddValidatorRoleDialog.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { Button, Modal, ModalVariant } from "@patternfly/react-core";
 import { FormProvider, useForm } from "react-hook-form";

--- a/src/realm-settings/user-profile/attribute/AttributeAnnotations.tsx
+++ b/src/realm-settings/user-profile/attribute/AttributeAnnotations.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { FormGroup, Grid, GridItem } from "@patternfly/react-core";
 

--- a/src/realm-settings/user-profile/attribute/AttributeGeneralSettings.tsx
+++ b/src/realm-settings/user-profile/attribute/AttributeGeneralSettings.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import {
   Divider,
   FormGroup,

--- a/src/realm-settings/user-profile/attribute/AttributePermission.tsx
+++ b/src/realm-settings/user-profile/attribute/AttributePermission.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Checkbox, FormGroup, Grid, GridItem } from "@patternfly/react-core";
 import { useTranslation } from "react-i18next";
 import { HelpItem } from "../../../components/help-enabler/HelpItem";

--- a/src/realm-settings/user-profile/attribute/AttributeValidations.tsx
+++ b/src/realm-settings/user-profile/attribute/AttributeValidations.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import {
   Button,
   ButtonVariant,

--- a/src/realm/add/NewRealmForm.tsx
+++ b/src/realm/add/NewRealmForm.tsx
@@ -7,7 +7,7 @@ import {
   Switch,
 } from "@patternfly/react-core";
 import type RealmRepresentation from "@keycloak/keycloak-admin-client/lib/defs/realmRepresentation";
-import React from "react";
+
 import { Controller, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useHistory } from "react-router-dom";

--- a/src/route-config.ts
+++ b/src/route-config.ts
@@ -1,6 +1,6 @@
 import type { TFunction } from "i18next";
 import type { AccessType } from "@keycloak/keycloak-admin-client/lib/defs/whoAmIRepresentation";
-import type { ComponentType } from "react";
+import type { ComponentType, LazyExoticComponent } from "react";
 import type { MatchOptions } from "use-react-router-breadcrumbs";
 import authenticationRoutes from "./authentication/routes";
 import clientScopesRoutes from "./client-scopes/routes";
@@ -19,7 +19,7 @@ import userRoutes from "./user/routes";
 
 export type RouteDef = {
   path: string;
-  component: ComponentType | React.LazyExoticComponent<() => JSX.Element>;
+  component: ComponentType | LazyExoticComponent<() => JSX.Element>;
   breadcrumb?: (t: TFunction) => string | ComponentType<any>;
   access: AccessType | AccessType[];
   matchOptions?: MatchOptions;

--- a/src/sessions/RevocationModal.tsx
+++ b/src/sessions/RevocationModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import {
   AlertVariant,
   Button,

--- a/src/sessions/SessionsSection.tsx
+++ b/src/sessions/SessionsSection.tsx
@@ -1,6 +1,6 @@
 import type ClientRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientRepresentation";
 import { DropdownItem, PageSection } from "@patternfly/react-core";
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { ViewHeader } from "../components/view-header/ViewHeader";

--- a/src/sessions/SessionsTable.tsx
+++ b/src/sessions/SessionsTable.tsx
@@ -7,7 +7,7 @@ import {
   ToolbarItem,
 } from "@patternfly/react-core";
 import { CubesIcon } from "@patternfly/react-icons";
-import React, { useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 

--- a/src/user-federation/ManagePriorityDialog.tsx
+++ b/src/user-federation/ManagePriorityDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { sortBy } from "lodash-es";
 import {

--- a/src/user-federation/UserFederationKerberosSettings.tsx
+++ b/src/user-federation/UserFederationKerberosSettings.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import {
   ActionGroup,
   AlertVariant,

--- a/src/user-federation/UserFederationKerberosWizard.tsx
+++ b/src/user-federation/UserFederationKerberosWizard.tsx
@@ -1,6 +1,6 @@
 import { Wizard } from "@patternfly/react-core";
 import { useTranslation } from "react-i18next";
-import React from "react";
+
 import { KerberosSettingsRequired } from "./kerberos/KerberosSettingsRequired";
 import { SettingsCache } from "./shared/SettingsCache";
 import type ComponentRepresentation from "@keycloak/keycloak-admin-client/lib/defs/componentRepresentation";

--- a/src/user-federation/UserFederationLdapSettings.tsx
+++ b/src/user-federation/UserFederationLdapSettings.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import {
   ActionGroup,
   AlertVariant,

--- a/src/user-federation/UserFederationLdapWizard.tsx
+++ b/src/user-federation/UserFederationLdapWizard.tsx
@@ -4,7 +4,7 @@ import {
   WizardContextConsumer,
   WizardFooter,
 } from "@patternfly/react-core";
-import React from "react";
+
 import { LdapSettingsGeneral } from "./ldap/LdapSettingsGeneral";
 import { LdapSettingsConnection } from "./ldap/LdapSettingsConnection";
 import { LdapSettingsSearching } from "./ldap/LdapSettingsSearching";

--- a/src/user-federation/UserFederationSection.tsx
+++ b/src/user-federation/UserFederationSection.tsx
@@ -15,7 +15,7 @@ import {
 } from "@patternfly/react-core";
 import { DatabaseIcon } from "@patternfly/react-icons";
 import type ComponentRepresentation from "@keycloak/keycloak-admin-client/lib/defs/componentRepresentation";
-import React, { useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useHistory } from "react-router-dom";
 import { useAlerts } from "../components/alert/Alerts";

--- a/src/user-federation/custom/CustomProviderSettings.tsx
+++ b/src/user-federation/custom/CustomProviderSettings.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { Link, useHistory, useParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { FormProvider, useForm } from "react-hook-form";

--- a/src/user-federation/kerberos/KerberosSettingsRequired.tsx
+++ b/src/user-federation/kerberos/KerberosSettingsRequired.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import {
   FormGroup,
   Select,

--- a/src/user-federation/ldap/LdapSettingsAdvanced.tsx
+++ b/src/user-federation/ldap/LdapSettingsAdvanced.tsx
@@ -1,6 +1,6 @@
 import { Button, FormGroup, Switch } from "@patternfly/react-core";
 import { useTranslation } from "react-i18next";
-import React from "react";
+
 import { HelpItem } from "../../components/help-enabler/HelpItem";
 import { UseFormMethods, Controller } from "react-hook-form";
 import { FormAccess } from "../../components/form-access/FormAccess";

--- a/src/user-federation/ldap/LdapSettingsConnection.tsx
+++ b/src/user-federation/ldap/LdapSettingsConnection.tsx
@@ -9,7 +9,7 @@ import {
   ValidatedOptions,
 } from "@patternfly/react-core";
 import { useTranslation } from "react-i18next";
-import React, { useState } from "react";
+import { useState } from "react";
 import { get, isEqual } from "lodash-es";
 
 import type TestLdapConnectionRepresentation from "@keycloak/keycloak-admin-client/lib/defs/testLdapConnection";

--- a/src/user-federation/ldap/LdapSettingsGeneral.tsx
+++ b/src/user-federation/ldap/LdapSettingsGeneral.tsx
@@ -5,7 +5,7 @@ import {
   SelectVariant,
 } from "@patternfly/react-core";
 import { useTranslation } from "react-i18next";
-import React, { useState } from "react";
+import { useState } from "react";
 import { HelpItem } from "../../components/help-enabler/HelpItem";
 import { UseFormMethods, Controller } from "react-hook-form";
 import { FormAccess } from "../../components/form-access/FormAccess";

--- a/src/user-federation/ldap/LdapSettingsKerberosIntegration.tsx
+++ b/src/user-federation/ldap/LdapSettingsKerberosIntegration.tsx
@@ -1,6 +1,6 @@
 import { FormGroup, Switch } from "@patternfly/react-core";
 import { useTranslation } from "react-i18next";
-import React from "react";
+
 import { HelpItem } from "../../components/help-enabler/HelpItem";
 import { UseFormMethods, Controller, useWatch } from "react-hook-form";
 import { FormAccess } from "../../components/form-access/FormAccess";

--- a/src/user-federation/ldap/LdapSettingsSearching.tsx
+++ b/src/user-federation/ldap/LdapSettingsSearching.tsx
@@ -6,7 +6,7 @@ import {
   Switch,
 } from "@patternfly/react-core";
 import { useTranslation } from "react-i18next";
-import React, { useState } from "react";
+import { useState } from "react";
 import { HelpItem } from "../../components/help-enabler/HelpItem";
 import { UseFormMethods, Controller } from "react-hook-form";
 import { FormAccess } from "../../components/form-access/FormAccess";

--- a/src/user-federation/ldap/LdapSettingsSynchronization.tsx
+++ b/src/user-federation/ldap/LdapSettingsSynchronization.tsx
@@ -1,6 +1,6 @@
 import { FormGroup, Switch } from "@patternfly/react-core";
 import { useTranslation } from "react-i18next";
-import React from "react";
+
 import { HelpItem } from "../../components/help-enabler/HelpItem";
 import { UseFormMethods, Controller } from "react-hook-form";
 import { FormAccess } from "../../components/form-access/FormAccess";

--- a/src/user-federation/ldap/mappers/LdapMapperDetails.tsx
+++ b/src/user-federation/ldap/mappers/LdapMapperDetails.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import {
   ActionGroup,
   AlertVariant,

--- a/src/user-federation/ldap/mappers/LdapMapperList.tsx
+++ b/src/user-federation/ldap/mappers/LdapMapperList.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { Link, useHistory, useParams, useRouteMatch } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import {

--- a/src/user-federation/shared/ExtendedHeader.tsx
+++ b/src/user-federation/shared/ExtendedHeader.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import {

--- a/src/user-federation/shared/Header.tsx
+++ b/src/user-federation/shared/Header.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from "react";
+import { ReactElement } from "react";
 import { useHistory, useParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import {

--- a/src/user-federation/shared/SettingsCache.tsx
+++ b/src/user-federation/shared/SettingsCache.tsx
@@ -6,7 +6,7 @@ import {
   SelectVariant,
 } from "@patternfly/react-core";
 import { useTranslation } from "react-i18next";
-import React from "react";
+
 import { HelpItem } from "../../components/help-enabler/HelpItem";
 import { UseFormMethods, useWatch, Controller } from "react-hook-form";
 import { FormAccess } from "../../components/form-access/FormAccess";

--- a/src/user/SearchUser.tsx
+++ b/src/user/SearchUser.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import {
   Button,

--- a/src/user/UserAttributes.tsx
+++ b/src/user/UserAttributes.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useForm } from "react-hook-form";
 import {

--- a/src/user/UserConsents.tsx
+++ b/src/user/UserConsents.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import {

--- a/src/user/UserCredentials.tsx
+++ b/src/user/UserCredentials.tsx
@@ -1,4 +1,10 @@
-import React, { Fragment, useMemo, useRef, useState } from "react";
+import {
+  DragEvent as ReactDragEvent,
+  Fragment,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   AlertVariant,
   Button,
@@ -171,7 +177,7 @@ export const UserCredentials = ({ user }: UserCredentialsProps) => {
     [groupedUserCredentials]
   );
 
-  const onDragStart = (evt: React.DragEvent) => {
+  const onDragStart = (evt: ReactDragEvent) => {
     evt.dataTransfer.effectAllowed = "move";
     evt.dataTransfer.setData("text/plain", evt.currentTarget.id);
     const draggedItemId = evt.currentTarget.id;
@@ -217,14 +223,14 @@ export const UserCredentials = ({ user }: UserCredentialsProps) => {
     });
   };
 
-  const onDragLeave = (evt: React.DragEvent) => {
+  const onDragLeave = (evt: ReactDragEvent) => {
     if (!isValidDrop(evt)) {
       move(itemOrder);
       setState({ ...state, draggingToItemIndex: -1 });
     }
   };
 
-  const isValidDrop = (evt: React.DragEvent) => {
+  const isValidDrop = (evt: ReactDragEvent) => {
     if (!bodyRef.current) return false;
     const ulRect = bodyRef.current.getBoundingClientRect();
     return (
@@ -235,7 +241,7 @@ export const UserCredentials = ({ user }: UserCredentialsProps) => {
     );
   };
 
-  const onDrop = (evt: React.DragEvent) => {
+  const onDrop = (evt: ReactDragEvent) => {
     if (isValidDrop(evt)) {
       onDragFinish(state.draggedItemId, state.tempItemOrder);
     } else {
@@ -243,7 +249,7 @@ export const UserCredentials = ({ user }: UserCredentialsProps) => {
     }
   };
 
-  const onDragOver = (evt: React.DragEvent) => {
+  const onDragOver = (evt: ReactDragEvent) => {
     evt.preventDefault();
     const td = evt.target as HTMLTableCellElement;
     const curListItem = td.closest("tr");
@@ -275,7 +281,7 @@ export const UserCredentials = ({ user }: UserCredentialsProps) => {
     }
   };
 
-  const onDragEnd = ({ target }: React.DragEvent) => {
+  const onDragEnd = ({ target }: ReactDragEvent) => {
     if (!(target instanceof HTMLTableRowElement)) {
       return;
     }

--- a/src/user/UserForm.tsx
+++ b/src/user/UserForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import {
   ActionGroup,
   AlertVariant,

--- a/src/user/UserGroups.tsx
+++ b/src/user/UserGroups.tsx
@@ -10,7 +10,7 @@ import { cellWidth } from "@patternfly/react-table";
 import type GroupRepresentation from "@keycloak/keycloak-admin-client/lib/defs/groupRepresentation";
 import type UserRepresentation from "@keycloak/keycloak-admin-client/lib/defs/userRepresentation";
 import { intersectionBy, sortBy } from "lodash-es";
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useAlerts } from "../components/alert/Alerts";
 import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";

--- a/src/user/UserIdPModal.tsx
+++ b/src/user/UserIdPModal.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import {
   AlertVariant,
   Button,

--- a/src/user/UserIdentityProviderLinks.tsx
+++ b/src/user/UserIdentityProviderLinks.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   AlertVariant,

--- a/src/user/UserRoleMapping.tsx
+++ b/src/user/UserRoleMapping.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { AlertVariant } from "@patternfly/react-core";
 

--- a/src/user/UserSessions.tsx
+++ b/src/user/UserSessions.tsx
@@ -1,5 +1,5 @@
 import { PageSection } from "@patternfly/react-core";
-import React from "react";
+
 import { useTranslation } from "react-i18next";
 import { useParams } from "react-router-dom";
 

--- a/src/user/UsersSection.tsx
+++ b/src/user/UsersSection.tsx
@@ -29,7 +29,7 @@ import type { IRowData } from "@patternfly/react-table";
 import type RealmRepresentation from "@keycloak/keycloak-admin-client/lib/defs/realmRepresentation";
 import type ComponentRepresentation from "@keycloak/keycloak-admin-client/lib/defs/componentRepresentation";
 import type UserRepresentation from "@keycloak/keycloak-admin-client/lib/defs/userRepresentation";
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Link, useHistory } from "react-router-dom";
 import { useAlerts } from "../components/alert/Alerts";

--- a/src/user/UsersTabs.tsx
+++ b/src/user/UsersTabs.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import {
   AlertVariant,
   ButtonVariant,

--- a/src/user/user-credentials/CredentialDataDialog.tsx
+++ b/src/user/user-credentials/CredentialDataDialog.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { Modal, ModalVariant } from "@patternfly/react-core";
 import {

--- a/src/user/user-credentials/CredentialRow.tsx
+++ b/src/user/user-credentials/CredentialRow.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useMemo } from "react";
+import { ReactNode, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { Td } from "@patternfly/react-table";
 import {

--- a/src/user/user-credentials/CredentialsResetActionMultiSelect.tsx
+++ b/src/user/user-credentials/CredentialsResetActionMultiSelect.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Controller, useFormContext } from "react-hook-form";
 import {

--- a/src/user/user-credentials/InlineLabelEdit.tsx
+++ b/src/user/user-credentials/InlineLabelEdit.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { useForm } from "react-hook-form";
 import { AlertVariant, Button, Form, FormGroup } from "@patternfly/react-core";

--- a/src/user/user-credentials/LifespanField.tsx
+++ b/src/user/user-credentials/LifespanField.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { Controller, useFormContext } from "react-hook-form";
 import { FormGroup } from "@patternfly/react-core";

--- a/src/user/user-credentials/ResetCredentialDialog.tsx
+++ b/src/user/user-credentials/ResetCredentialDialog.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { FormProvider, useForm, useWatch } from "react-hook-form";
 import { ModalVariant, Form, AlertVariant } from "@patternfly/react-core";

--- a/src/user/user-credentials/ResetPasswordDialog.tsx
+++ b/src/user/user-credentials/ResetPasswordDialog.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { Controller, useForm } from "react-hook-form";
 import {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react",
+    "jsx": "react-jsx",
     "baseUrl": "./",
   },
   "include": ["src"],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
       include: [],
     },
   },
-  plugins: [react({ jsxRuntime: "classic" }), checker({ typescript: true })],
+  plugins: [react(), checker({ typescript: true })],
   test: {
     setupFiles: "vitest.setup.ts",
     watch: false,


### PR DESCRIPTION
Introduces the [new JSX transformation](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html) which allows us to get rid of the default export of React. It introduces a couple of other benefits:

- Better performance now and in the future. The [Motivations](https://github.com/reactjs/rfcs/blob/createlement-rfc/text/0000-create-element-changes.md#motivation) section in the RFC explains the specifics of performance issues with `React.createElement`.
- In the future, we won't need `React.forwardRef` anymore.
- Faster parsing of JavaScript by web browser (`React.createElement` cannot be minified).
- Aligning with the defaults of Vite, removing complexity from the configuration.

This also introduces an ESLint rule that will prevent the default import of React from being used, instead named exports should be used.