### PR TITLE
Fix deleteAll in Client -> Client scopes (#3043)

### DIFF
--- a/src/clients/scopes/ClientScopes.tsx
+++ b/src/clients/scopes/ClientScopes.tsx
@@ -76,7 +76,6 @@ export const ClientScopes = ({
   );
 
   const [addDialogOpen, setAddDialogOpen] = useState(false);
-  const [kebabOpen, setKebabOpen] = useState(false);
 
   const [rest, setRest] = useState<ClientScopeRepresentation[]>();
   const [selectedRows, setSelectedRows] = useState<Row[]>([]);
@@ -195,6 +194,8 @@ export const ClientScopes = ({
   });
 
   const ManagerToolbarItems = () => {
+    const [kebabOpen, setKebabOpen] = useState(false);
+
     if (!isManager) return <span />;
 
     return (
@@ -235,6 +236,7 @@ export const ClientScopes = ({
                     );
 
                     setKebabOpen(false);
+                    setSelectedRows([]);
                     addAlert(
                       t("clients:clientScopeRemoveSuccess"),
                       AlertVariant.success


### PR DESCRIPTION
## Motivation
This PR is to fix https://github.com/keycloak/keycloak-admin-ui/issues/3043

## Brief Description
It seems that "sub component" was not rerendered when setKebabOpen was called. I move the useState in the sub component, I also empty selectedRows after delete because delete button was not disabled.

## Verification Steps
1. Go to client detail
2. Click on Dropdown and delete all button is displayed

## Checklist:

- [X] Code has been tested locally by PR requester
