### PR TITLE
Add PKCE Enabled and PKCE Method to OIDC Identity Providers

### DIFF
--- a/public/resources/en/identity-providers-help.json
+++ b/public/resources/en/identity-providers-help.json
@@ -22,6 +22,8 @@
   "validateSignature": "Enable/disable signature validation of external IDP signatures.",
   "useJwksUrl": "If the switch is on, identity provider public keys will be downloaded from given JWKS URL. This allows great flexibility because new keys will be always re-downloaded again when identity provider generates new keypair. If the switch is off, public key (or certificate) from the Keycloak DB is used, so when the identity provider keypair changes, you always need to import the new key to the Keycloak DB as well.",
   "jwksUrl": "URL where identity provider keys in JWK format are stored. See JWK specification for more details. If you use external Keycloak identity provider, you can use URL like 'http://broker-keycloak:8180/realms/test/protocol/openid-connect/certs' assuming your brokered Keycloak is running on 'http://broker-keycloak:8180' and its realm is 'test' .",
+  "pkceEnabled": "Use PKCE (Proof of Key-code exchange) for IdP Brokering",
+  "pkceMethod": "PKCE Method to use",
   "allowedClockSkew": "Clock skew in seconds that is tolerated when validating identity provider tokens. Default value is zero.",
   "attributeConsumingServiceIndex": "Index of the Attribute Consuming Service profile to request during authentication.",
   "attributeConsumingServiceName": "Name of the Attribute Consuming Service profile to advertise in the SP metadata.",

--- a/public/resources/en/identity-providers.json
+++ b/public/resources/en/identity-providers.json
@@ -120,6 +120,8 @@
   "validateSignature": "Validate Signatures",
   "useJwksUrl": "Use JWKS URL",
   "jwksUrl": "JWKS URL",
+  "pkceEnabled": "Use PKCE",
+  "pkceMethod": "PKCE Method",
   "allowedClockSkew": "Allowed clock skew",
   "attributeConsumingServiceIndex": "Attribute Consuming Service Index",
   "attributeConsumingServiceName": "Attribute Consuming Service Name",

--- a/src/identity-providers/add/DiscoverySettings.tsx
+++ b/src/identity-providers/add/DiscoverySettings.tsx
@@ -153,7 +153,7 @@ const Fields = ({ readOnly }: DiscoverySettingsProps) => {
               <Select
                 toggleId="pkceMethod"
                 required
-                direction="up"
+                direction="down"
                 onToggle={() => setPkceMethodOpen(!pkceMethodOpen)}
                 onSelect={(_, value) => {
                   onChange(value as string);

--- a/src/identity-providers/add/DiscoverySettings.tsx
+++ b/src/identity-providers/add/DiscoverySettings.tsx
@@ -1,15 +1,19 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useFormContext, useWatch } from "react-hook-form";
+import { Controller, useFormContext, useWatch } from "react-hook-form";
 import {
   ExpandableSection,
   FormGroup,
   ValidatedOptions,
+  Select,
+  SelectOption,
+  SelectVariant,
 } from "@patternfly/react-core";
 
 import { SwitchField } from "../component/SwitchField";
 import { TextField } from "../component/TextField";
 import { KeycloakTextInput } from "../../components/keycloak-text-input/KeycloakTextInput";
+import { HelpItem } from "../../components/help-enabler/HelpItem";
 
 import "./discovery-settings.css";
 
@@ -19,6 +23,8 @@ type DiscoverySettingsProps = {
 
 const Fields = ({ readOnly }: DiscoverySettingsProps) => {
   const { t } = useTranslation("identity-providers");
+  const pkceMethods = ["plain", "S256"];
+  const [pkceMethodOpen, setPkceMethodOpen] = useState(false);
   const {
     register,
     control,
@@ -32,6 +38,10 @@ const Fields = ({ readOnly }: DiscoverySettingsProps) => {
   const useJwks = useWatch({
     control: control,
     name: "config.useJwksUrl",
+  });
+  const isPkceEnabled = useWatch({
+    control: control,
+    name: "config.pkceEnabled",
   });
 
   return (
@@ -117,6 +127,56 @@ const Fields = ({ readOnly }: DiscoverySettingsProps) => {
             />
           )}
         </>
+      )}
+      <SwitchField
+        field="config.pkceEnabled"
+        label="pkceEnabled"
+        isReadOnly={readOnly}
+      />
+      {isPkceEnabled === "true" && (
+        <FormGroup
+          className="pf-u-pb-3xl"
+          label={t("pkceMethod")}
+          labelIcon={
+            <HelpItem
+              helpText="identity-providers-help:pkceMethod"
+              fieldLabelId="identity-providers:pkceMethod"
+            />
+          }
+          fieldId="pkceMethod"
+        >
+          <Controller
+            name="config.pkceMethod"
+            defaultValue={pkceMethods[0]}
+            control={control}
+            render={({ onChange, value }) => (
+              <Select
+                toggleId="pkceMethod"
+                required
+                direction="up"
+                onToggle={() => setPkceMethodOpen(!pkceMethodOpen)}
+                onSelect={(_, value) => {
+                  onChange(value as string);
+                  setPkceMethodOpen(false);
+                }}
+                selections={t(`${value}`)}
+                variant={SelectVariant.single}
+                aria-label={t("pkceMethod")}
+                isOpen={pkceMethodOpen}
+              >
+                {pkceMethods.map((option) => (
+                  <SelectOption
+                    selected={option === value}
+                    key={option}
+                    value={option}
+                  >
+                    {t(`${option}`)}
+                  </SelectOption>
+                ))}
+              </Select>
+            )}
+          />
+        </FormGroup>
       )}
     </div>
   );

--- a/src/identity-providers/add/DiscoverySettings.tsx
+++ b/src/identity-providers/add/DiscoverySettings.tsx
@@ -17,13 +17,14 @@ import { HelpItem } from "../../components/help-enabler/HelpItem";
 
 import "./discovery-settings.css";
 
+const PKCE_METHODS = ["plain", "S256"] as const;
+
 type DiscoverySettingsProps = {
   readOnly: boolean;
 };
 
 const Fields = ({ readOnly }: DiscoverySettingsProps) => {
   const { t } = useTranslation("identity-providers");
-  const pkceMethods = ["plain", "S256"];
   const [pkceMethodOpen, setPkceMethodOpen] = useState(false);
   const {
     register,
@@ -32,15 +33,15 @@ const Fields = ({ readOnly }: DiscoverySettingsProps) => {
   } = useFormContext();
 
   const validateSignature = useWatch({
-    control: control,
+    control,
     name: "config.validateSignature",
   });
   const useJwks = useWatch({
-    control: control,
+    control,
     name: "config.useJwksUrl",
   });
   const isPkceEnabled = useWatch({
-    control: control,
+    control,
     name: "config.pkceEnabled",
   });
 
@@ -147,7 +148,7 @@ const Fields = ({ readOnly }: DiscoverySettingsProps) => {
         >
           <Controller
             name="config.pkceMethod"
-            defaultValue={pkceMethods[0]}
+            defaultValue={PKCE_METHODS[0]}
             control={control}
             render={({ onChange, value }) => (
               <Select
@@ -164,7 +165,7 @@ const Fields = ({ readOnly }: DiscoverySettingsProps) => {
                 aria-label={t("pkceMethod")}
                 isOpen={pkceMethodOpen}
               >
-                {pkceMethods.map((option) => (
+                {PKCE_METHODS.map((option) => (
                   <SelectOption
                     selected={option === value}
                     key={option}


### PR DESCRIPTION
## Motivation
Fixes https://github.com/keycloak/keycloak-admin-ui/issues/3050

## Brief Description
Adds missing fields

## Verification Steps
1. Create OIDC or Keycloak OIDC identity provider
2. Verify `Use PKCE` and `PKCE Method` fields are saving properly

