### PR TITLE
adding missing parameter for Google Identity Provider

### DIFF
--- a/public/resources/en/identity-providers-help.json
+++ b/public/resources/en/identity-providers-help.json
@@ -16,6 +16,7 @@
   "disableUserInfo": "Disable usage of User Info service to obtain additional user information?  Default is to use this OIDC service.",
   "userInfoUrl": "The User Info Url. This is optional.",
   "issuer": "The issuer identifier for the issuer of the response. If not provided, no validation will be performed.",
+  "hostedDomain": "Set 'hd' query parameter when logging in with Google. Google will list accounts only for this domain. Keycloak validates that the returned identity token has a claim for this domain. When '*' is entered, any hosted account can be used.",
   "scopes": "The scopes to be sent when asking for authorization. It can be a space-separated list of scopes. Defaults to 'openid'.",
   "prompt": "Specifies whether the Authorization Server prompts the End-User for re-authentication and consent.",
   "acceptsPromptNone": "This is just used together with Identity Provider Authenticator or when kc_idp_hint points to this identity provider. In case that client sends a request with prompt=none and user is not yet authenticated, the error will not be directly returned to client, but the request with prompt=none will be forwarded to this identity provider.",

--- a/public/resources/en/identity-providers.json
+++ b/public/resources/en/identity-providers.json
@@ -100,6 +100,7 @@
   "disableUserInfo": "Disable user info",
   "userInfoUrl": "User Info URL",
   "issuer": "Issuer",
+  "hostedDomain": "Hosted Domain",
   "scopes": "Scopes",
   "prompt": "Prompt",
   "prompts": {

--- a/src/identity-providers/add/AdvancedSettings.tsx
+++ b/src/identity-providers/add/AdvancedSettings.tsx
@@ -93,14 +93,25 @@ const LoginFlow = ({
 };
 
 const syncModes = ["import", "legacy", "force"];
-type AdvancedSettingsProps = { isOIDC: boolean; isSAML: boolean };
+type AdvancedSettingsProps = {
+  isOIDC: boolean;
+  isSAML: boolean;
+  isGoogle: boolean;
+};
 
-export const AdvancedSettings = ({ isOIDC, isSAML }: AdvancedSettingsProps) => {
+export const AdvancedSettings = ({
+  isOIDC,
+  isSAML,
+  isGoogle,
+}: AdvancedSettingsProps) => {
   const { t } = useTranslation("identity-providers");
   const { control } = useFormContext();
   const [syncModeOpen, setSyncModeOpen] = useState(false);
   return (
     <>
+      {isGoogle && (
+        <TextField field="config.hostedDomain" label="hostedDomain" />
+      )}
       {!isOIDC && !isSAML && (
         <TextField field="config.defaultScope" label="scopes" />
       )}

--- a/src/identity-providers/add/DetailSettings.tsx
+++ b/src/identity-providers/add/DetailSettings.tsx
@@ -240,6 +240,7 @@ export default function DetailSettings() {
 
   const isOIDC = provider.providerId!.includes("oidc");
   const isSAML = provider.providerId!.includes("saml");
+  const isGoogle = provider.providerId!.includes("google");
 
   const loader = async () => {
     const [loaderMappers, loaderMapperTypes] = await Promise.all([
@@ -321,7 +322,11 @@ export default function DetailSettings() {
           isHorizontal
           onSubmit={handleSubmit(save)}
         >
-          <AdvancedSettings isOIDC={isOIDC!} isSAML={isSAML!} />
+          <AdvancedSettings
+            isOIDC={isOIDC!}
+            isSAML={isSAML!}
+            isGoogle={isGoogle!}
+          />
 
           <ActionGroup className="keycloak__form_actions">
             <Button data-testid={"save"} type="submit">


### PR DESCRIPTION
## Motivation
Fixes #3083 


## Verification Steps

1. Go to Identity Providers -> Add Social Google provider -> Add
2. In Advanced settings -> Hosted Domain input is visible
## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [ ] Unit tests have been created/updated

## Additional Notes
<!-- 
Add images and/or screen caps to illustrate what was changed if this pull request adds to or modifies existing user-visible appearance/output. 
-->
